### PR TITLE
perf(ops): gzip/zstd-compress web assets in Caddy

### DIFF
--- a/ops/Caddyfile
+++ b/ops/Caddyfile
@@ -16,6 +16,9 @@
 manabrew.app {
     root * /srv/manabrew
 
+    # Compress text assets — the JS bundle is ~8 MB raw, ~2 MB gzipped.
+    encode zstd gzip
+
     # Module-worker bundles need require-corp; matched before the broader
     # asset block below.
     @worker path_regexp \.worker[.-][^/]+\.js$

--- a/ops/staging.Caddyfile
+++ b/ops/staging.Caddyfile
@@ -4,6 +4,9 @@
 :80 {
     root * /srv/manabrew
 
+    # Compress text assets — the JS bundle is ~8 MB raw, ~2 MB gzipped.
+    encode zstd gzip
+
     # Module workers need require-corp (Chrome's SharedArrayBuffer rule).
     @worker path_regexp \.worker[.-][^/]+\.js$
     handle @worker {


### PR DESCRIPTION
## Summary
Add `encode zstd gzip` to the `manabrew.app` and staging web vhosts in `ops/Caddyfile` and `ops/staging.Caddyfile`.

## Why
The web JS bundle is ~8 MB and was served **uncompressed** (confirmed: `content-length: 8091980`, no `content-encoding`), making first load slow — very noticeable on staging. Compression takes the JS to ~2 MB and also covers CSS/HTML/JSON. Binary assets (wasm, the rkyv cardset) are largely incompressible and unaffected.

## Test plan
- `caddy validate` / deploy; verify `content-encoding: gzip` (or `zstd`) on `/assets/*.js` and a much smaller transfer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)