### PR TITLE
fix(prod): caddy scryfall proxy 404 + deploy --remove-orphans (post-#19 outage)

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -167,7 +167,11 @@ PROFILE_FLAG=""
 if echo "$SERVICES_TO_RESTART" | grep -q "parity-dashboard"; then
     PROFILE_FLAG="--profile parity"
 fi
-docker compose -f "$COMPOSE_FILE" $PROFILE_FLAG up -d $SERVICES_TO_RESTART >> "$RAW_LOG" 2>&1
+# --remove-orphans: when a service is renamed or removed (e.g. the
+# nginx→caddy consolidation that dropped the separate `caddy` service),
+# the old container otherwise lingers and can hold the host ports the new
+# one needs — exactly what took prod down on the #19 merge deploy.
+docker compose -f "$COMPOSE_FILE" $PROFILE_FLAG up -d --remove-orphans $SERVICES_TO_RESTART >> "$RAW_LOG" 2>&1
 
 BUILD_END=$(date +%s)
 BUILD_DURATION=$(( BUILD_END - BUILD_START ))

--- a/ops/Caddyfile
+++ b/ops/Caddyfile
@@ -45,8 +45,14 @@ manabrew.app {
     # can fetch() them. svgs.scryfall.io doesn't send Access-Control-Allow-
     # Origin, which blocks cross-origin fetch(). Card art works because it
     # uses <img>, which doesn't need CORS for display.
-    handle /scryfall-symbols/* {
-        rewrite * /card-symbols{path}
+    #
+    # Regex capture (not `handle_path` + `{path}`) so the upstream URI is
+    # unambiguous: /scryfall-symbols/G.svg → /card-symbols/G.svg. The
+    # `handle_path` + `{path}` form left the prefix in the rewritten path
+    # and 404'd.
+    @scryfall path_regexp scryfall ^/scryfall-symbols/(.*)$
+    handle @scryfall {
+        rewrite * /card-symbols/{re.scryfall.1}
         reverse_proxy https://svgs.scryfall.io {
             header_up Host svgs.scryfall.io
             header_down -Access-Control-Allow-Origin


### PR DESCRIPTION
## Summary
Two fixes from the prod outage when #19 merged. **Both are already applied live on the host** (manual recovery); this PR lands them in the repo so the next deploy doesn't reintroduce them.

### 1. Outage root cause — `deploy.sh` orphan
#19 consolidated the two-tier `caddy` + in-container `nginx` into one `manabrew` (caddy) service. On the merge deploy, the **old `manabrew-caddy-1` container lingered as an orphan and kept ports 80/443**, so the new container couldn't bind → deploy failed → site down. Adding `--remove-orphans` to the `docker compose up -d` so a renamed/removed service can't strand a port-holding container again.

### 2. Latent Scryfall proxy 404
The `/scryfall-symbols` proxy used `handle` + `rewrite * /card-symbols{path}`, which left the prefix in the upstream path (`/card-symbols/scryfall-symbols/G.svg` → 404). `handle_path` + `{path}` also misbehaved (placeholder timing). Switched to an explicit regex capture: `/scryfall-symbols/G.svg → /card-symbols/G.svg`. Only surfaced now because the caddy-only path never actually ran until #19 deployed.

## Recovery notes (already done, for the record)
- Removed orphan `manabrew-caddy-1` + leftover `manabrew-staging-*`, `docker compose up -d --remove-orphans`
- Force-recreated `manabrew` to defeat the Docker single-file bind-mount inode trap (editing the mounted Caddyfile with `sed -i` swaps the inode; the running container keeps reading the old one until recreated)
- Verified: manabrew.app 200 + correct COEP split, all mana symbols 200, relay reachable

## Test plan
- [ ] Merge → deploy runs clean (no orphan port conflict)
- [ ] `/scryfall-symbols/{W,U,B,R,G,C}.svg` all 200
- [ ] manabrew.app still cross-origin-isolated

## Build artifacts
- [ ] Build macOS .dmg
- [ ] Build Windows .exe