### PR TITLE
ci(release): fire discord embed when release-please tag publishes

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -423,32 +423,14 @@ jobs:
           name: windows-exe-${{ github.sha }}
           path: release-assets/windows
 
-      - name: Generate changelog
-        id: changelog
-        uses: mikepenz/release-changelog-builder-action@v5
-        with:
-          configurationJson: |
-            {
-              "categories": [
-                { "title": "## Features",      "labels": ["feat", "feature"] },
-                { "title": "## Fixes",         "labels": ["fix", "bug"] },
-                { "title": "## Changes",       "labels": [] }
-              ],
-              "label_extractor": [
-                { "pattern": "^(feat|fix|chore|docs|refactor|perf|test|ci)(\\(.+\\))?!?:.+", "target": "$1", "on_property": "title" }
-              ],
-              "template": "#{{CHANGELOG}}\n\n**Full Changelog**: #{{RELEASE_DIFF}}"
-            }
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish Release
+      # Attach artifacts to the release release-please already created from
+      # CHANGELOG.md. Omitting `body` makes softprops/action-gh-release leave
+      # the existing release notes untouched.
+      - name: Attach artifacts to release
         id: publish
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
-          body: ${{ steps.changelog.outputs.changelog }}
           draft: false
           prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') }}
           files: |
@@ -458,6 +440,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Fetch release body for Discord
+        id: relbody
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          BODY=$(gh release view "$TAG" --json body --jq .body 2>/dev/null || echo '')
+          {
+            echo 'body<<RELBODY_EOF'
+            echo "$BODY"
+            echo 'RELBODY_EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Post Discord embed (release published)
         if: steps.publish.outputs.url != ''
         env:
@@ -465,7 +461,7 @@ jobs:
           CHANNEL_ID: ${{ secrets.DISCORD_DEPLOY_CHANNEL_ID }}
           RELEASE_TAG: ${{ github.ref_name }}
           RELEASE_URL: ${{ steps.publish.outputs.url }}
-          RELEASE_BODY: ${{ steps.changelog.outputs.changelog }}
+          RELEASE_BODY: ${{ steps.relbody.outputs.body }}
           COMMIT_SHA: ${{ github.sha }}
           ACTOR: ${{ github.actor }}
           PRERELEASE: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 concurrency:
   group: release-please-${{ github.ref }}
@@ -24,9 +25,30 @@ jobs:
   release-please:
     name: Run release-please
     runs-on: [self-hosted, Linux]
+    outputs:
+      release_created: ${{ steps.rp.outputs.release_created }}
+      tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: rp
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  # release-please pushes the vX.Y.Z tag using GITHUB_TOKEN, which by design
+  # does not trigger downstream workflows. Dispatch release-artifacts.yml
+  # explicitly on the new tag ref so the macOS/Windows builds + Discord
+  # release notification fire.
+  dispatch-artifacts:
+    name: Dispatch release-artifacts on new tag
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Trigger release-artifacts workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: gh workflow run release-artifacts.yml --ref "$TAG"


### PR DESCRIPTION
## Summary
- Capture `release_created` + `tag_name` from `googleapis/release-please-action` and dispatch `release-artifacts.yml` on the new tag ref via `gh workflow run` (uses `GITHUB_TOKEN` with `actions: write`).
- Drop the redundant `mikepenz/release-changelog-builder-action` step and stop overriding the release `name`/`body` — release-please already writes CHANGELOG.md into the release notes.
- Source the Discord embed body from `gh release view --json body` so the message reflects what users see on the release page.

## Why
release-please pushes the `vX.Y.Z` tag using `GITHUB_TOKEN`. By design, events triggered by `GITHUB_TOKEN` do **not** create new workflow runs (prevents recursive triggers — see [GitHub docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)). So `release-artifacts.yml`, which is gated on `push: tags: ["v*"]`, never ran after a release PR merge — meaning no `.dmg`/`.exe` attached to the release and no Discord release notification. Explicit dispatch from `release.yml` fixes the chain without requiring a new PAT secret.

## Test plan
- `node -e "require('js-yaml').load(...)"` on both workflow files → OK.
- Existing tag-ref gate in `release-artifacts.yml` (`ref.startsWith('refs/tags/v')` → builds both platforms, `release` job runs) is unchanged; only the trigger source is new.
- Will be verified end-to-end on the next release-please PR merge: tag appears → `dispatch-artifacts` job runs → `release-artifacts.yml` on tag ref builds both platforms → release gets artifacts + Discord embed posts with release URL + CHANGELOG.md body.

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main