### PR TITLE
ci(deploy): attach raw deploy log to discord on failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,18 @@ jobs:
             "cd '$DEPLOY_PATH' && ./deploy.sh 2>&1" 2>&1 | tee deploy.log
           exit ${PIPESTATUS[0]}
 
+      - name: Fetch raw deploy log on failure
+        if: steps.deploy.outcome != 'success'
+        env:
+          HOST: ${{ secrets.DEPLOY_HOST }}
+          USER: ${{ secrets.DEPLOY_USER }}
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          scp -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes \
+            "$USER@$HOST:/tmp/deploy-raw.log" deploy-raw.log || \
+            echo "(raw log not retrievable from server)"
+
       - name: Post Discord embed (as bot)
         if: always()
         env:
@@ -95,11 +107,19 @@ jobs:
               }]
             }')
 
-          curl -fsS -X POST \
-            -H "Authorization: Bot $BOT_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD" \
-            "https://discord.com/api/v10/channels/$CHANNEL_ID/messages"
+          if [ "$DEPLOY_OUTCOME" != "success" ] && [ -f deploy-raw.log ] && [ -s deploy-raw.log ]; then
+            curl -fsS -X POST \
+              -H "Authorization: Bot $BOT_TOKEN" \
+              -F "payload_json=$PAYLOAD" \
+              -F "files[0]=@deploy-raw.log;type=text/plain" \
+              "https://discord.com/api/v10/channels/$CHANNEL_ID/messages"
+          else
+            curl -fsS -X POST \
+              -H "Authorization: Bot $BOT_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "$PAYLOAD" \
+              "https://discord.com/api/v10/channels/$CHANNEL_ID/messages"
+          fi
 
       - name: Fail job if deploy failed
         if: steps.deploy.outcome != 'success'

--- a/src/views/DeckEditor.tsx
+++ b/src/views/DeckEditor.tsx
@@ -103,6 +103,7 @@ export default function DeckEditor() {
   });
   // True when readonly was triggered by an in-page preset click (no route
   // navigation), so Back restores the grid instead of popping history.
+  //
   const [readonlyEnteredInPage, setReadonlyEnteredInPage] = useState(false);
   const view = isReadOnly ? "editor" : stateView;
   const setView = setStateView;


### PR DESCRIPTION
## Summary
- On failed deploy, scp `/tmp/deploy-raw.log` from the VM back to the runner.
- Discord post step now uploads that file as an attachment (multipart) alongside the existing red failure embed.
- Success path unchanged: same plain-JSON embed as before.

## Why
The Discord embed already carries `deploy.log` (the captured stdout summary), but the full raw build output stays on the VM at `/tmp/deploy-raw.log`. Until now, debugging a failed deploy required SSH access to the host. Attaching the raw log to the failure message lets anyone in the Discord channel triage without needing VM access.

## Test plan
- [ ] Trigger a deploy via `workflow_dispatch` against a known-failing commit (or temporarily break `deploy.sh`) and confirm Discord receives the embed **plus** a `deploy-raw.log` attachment.
- [ ] Confirm a successful deploy still posts the green embed with no attachment.
- [ ] Confirm that if scp fails (raw log missing on host), the workflow still posts the failure embed (without crashing the job — `continue-on-error: true`).

## Build artifacts
- [x] Build macOS .dmg on merge to main
- [x] Build Windows .exe / .msi on merge to main