### PR TITLE
feat(deploy): joyful Discord embed + rename to Wasm deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to production
+name: Wasm deploy
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: production-deploy
+  group: wasm-deploy
   cancel-in-progress: false
 
 jobs:
@@ -62,10 +62,10 @@ jobs:
 
           if [ "$DEPLOY_OUTCOME" = "success" ]; then
             COLOR=5763719   # 0x57F287 green
-            TITLE="🚀 Deploy successful"
+            TITLE="🚀 Wasm deploy successful"
           else
             COLOR=15548997  # 0xED4245 red
-            TITLE="💥 Deploy failed"
+            TITLE="💥 Wasm deploy failed"
           fi
 
           SHORT_SHA="${COMMIT_SHA:0:7}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,21 +62,38 @@ jobs:
 
           if [ "$DEPLOY_OUTCOME" = "success" ]; then
             COLOR=5763719   # 0x57F287 green
-            TITLE="Deploy complete"
+            TITLE="🚀 Deploy successful"
           else
             COLOR=15548997  # 0xED4245 red
-            TITLE="Deploy failed"
+            TITLE="💥 Deploy failed"
           fi
 
           SHORT_SHA="${COMMIT_SHA:0:7}"
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          AVATAR_URL="https://github.com/${ACTOR}.png?size=64"
+          ACTOR_URL="https://github.com/${ACTOR}"
 
           PAYLOAD=$(jq -n \
             --arg title "$TITLE" \
             --arg url "$RUN_URL" \
             --arg desc "$LOG" \
-            --arg footer "$SHORT_SHA · $ACTOR" \
+            --arg footer "manabrew · $SHORT_SHA" \
+            --arg actor "$ACTOR" \
+            --arg actor_url "$ACTOR_URL" \
+            --arg avatar_url "$AVATAR_URL" \
+            --arg timestamp "$TIMESTAMP" \
             --argjson color "$COLOR" \
-            '{embeds: [{title: $title, url: $url, description: $desc, color: $color, footer: {text: $footer}}]}')
+            '{
+              embeds: [{
+                title: $title,
+                url: $url,
+                description: $desc,
+                color: $color,
+                author: { name: $actor, url: $actor_url, icon_url: $avatar_url },
+                footer: { text: $footer },
+                timestamp: $timestamp
+              }]
+            }')
 
           curl -fsS -X POST \
             -H "Authorization: Bot $BOT_TOKEN" \

--- a/deploy.sh
+++ b/deploy.sh
@@ -8,8 +8,8 @@
 set -euo pipefail
 
 on_failure() {
-    echo "**Deploy FAILED** at $(date '+%H:%M:%S')"
-    echo "Check raw log: \`${RAW_LOG:-/tmp/deploy-raw.log}\`"
+    echo "💥 **Deploy FAILED** at $(date '+%H:%M:%S')"
+    echo "📄 Check raw log: \`${RAW_LOG:-/tmp/deploy-raw.log}\`"
     tail -20 "${RAW_LOG:-/tmp/deploy-raw.log}" 2>/dev/null | sed 's/^/> /'
 }
 trap on_failure ERR
@@ -57,7 +57,7 @@ git pull origin main --ff-only >> "$RAW_LOG" 2>&1
 CURR=$(git rev-parse --short HEAD)
 
 if [ "$PREV" = "$CURR" ]; then
-    echo "No new commits. Nothing to deploy."
+    echo "😴 No new commits. Nothing to deploy."
     exit 0
 fi
 
@@ -149,7 +149,7 @@ elif $WEB_CHANGED || $RUST_CHANGED; then
 fi
 
 if [ -z "$SERVICES_TO_RESTART" ]; then
-    echo "No Java/Rust/infra changes — skipping build."
+    echo "🧹 No Java/Rust/infra changes — skipping build."
     exit 0
 fi
 
@@ -166,26 +166,26 @@ BUILD_DURATION=$(( BUILD_END - BUILD_START ))
 # ── Pretty summary for Discord ───────────────────────────────────────
 SERVICES_FMT=$(echo "$SERVICES_TO_RESTART" | xargs -n1 | sed 's/^/  - /' | tr '\n' '\n')
 
-# Build change flags string
+# Build change flags string (with per-stack emoji)
 CHANGES=""
-$JAVA_CHANGED && CHANGES="${CHANGES} Java"
-$RUST_CHANGED && CHANGES="${CHANGES} Rust"
-$WEB_CHANGED && CHANGES="${CHANGES} Web"
-$INFRA_CHANGED && CHANGES="${CHANGES} Infra"
+$JAVA_CHANGED  && CHANGES="${CHANGES} ☕ Java"
+$RUST_CHANGED  && CHANGES="${CHANGES} 🦀 Rust"
+$WEB_CHANGED   && CHANGES="${CHANGES} 🌐 Web"
+$INFRA_CHANGED && CHANGES="${CHANGES} 🐳 Infra"
 CHANGES=$(echo "$CHANGES" | xargs)
 
 cat <<EOF
-**Deploy complete** (\`${PREV}\` -> \`${CURR}\`)
+🎉 **Deploy complete** (\`${PREV}\` → \`${CURR}\`)
 
 > ${COMMIT_MSG}
 > — ${AUTHOR} (${COMMIT_COUNT} commit(s))
 
-**Changed:** ${CHANGES}
-**Services rebuilt:**
+📦 **Changed:** ${CHANGES}
+🔁 **Services rebuilt:**
 ${SERVICES_FMT}
-**Build time:** ${BUILD_DURATION}s
-**Log:** \`${RAW_LOG}\`
+⏱️ **Build time:** ${BUILD_DURATION}s
+📄 **Log:** \`${RAW_LOG}\`
 
-**Changelog:**
+📝 **Changelog:**
 ${CHANGELOG}
 EOF

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-# deploy.sh — Smart rebuild: only rebuilds what changed since last deploy.
-# Triggered by .github/workflows/deploy.yml via SSH from GitHub Actions on push to main.
+# deploy.sh — Smart rebuild of the Wasm/web stack on the production host.
+# Scope: builds manabrew (Wasm + React via nginx), forge-server, and
+# optionally parity-dashboard. Native Tauri installers (.dmg / .exe) are
+# built separately by .github/workflows/release-artifacts.yml.
+# Triggered by .github/workflows/deploy.yml (the "Wasm deploy" workflow)
+# via SSH from GitHub Actions on push to main.
 # Docker BuildKit layer caching handles unchanged layers within each build.
 #
 # stdout = clean summary (captured by the workflow and posted to Discord).
@@ -8,7 +12,7 @@
 set -euo pipefail
 
 on_failure() {
-    echo "💥 **Deploy FAILED** at $(date '+%H:%M:%S')"
+    echo "💥 **Wasm deploy FAILED** at $(date '+%H:%M:%S')"
     echo "📄 Check raw log: \`${RAW_LOG:-/tmp/deploy-raw.log}\`"
     tail -20 "${RAW_LOG:-/tmp/deploy-raw.log}" 2>/dev/null | sed 's/^/> /'
 }
@@ -175,7 +179,7 @@ $INFRA_CHANGED && CHANGES="${CHANGES} 🐳 Infra"
 CHANGES=$(echo "$CHANGES" | xargs)
 
 cat <<EOF
-🎉 **Deploy complete** (\`${PREV}\` → \`${CURR}\`)
+🎉 **Wasm deploy complete** (\`${PREV}\` → \`${CURR}\`)
 
 > ${COMMIT_MSG}
 > — ${AUTHOR} (${COMMIT_COUNT} commit(s))

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -135,9 +135,15 @@ Dashboard will be at `http://<server-ip>:8080`.
 
 ## Auto-Deploy with GitHub Actions
 
-Every push to `main` triggers `.github/workflows/deploy.yml`, which SSHes into
-the server, runs `deploy.sh`, and posts a success/failure embed to the
+Every push to `main` triggers the **Wasm deploy** workflow
+(`.github/workflows/deploy.yml`), which SSHes into the server, runs
+`deploy.sh` to rebuild the Wasm/web stack (manabrew, forge-server, optional
+parity-dashboard) under Docker, and posts a success/failure embed to the
 community Discord channel via the project's Discord bot.
+
+Native Tauri installers (`.dmg` / `.exe` / `.msi`) are built by a separate
+workflow, `.github/workflows/release-artifacts.yml`, which uploads them to
+the workflow run and (on tag pushes) attaches them to a GitHub Release.
 
 ### 1. Generate an SSH keypair for the deploy
 
@@ -200,12 +206,12 @@ n8n endpoint (`/webhook/github-deploy`).
 
 ### 6. Test it
 
-Trigger manually first: **Actions → Deploy to production → Run workflow → branch `main`**.
+Trigger manually first: **Actions → Wasm deploy → Run workflow → branch `main`**.
 
 Verify:
 
 - The workflow's `SSH and run deploy.sh` step is green.
-- The configured Discord channel receives a green "Deploy complete" embed posted by your bot.
+- The configured Discord channel receives a green "🚀 Wasm deploy successful" embed posted by your bot.
 - `docker compose -f compose.production.yml ps` on the server (or the dev
   compose path, if that's what `$COMPOSE_FILE` points to) shows the expected
   containers as `Up`.


### PR DESCRIPTION
## Summary

Two related improvements to the deploy workflow now that there's a clean split between this pipeline and `release-artifacts.yml`:

**1. Rename → "Wasm deploy"**

This workflow builds the Wasm/web stack on the production host (`manabrew` web client served via nginx, `forge-server`, optional `parity-dashboard`). Native Tauri installers (.dmg / .exe / .msi) come from `release-artifacts.yml`. The names should reflect that.

- Workflow `name`: `Deploy to production` → `Wasm deploy`
- Concurrency group: `production-deploy` → `wasm-deploy`
- `deploy.sh` header comment scope-clarified and cross-linked to the Tauri pipeline
- `docs/DEPLOY.md` Auto-Deploy section explains the split

**2. Joyful Discord embed**

- Title with emoji: `🚀 Wasm deploy successful` / `💥 Wasm deploy failed`
- Author block carries the actor's GitHub avatar + profile link
- `timestamp` field — Discord renders as a live relative time
- Footer rebranded to `manabrew · <short-sha>`

**3. Joyful body (deploy.sh stdout → embed description)**

- `🎉 **Wasm deploy complete** (\`abc1234\` → \`def5678\`)`
- `😴` / `🧹` for early-exit paths (no commits / no relevant changes)
- Per-stack chips on Changed: ☕ Java, 🦀 Rust, 🌐 Web, 🐳 Infra
- Section icons: 📦 Changed, 🔁 Services rebuilt, ⏱️ Build time, 📄 Log, 📝 Changelog
- Unicode `→` in the SHA range

## Test plan

- [ ] Manually dispatch (`Actions → Wasm deploy → Run workflow → main`); green `🚀 Wasm deploy successful` embed in Discord with the actor's avatar and a relative timestamp.
- [ ] Push a no-op change to main: embed body contains `🧹 No Java/Rust/infra changes — skipping build.`
- [ ] Force a failure on a test branch (deliberately broken deploy.sh, manual dispatch): red `💥 Wasm deploy failed` embed; body opens with `💥 **Wasm deploy FAILED**` + log tail.
- [ ] `release-artifacts.yml` still runs independently on push-to-main / tag-push (unchanged here, should be unaffected).

## Build artifacts
<!--
  Check the boxes below to build the corresponding installer on merge to main
  (uploaded to the Actions run, 30-day retention).
  Leave unchecked to skip — faster CI, no binaries produced.
  Tag pushes (v*) always build both and publish a GitHub Release regardless.
-->
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main