### PR TITLE
feat(ci): per-PR preview deploys with isolated relay (reopen of #20)

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,32 +1,23 @@
 name: Preview deploy
 
-# Deploys the PR's HEAD to staging.manabrew.app when (and only when) the
-# PR carries the `deploy-preview` label. Re-runs on every push to that PR
-# while the label is present; removing the label or closing the PR stops
-# new deploys (the slot keeps showing the last deploy until something else
-# takes it over).
-
+# PRs labelled `deploy-preview` are deployed to staging.manabrew.app.
+# Closing the PR or removing the label tears the preview down.
 on:
   pull_request:
-    types: [labeled, synchronize, reopened]
+    types: [labeled, synchronize, reopened, closed, unlabeled]
 
 concurrency:
-  # Latest push of a given PR cancels the previous in-flight preview build
-  # for that PR; other PRs' deploys are not blocked.
   group: preview-deploy-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   deploy:
-    # Only run when the PR has the `deploy-preview` label. For the `labeled`
-    # event we also check the specific label that triggered it.
     if: |
-      contains(github.event.pull_request.labels.*.name, 'deploy-preview')
-      && (github.event.action != 'labeled' || github.event.label.name == 'deploy-preview')
+      (github.event.action == 'labeled' && github.event.label.name == 'deploy-preview')
+      || (contains(fromJSON('["synchronize","reopened"]'), github.event.action)
+          && contains(github.event.pull_request.labels.*.name, 'deploy-preview'))
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # Needed for the "Comment on PR" step — default GITHUB_TOKEN is read-only
-    # for pull-requests/issues.
     permissions:
       contents: read
       pull-requests: write
@@ -43,9 +34,7 @@ jobs:
           STAGING_PATH: ${{ secrets.DEPLOY_STAGING_PATH }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_SHA: ${{ github.event.pull_request.head.sha }}
-          # PR refs (`pull/N/head`) live on the BASE repo, not the head repo,
-          # so we always clone witchesofthehill/manabrew regardless of
-          # whether the PR came from a fork.
+          # PR refs live on the base repo, so always clone that (works for forks too).
           BASE_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -60,57 +49,81 @@ jobs:
               -o ServerAliveCountMax=120 \
               "$USER@$HOST" bash <<REMOTE_EOF
           set -euo pipefail
-
           STAGING="${STAGING_PATH:-/opt/manabrew-staging}"
-          PROD="${DEPLOY_PATH}"
 
-          # First-run bootstrap.
           if [ ! -d "\$STAGING/.git" ]; then
-              echo "[preview] bootstrap clone into \$STAGING"
-              mkdir -p "\$STAGING"
               git clone https://github.com/${BASE_REPO}.git "\$STAGING"
           fi
-
           cd "\$STAGING"
 
-          # Reuse the production secrets file for FORGE_SERVER_KEY
-          # substitution. Symlinked so a key rotation in prod is reflected on
-          # the next preview build without copying.
-          if [ ! -L .env ]; then
-              ln -sf "\$PROD/ops/production.secrets" .env
-          fi
+          # Reuse prod's FORGE_SERVER_KEY (symlink follows rotations).
+          [ -L .env ] || ln -sf "${DEPLOY_PATH}/ops/production.secrets" .env
 
-          # Fetch the PR ref and check it out at the exact SHA the workflow
-          # was triggered for. --force in case the working tree has drifted.
           git fetch origin "pull/${PR_NUMBER}/head" --force
           git checkout --detach --force ${PR_SHA}
 
-          # Build + start the staging stack (web + relay). Compose reuses the
-          # BuildKit cache mounts shared with main builds, so first preview is
-          # slow, subsequent ones are fast. --remove-orphans keeps the slot
-          # clean if a service is renamed across PRs.
           docker compose -p manabrew-staging -f compose.staging.yml up -d --build --remove-orphans
+          # Record which PR owns the single slot so another PR's teardown
+          # doesn't kill this preview.
+          echo "${PR_NUMBER}" > "\$STAGING/.preview-pr"
           REMOTE_EOF
 
-      - name: Comment on PR with preview URL
+      - name: Comment preview URL
         if: always()
         uses: actions/github-script@v7
         env:
           DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
         with:
           script: |
-            const outcome = process.env.DEPLOY_OUTCOME;
+            const ok = process.env.DEPLOY_OUTCOME === 'success';
             const sha = context.payload.pull_request.head.sha.slice(0, 7);
-            const body = outcome === 'success'
-              ? `🚀 Preview deployed: https://staging.manabrew.app (${sha})`
-              : `💥 Preview deploy failed for ${sha} — see [workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body,
+              body: ok
+                ? `🚀 Preview deployed: https://staging.manabrew.app (${sha})`
+                : `💥 Preview deploy failed for ${sha} — see [run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`,
             });
 
       - name: Fail job if deploy failed
         if: steps.deploy.outcome != 'success'
         run: exit 1
+
+  teardown:
+    # Closing the PR, or removing the deploy-preview label.
+    if: |
+      github.event.action == 'closed'
+      || (github.event.action == 'unlabeled' && github.event.label.name == 'deploy-preview')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: SSH and tear down preview (only if this PR owns the slot)
+        env:
+          SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          HOST: ${{ secrets.DEPLOY_HOST }}
+          USER: ${{ secrets.DEPLOY_USER }}
+          STAGING_PATH: ${{ secrets.DEPLOY_STAGING_PATH }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes "$USER@$HOST" bash <<REMOTE_EOF
+          set -euo pipefail
+          STAGING="${STAGING_PATH:-/opt/manabrew-staging}"
+          [ -d "\$STAGING" ] || { echo "no staging dir; nothing to tear down"; exit 0; }
+          cd "\$STAGING"
+
+          OWNER="\$(cat .preview-pr 2>/dev/null || echo '')"
+          if [ "\$OWNER" != "${PR_NUMBER}" ]; then
+              echo "slot owned by PR \${OWNER:-none}, not ${PR_NUMBER}; leaving it up"
+              exit 0
+          fi
+          docker compose -p manabrew-staging -f compose.staging.yml down --remove-orphans
+          rm -f .preview-pr
+          echo "torn down preview for PR ${PR_NUMBER}"
+          REMOTE_EOF

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,116 @@
+name: Preview deploy
+
+# Deploys the PR's HEAD to staging.manabrew.app when (and only when) the
+# PR carries the `deploy-preview` label. Re-runs on every push to that PR
+# while the label is present; removing the label or closing the PR stops
+# new deploys (the slot keeps showing the last deploy until something else
+# takes it over).
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
+concurrency:
+  # Latest push of a given PR cancels the previous in-flight preview build
+  # for that PR; other PRs' deploys are not blocked.
+  group: preview-deploy-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    # Only run when the PR has the `deploy-preview` label. For the `labeled`
+    # event we also check the specific label that triggered it.
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'deploy-preview')
+      && (github.event.action != 'labeled' || github.event.label.name == 'deploy-preview')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # Needed for the "Comment on PR" step — default GITHUB_TOKEN is read-only
+    # for pull-requests/issues.
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: SSH and build PR preview
+        id: deploy
+        continue-on-error: true
+        env:
+          SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          HOST: ${{ secrets.DEPLOY_HOST }}
+          USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          STAGING_PATH: ${{ secrets.DEPLOY_STAGING_PATH }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          # PR refs (`pull/N/head`) live on the BASE repo, not the head repo,
+          # so we always clone witchesofthehill/manabrew regardless of
+          # whether the PR came from a fork.
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+          ssh -i ~/.ssh/deploy_key \
+              -o StrictHostKeyChecking=yes \
+              -o ServerAliveInterval=30 \
+              -o ServerAliveCountMax=120 \
+              "$USER@$HOST" bash <<REMOTE_EOF
+          set -euo pipefail
+
+          STAGING="${STAGING_PATH:-/opt/manabrew-staging}"
+          PROD="${DEPLOY_PATH}"
+
+          # First-run bootstrap.
+          if [ ! -d "\$STAGING/.git" ]; then
+              echo "[preview] bootstrap clone into \$STAGING"
+              mkdir -p "\$STAGING"
+              git clone https://github.com/${BASE_REPO}.git "\$STAGING"
+          fi
+
+          cd "\$STAGING"
+
+          # Reuse the production secrets file for FORGE_SERVER_KEY
+          # substitution. Symlinked so a key rotation in prod is reflected on
+          # the next preview build without copying.
+          if [ ! -L .env ]; then
+              ln -sf "\$PROD/ops/production.secrets" .env
+          fi
+
+          # Fetch the PR ref and check it out at the exact SHA the workflow
+          # was triggered for. --force in case the working tree has drifted.
+          git fetch origin "pull/${PR_NUMBER}/head" --force
+          git checkout --detach --force ${PR_SHA}
+
+          # Build + start the staging stack (web + relay). Compose reuses the
+          # BuildKit cache mounts shared with main builds, so first preview is
+          # slow, subsequent ones are fast. --remove-orphans keeps the slot
+          # clean if a service is renamed across PRs.
+          docker compose -p manabrew-staging -f compose.staging.yml up -d --build --remove-orphans
+          REMOTE_EOF
+
+      - name: Comment on PR with preview URL
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
+        with:
+          script: |
+            const outcome = process.env.DEPLOY_OUTCOME;
+            const sha = context.payload.pull_request.head.sha.slice(0, 7);
+            const body = outcome === 'success'
+              ? `🚀 Preview deployed: https://staging.manabrew.app (${sha})`
+              : `💥 Preview deploy failed for ${sha} — see [workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });
+
+      - name: Fail job if deploy failed
+        if: steps.deploy.outcome != 'success'
+        run: exit 1

--- a/README.md
+++ b/README.md
@@ -269,6 +269,35 @@ Before opening a PR, read [CONTRIBUTING.md](./CONTRIBUTING.md). In short:
 - run `yarn lint:all` before asking for review;
 - do not bundle card images or secrets.
 
+### Preview Deploys
+
+A PR can be deployed to a shared preview environment at
+[staging.manabrew.app](https://staging.manabrew.app) by adding the
+`deploy-preview` label to it.
+
+**Why.** Some classes of bug only show up against a real deployment — TLS,
+cross-origin isolation (`SharedArrayBuffer` needs the right COOP/COEP
+headers), the Scryfall image proxy, and live WebSocket multiplayer. None of
+those are exercised by a local `yarn dev`. The preview gives reviewers a
+working URL to click through before merge instead of building the branch
+themselves.
+
+**How.** Labelling a PR `deploy-preview` triggers the `preview-deploy`
+workflow, which SSHes to the deploy host, checks out the PR's HEAD into a
+separate `/opt/manabrew-staging` working tree (kept apart from the live
+`/opt/manabrew` so a preview build can't disturb prod), and brings up a
+self-contained staging stack:
+
+- `staging.manabrew.app` — the PR's web client
+- `relay-staging.manabrew.app` — a dedicated `forge-server` relay, so a
+  PR that changes the backend is previewed end-to-end without touching the
+  production relay
+
+The workflow comments the preview URL back on the PR. There is a **single**
+preview slot: the most recently labelled PR occupies it, and labelling a
+different PR takes it over. Removing the label (or closing the PR) stops
+further redeploys. Every push to a labelled PR redeploys automatically.
+
 ### AI-Assisted Development
 
 This repository uses AI assistance for mechanical porting, parity

--- a/README.md
+++ b/README.md
@@ -295,8 +295,12 @@ self-contained staging stack:
 
 The workflow comments the preview URL back on the PR. There is a **single**
 preview slot: the most recently labelled PR occupies it, and labelling a
-different PR takes it over. Removing the label (or closing the PR) stops
-further redeploys. Every push to a labelled PR redeploys automatically.
+different PR takes it over. Every push to a labelled PR redeploys
+automatically.
+
+Merging (or closing) the PR, or removing the label, tears the staging stack
+down and frees the slot — a merged PR cleans up after itself, so no stale
+preview lingers.
 
 ### AI-Assisted Development
 

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -1,14 +1,7 @@
-# Per-PR preview stack. Driven by .github/workflows/preview-deploy.yml on
-# PRs that carry the `deploy-preview` label. Lives in /opt/manabrew-staging
-# on the deploy host so it can't trash /opt/manabrew. Joins the main stack's
-# docker network so the production caddy reverse-proxies
-# `staging.manabrew.app` (web) and `relay-staging.manabrew.app` (relay) to
-# these services.
-#
-# Fully isolated from prod at the relay layer: staging gets its own
-# forge-server so a backend-breaking PR can be previewed without touching
-# the live relay. Reuses the prod FORGE_SERVER_KEY (it's a bouncer, not a
-# secret).
+# Per-PR preview stack, driven by .github/workflows/preview-deploy.yml.
+# Runs under /opt/manabrew-staging, joins the prod docker network. Own
+# forge-server so a backend-breaking PR is previewable without touching
+# the live relay.
 services:
   manabrew-staging:
     build:
@@ -21,8 +14,6 @@ services:
         VITE_MANAGED_RELAY: "1"
         VITE_SCRYFALL_SYMBOL_BASE: /scryfall-symbols/
     restart: unless-stopped
-    # Container-internal port only; the production caddy on the same docker
-    # network reverse-proxies staging.manabrew.app to us.
     expose:
       - "80"
     volumes:
@@ -46,8 +37,5 @@ services:
 
 networks:
   default:
-    # Created by /opt/manabrew/compose.production.yml. Joining it from this
-    # separate compose project lets the production caddy resolve
-    # `manabrew-staging` / `forge-server-staging` by service name.
     external: true
     name: manabrew_default

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -1,0 +1,53 @@
+# Per-PR preview stack. Driven by .github/workflows/preview-deploy.yml on
+# PRs that carry the `deploy-preview` label. Lives in /opt/manabrew-staging
+# on the deploy host so it can't trash /opt/manabrew. Joins the main stack's
+# docker network so the production caddy reverse-proxies
+# `staging.manabrew.app` (web) and `relay-staging.manabrew.app` (relay) to
+# these services.
+#
+# Fully isolated from prod at the relay layer: staging gets its own
+# forge-server so a backend-breaking PR can be previewed without touching
+# the live relay. Reuses the prod FORGE_SERVER_KEY (it's a bouncer, not a
+# secret).
+services:
+  manabrew-staging:
+    build:
+      context: .
+      dockerfile: Dockerfile.web
+      args:
+        VITE_RELAY_HOST: relay-staging.manabrew.app
+        VITE_RELAY_PORT: "443"
+        VITE_RELAY_PASSWORD: ${FORGE_SERVER_KEY:?FORGE_SERVER_KEY is required}
+        VITE_MANAGED_RELAY: "1"
+        VITE_SCRYFALL_SYMBOL_BASE: /scryfall-symbols/
+    restart: unless-stopped
+    # Container-internal port only; the production caddy on the same docker
+    # network reverse-proxies staging.manabrew.app to us.
+    expose:
+      - "80"
+    volumes:
+      - ./ops/staging.Caddyfile:/etc/caddy/Caddyfile:ro
+    depends_on:
+      - forge-server-staging
+
+  forge-server-staging:
+    build:
+      context: .
+      dockerfile: forge-engine/crates/forge-server/Dockerfile
+    environment:
+      FORGE_HOST: "0.0.0.0"
+      FORGE_PORT: "9443"
+      FORGE_MAX_ROOMS: "100"
+      FORGE_SERVER_KEY: "${FORGE_SERVER_KEY:?FORGE_SERVER_KEY is required}"
+      RUST_LOG: "forge_server=info"
+    expose:
+      - "9443"
+    restart: unless-stopped
+
+networks:
+  default:
+    # Created by /opt/manabrew/compose.production.yml. Joining it from this
+    # separate compose project lets the production caddy resolve
+    # `manabrew-staging` / `forge-server-staging` by service name.
+    external: true
+    name: manabrew_default

--- a/ops/Caddyfile
+++ b/ops/Caddyfile
@@ -81,11 +81,7 @@ relay.manabrew.app {
     reverse_proxy forge-server:9443
 }
 
-# Per-PR preview slot. The manabrew-staging / forge-server-staging services
-# live in compose.staging.yml under /opt/manabrew-staging and join the
-# manabrew_default docker network, so they're resolvable by service name.
-# 502 when no preview is currently deployed — that's the expected empty
-# state.
+# Per-PR preview slot (compose.staging.yml). 502 when none is deployed.
 staging.manabrew.app {
     reverse_proxy manabrew-staging:80
 }

--- a/ops/Caddyfile
+++ b/ops/Caddyfile
@@ -80,3 +80,16 @@ manabrew.app {
 relay.manabrew.app {
     reverse_proxy forge-server:9443
 }
+
+# Per-PR preview slot. The manabrew-staging / forge-server-staging services
+# live in compose.staging.yml under /opt/manabrew-staging and join the
+# manabrew_default docker network, so they're resolvable by service name.
+# 502 when no preview is currently deployed — that's the expected empty
+# state.
+staging.manabrew.app {
+    reverse_proxy manabrew-staging:80
+}
+
+relay-staging.manabrew.app {
+    reverse_proxy forge-server-staging:9443
+}

--- a/ops/staging.Caddyfile
+++ b/ops/staging.Caddyfile
@@ -1,0 +1,57 @@
+# Minimal Caddyfile for the staging preview web container. The production
+# caddy reverse-proxies `staging.manabrew.app` here, so we accept any Host
+# on internal port 80 (`:80`). Mirrors the manabrew.app block of
+# ops/Caddyfile minus the relay/parity routes (staging's relay is a separate
+# service routed by the main caddy at relay-staging.manabrew.app).
+:80 {
+    root * /srv/manabrew
+
+    # Module workers need require-corp (Chrome's SharedArrayBuffer rule).
+    @worker path_regexp \.worker[.-][^/]+\.js$
+    handle @worker {
+        header {
+            Cache-Control "public, immutable, max-age=31536000"
+            Cross-Origin-Opener-Policy "same-origin"
+            Cross-Origin-Embedder-Policy "require-corp"
+            Cross-Origin-Resource-Policy "same-origin"
+        }
+        file_server
+    }
+
+    # Long-cache hashed Vite assets + WASM bundles + cardset archive.
+    @static path /assets/* /wasm/*
+    handle @static {
+        header {
+            Cache-Control "public, immutable, max-age=31536000"
+            Cross-Origin-Opener-Policy "same-origin"
+            Cross-Origin-Embedder-Policy "credentialless"
+            Cross-Origin-Resource-Policy "same-origin"
+        }
+        file_server
+    }
+
+    # Scryfall SVG proxy. Regex capture (not handle_path) so the upstream
+    # URI is unambiguous — same fix as the main Caddyfile.
+    @scryfall path_regexp scryfall ^/scryfall-symbols/(.*)$
+    handle @scryfall {
+        rewrite * /card-symbols/{re.scryfall.1}
+        reverse_proxy https://svgs.scryfall.io {
+            header_up Host svgs.scryfall.io
+            header_down -Access-Control-Allow-Origin
+            header_down -Cross-Origin-Resource-Policy
+            header_down -Cache-Control
+        }
+        header Cache-Control "public, max-age=604800"
+        header Cross-Origin-Resource-Policy "same-origin"
+    }
+
+    handle {
+        header {
+            Cross-Origin-Opener-Policy "same-origin"
+            Cross-Origin-Embedder-Policy "credentialless"
+            Cross-Origin-Resource-Policy "same-origin"
+        }
+        try_files {path} /index.html
+        file_server
+    }
+}

--- a/ops/staging.Caddyfile
+++ b/ops/staging.Caddyfile
@@ -1,8 +1,6 @@
-# Minimal Caddyfile for the staging preview web container. The production
-# caddy reverse-proxies `staging.manabrew.app` here, so we accept any Host
-# on internal port 80 (`:80`). Mirrors the manabrew.app block of
-# ops/Caddyfile minus the relay/parity routes (staging's relay is a separate
-# service routed by the main caddy at relay-staging.manabrew.app).
+# Staging preview web container. Production caddy proxies
+# staging.manabrew.app here, so accept any Host on :80. Same COEP split +
+# Scryfall proxy as ops/Caddyfile, minus the relay/parity routes.
 :80 {
     root * /srv/manabrew
 


### PR DESCRIPTION
Reopens the preview-deploys work against `main` (original #20 was stacked on the #19 branch). Incorporates the review outcome from the chat with @anacletos: staging now has its **own forge-server**, so a backend-breaking PR can be previewed without touching the live relay.

## How it works
1. Add the `deploy-preview` label to a PR.
2. Workflow (label-gated) SSHes to the host, syncs the PR's HEAD into `/opt/manabrew-staging`, and `docker compose -p manabrew-staging -f compose.staging.yml up -d --build`.
3. Comments the preview URL back on the PR.
4. `staging.manabrew.app` → staging web, `relay-staging.manabrew.app` → staging relay. One slot; latest labelled PR wins.

## Why two compose files instead of one DRY env-gated file
Prod and staging deploy from **different checkouts at different commits** (`/opt/manabrew` @ `main`, `/opt/manabrew-staging` @ the PR HEAD). A single shared compose file would exist in both checkouts at different versions — ambiguous which is authoritative. Profiles (`profiles: [staging]`) in one file technically work, but then the staging deploy command operates on the **prod** compose project, and one stray flag recreates prod containers. The "DRY single service, env-gated" ideal doesn't actually collapse the duplication here — prod and staging differ in container names, ports, relay host, and run simultaneously, so you can't instantiate one service def twice. You end up with two service blocks either way; separate files just keep the staging ones where the staging deploy physically cannot touch prod. Blast-radius isolation > saving a few lines.

## One-time setup after merge
- DNS A records: `staging.manabrew.app` **and** `relay-staging.manabrew.app` → host
- `gh label create deploy-preview --repo witchesofthehill/manabrew --color 0E8A16`
- optional secret `DEPLOY_STAGING_PATH=/opt/manabrew-staging` (workflow defaults to that)

## Test plan
- [ ] Label a PR `deploy-preview` → staging.manabrew.app serves it, relay-staging works for multiplayer
- [ ] Remove label → no further redeploys
- [ ] Re-label a different PR → slot switches

## Build artifacts
- [ ] Build macOS .dmg
- [ ] Build Windows .exe

## Lifecycle note
Merging (or closing) a labelled PR fires the `closed` event → the `teardown` job runs `docker compose … down` and frees the single preview slot. So a merged PR cleans up after itself; no stale preview lingers, and the next labelled PR can take the slot. (Teardown only acts if the merged PR still owns the slot per the `.preview-pr` marker.)