### PR TITLE
feat(ci): label-gated per-PR preview deploys to staging.manabrew.app

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,109 @@
+name: Preview deploy
+
+# Deploys the PR's HEAD to staging.manabrew.app when (and only when) the
+# PR carries the `deploy-preview` label. Re-runs on every push to that PR
+# while the label is present; removing the label or closing the PR stops
+# new deploys (the slot keeps showing the last deploy until something
+# else takes it over).
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
+concurrency:
+  # Latest push of a given PR cancels the previous in-flight preview
+  # build for that PR; other PRs' deploys are not blocked.
+  group: preview-deploy-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    # Only run when the PR has the `deploy-preview` label. For the
+    # `labeled` event we also check the specific label that triggered it.
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'deploy-preview')
+      && (github.event.action != 'labeled' || github.event.label.name == 'deploy-preview')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: SSH and build PR preview
+        id: deploy
+        continue-on-error: true
+        env:
+          SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          HOST: ${{ secrets.DEPLOY_HOST }}
+          USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          STAGING_PATH: ${{ secrets.DEPLOY_STAGING_PATH }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          # PR refs (`pull/N/head`) live on the BASE repo, not the head
+          # repo, so we always clone witchesofthehill/manabrew regardless
+          # of whether the PR came from a fork.
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+          ssh -i ~/.ssh/deploy_key \
+              -o StrictHostKeyChecking=yes \
+              -o ServerAliveInterval=30 \
+              -o ServerAliveCountMax=120 \
+              "$USER@$HOST" bash <<REMOTE_EOF
+          set -euo pipefail
+
+          STAGING="${STAGING_PATH:-/opt/manabrew-staging}"
+          PROD="${DEPLOY_PATH}"
+
+          # First-run bootstrap.
+          if [ ! -d "\$STAGING/.git" ]; then
+              echo "[preview] bootstrap clone into \$STAGING"
+              mkdir -p "\$STAGING"
+              git clone https://github.com/${BASE_REPO}.git "\$STAGING"
+          fi
+
+          cd "\$STAGING"
+
+          # Reuse the production secrets file for FORGE_SERVER_KEY
+          # substitution. Symlinked so a key rotation in prod is reflected
+          # on the next preview build without copying.
+          if [ ! -L .env ]; then
+              ln -sf "\$PROD/ops/production.secrets" .env
+          fi
+
+          # Fetch the PR ref and check it out at the exact SHA the
+          # workflow was triggered for.
+          git fetch origin "pull/${PR_NUMBER}/head" --force
+          git checkout --detach ${PR_SHA}
+
+          # Build + start the manabrew-staging service. Compose reuses
+          # BuildKit cache mounts shared with main builds — first preview
+          # is slow, subsequent ones are fast.
+          docker compose -p manabrew-staging -f compose.staging.yml up -d --build manabrew-staging
+          REMOTE_EOF
+
+      - name: Comment on PR with preview URL
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
+        with:
+          script: |
+            const outcome = process.env.DEPLOY_OUTCOME;
+            const sha = context.payload.pull_request.head.sha.slice(0, 7);
+            const body = outcome === 'success'
+              ? `🚀 Preview deployed: https://staging.manabrew.app (${sha})`
+              : `💥 Preview deploy failed for ${sha} — see [workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });
+
+      - name: Fail job if deploy failed
+        if: steps.deploy.outcome != 'success'
+        run: exit 1

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -1,0 +1,33 @@
+# Per-PR preview stack. Driven by .github/workflows/preview-deploy.yml on
+# PRs that carry the `deploy-preview` label. Lives in /opt/manabrew-staging
+# on the deploy host so it can't trash /opt/manabrew. Joins the main
+# stack's docker network so the production caddy reverse-proxies
+# `staging.manabrew.app` to this service.
+services:
+  manabrew-staging:
+    build:
+      context: .
+      dockerfile: Dockerfile.web
+      args:
+        # Preview clients still talk to the real relay + parity dashboard.
+        # Swap to a staging relay later if/when we run one.
+        VITE_RELAY_HOST: relay.manabrew.app
+        VITE_RELAY_PORT: "443"
+        VITE_RELAY_PASSWORD: ${FORGE_SERVER_KEY:?FORGE_SERVER_KEY is required}
+        VITE_MANAGED_RELAY: "1"
+        VITE_SCRYFALL_SYMBOL_BASE: /scryfall-symbols/
+    restart: unless-stopped
+    # Container-internal port only; the production caddy on the same docker
+    # network is what reverse-proxies staging.manabrew.app to us.
+    expose:
+      - "80"
+    volumes:
+      - ./ops/staging.Caddyfile:/etc/caddy/Caddyfile:ro
+
+networks:
+  default:
+    # Created by /opt/manabrew/compose.production.yml. Joining it from
+    # this separate compose project means caddy (in the main project) can
+    # resolve `manabrew-staging` by service name and reverse-proxy us.
+    external: true
+    name: manabrew_default

--- a/ops/Caddyfile
+++ b/ops/Caddyfile
@@ -78,3 +78,12 @@ relay.manabrew.app {
 parity.manabrew.app {
     reverse_proxy parity-dashboard:8080
 }
+
+# Preview slot for the latest PR tagged `deploy-preview`. The
+# manabrew-staging service lives in compose.staging.yml under
+# /opt/manabrew-staging and joins the manabrew_default docker network so
+# it's resolvable by service name. When no preview is currently deployed,
+# Caddy returns 502 — that's expected.
+staging.manabrew.app {
+    reverse_proxy manabrew-staging:80
+}

--- a/ops/staging.Caddyfile
+++ b/ops/staging.Caddyfile
@@ -1,0 +1,55 @@
+# Minimal Caddyfile for the staging preview container. The production
+# caddy reverse-proxies `staging.manabrew.app` here, so we accept any
+# Host on internal port 80 (`:80`). Mirrors the manabrew.app block of
+# ops/Caddyfile minus the relay/parity routes — staging shares the live
+# relay + parity dashboard.
+:80 {
+    root * /srv/manabrew
+
+    # Module workers need require-corp (Chrome's SharedArrayBuffer rule).
+    @worker path_regexp \.worker[.-][^/]+\.js$
+    handle @worker {
+        header {
+            Cache-Control "public, immutable, max-age=31536000"
+            Cross-Origin-Opener-Policy "same-origin"
+            Cross-Origin-Embedder-Policy "require-corp"
+            Cross-Origin-Resource-Policy "same-origin"
+        }
+        file_server
+    }
+
+    # Long-cache hashed Vite assets + WASM bundles + cardset archive.
+    @static path /assets/* /wasm/*
+    handle @static {
+        header {
+            Cache-Control "public, immutable, max-age=31536000"
+            Cross-Origin-Opener-Policy "same-origin"
+            Cross-Origin-Embedder-Policy "credentialless"
+            Cross-Origin-Resource-Policy "same-origin"
+        }
+        file_server
+    }
+
+    # Same Scryfall SVG proxy as main; staging hits the same upstream.
+    handle /scryfall-symbols/* {
+        rewrite * /card-symbols{path}
+        reverse_proxy https://svgs.scryfall.io {
+            header_up Host svgs.scryfall.io
+            header_down -Access-Control-Allow-Origin
+            header_down -Cross-Origin-Resource-Policy
+            header_down -Cache-Control
+        }
+        header Cache-Control "public, max-age=604800"
+        header Cross-Origin-Resource-Policy "same-origin"
+    }
+
+    handle {
+        header {
+            Cross-Origin-Opener-Policy "same-origin"
+            Cross-Origin-Embedder-Policy "credentialless"
+            Cross-Origin-Resource-Policy "same-origin"
+        }
+        try_files {path} /index.html
+        file_server
+    }
+}


### PR DESCRIPTION
**Stacked on #19** — base branch is `chore/issue-cleanup-4-5-8-9`. Merge #19 first, then this rebases onto main automatically.

## Summary
Adds a single preview slot at `staging.manabrew.app` that gets overwritten by the latest PR carrying the `deploy-preview` label. PRs without the label do nothing.

## How it works
1. Maintainer adds `deploy-preview` label to a PR.
2. Workflow fires on the label add (and every subsequent push to that PR while the label is on).
3. Workflow SSHes to the deploy host, syncs the PR's HEAD into `/opt/manabrew-staging` via `git fetch pull/N/head`, then `docker compose -p manabrew-staging -f compose.staging.yml up -d --build manabrew-staging`.
4. Workflow comments back on the PR with `https://staging.manabrew.app` (or a failure link).

## Pieces
- `.github/workflows/preview-deploy.yml` — label-gated, concurrency-grouped per PR so a fresh push cancels an in-flight build for the same PR.
- `compose.staging.yml` — single `manabrew-staging` service. Joins the external `manabrew_default` docker network so the production caddy can resolve it by service name. Same `Dockerfile.web` build args as prod.
- `ops/staging.Caddyfile` — minimal `:80` site for the staging container (file_server + COEP split + Scryfall proxy; no relay/parity blocks).
- `ops/Caddyfile` — new `staging.manabrew.app` block reverse-proxying to `manabrew-staging:80`. Returns 502 when no preview is deployed (intentional empty state).

## One-time setup (not in this PR — do after merge)
- DNS A record \`staging.manabrew.app → <deploy host>\`
- Create GH label `deploy-preview` (one-liner: `gh label create deploy-preview --repo witchesofthehill/manabrew --color 0E8A16`)
- Optional GH secret `DEPLOY_STAGING_PATH=/opt/manabrew-staging` (the workflow falls back to that default if unset)
- First `git clone` into `/opt/manabrew-staging` happens lazily in the workflow (no manual bootstrap)

## Limitations
- One PR previewable at a time. Picking a different PR for preview overwrites the slot.
- Previews share the live relay + parity backend. Backend-breaking PRs can't be safely previewed this way until we run a staging relay (out of scope).
- BuildKit cache mounts from #9 are reused across main + staging builds since they share the deploy host's docker.

## Test plan
- [ ] Label this PR with `deploy-preview` after merge; verify staging.manabrew.app serves it
- [ ] Remove label; subsequent pushes do not redeploy
- [ ] Re-label a different PR; staging slot switches

## Build artifacts
- [ ] Build macOS .dmg
- [ ] Build Windows .exe