### PR TITLE
ci: pin wasm-pack to v0.13.1 + add SSH keep-alive to wasm deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,16 @@ jobs:
           printf '%s\n' "$SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H "$HOST" >> ~/.ssh/known_hosts 2>/dev/null
-          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes "$USER@$HOST" \
+          # ServerAliveInterval/CountMax keep the SSH connection healthy
+          # while deploy.sh has quiet stretches (cargo compiles, docker
+          # pulls). Without them the runner's SSH client times out after
+          # a few minutes idle and we get `client_loop: send disconnect:
+          # Broken pipe` mid-deploy.
+          ssh -i ~/.ssh/deploy_key \
+              -o StrictHostKeyChecking=yes \
+              -o ServerAliveInterval=30 \
+              -o ServerAliveCountMax=120 \
+              "$USER@$HOST" \
             "cd '$DEPLOY_PATH' && ./deploy.sh 2>&1" 2>&1 | tee deploy.log
           exit ${PIPESTATUS[0]}
 

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -124,7 +124,10 @@ jobs:
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
         with:
-          version: latest
+          # Pin to the same version Dockerfile.web uses. `version: latest`
+          # fetches v0.15.0+, which jetli/wasm-pack-action's platform-mapper
+          # doesn't recognise on Windows ("Unsupported platform: x64").
+          version: "v0.13.1"
 
       - run: yarn
 
@@ -273,7 +276,10 @@ jobs:
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
         with:
-          version: latest
+          # Pin to the same version Dockerfile.web uses. `version: latest`
+          # fetches v0.15.0+, which jetli/wasm-pack-action's platform-mapper
+          # doesn't recognise on Windows ("Unsupported platform: x64").
+          version: "v0.13.1"
 
       - run: yarn
 


### PR DESCRIPTION
## Summary
Two CI fixes that landed together because they were both noticed on the same post-#3-merge run:

**`release-artifacts.yml` (Windows + macOS builders)**
`jetli/wasm-pack-action@v0.4.0` with `version: latest` is fetching wasm-pack v0.15.0+, whose Windows binary the action's platform-mapper doesn't recognise — fails with `Unsupported platform: x64`. Pinning to `v0.13.1` (same version `Dockerfile.web` installs) so desktop and web builds use identical tooling.

**`deploy.yml` ("Wasm deploy")**
The SSH step has no keep-alive, so when `deploy.sh` has any long quiet stretch (cargo compile, docker pull) the GH runner's SSH client times out: `client_loop: send disconnect: Broken pipe` after ~4.5 min. Adding `ServerAliveInterval=30` + `ServerAliveCountMax=120` so the client probes every 30 s and tolerates up to 60 min of silence.

## Why bundled
Both are one-or-two-line workflow patches addressing the same root failure mode (CI green check on main), and reviewing them together is cheaper than two PRs.

## Test plan
- [ ] Merge → next push triggers \"Wasm deploy\" successfully
- [ ] A subsequent release-please tag triggers \"Release artifacts\" and both Windows + macOS jobs install wasm-pack v0.13.1 cleanly

## Build artifacts
- [x] Build macOS .dmg
- [x] Build Windows .exe