### PR TITLE
fix(relay): app-level keepalive so idle clients aren't dropped

### DIFF
--- a/forge-engine/crates/forge-agent-interface/src/protocol.rs
+++ b/forge-engine/crates/forge-agent-interface/src/protocol.rs
@@ -82,6 +82,8 @@ pub enum ClientMessage {
         password: String,
     },
 
+    Ping,
+
     ListRooms,
 
     ListPlayers,

--- a/forge-engine/crates/forge-server/src/connection.rs
+++ b/forge-engine/crates/forge-server/src/connection.rs
@@ -1017,6 +1017,7 @@ fn msg_type_of(msg: &ServerMessage) -> &'static str {
 fn client_msg_type(msg: &ClientMessage) -> &'static str {
     match msg {
         ClientMessage::Authenticate { .. } => "Authenticate",
+        ClientMessage::Ping => "Ping",
         ClientMessage::ListRooms => "ListRooms",
         ClientMessage::ListPlayers => "ListPlayers",
         ClientMessage::CreateRoom { .. } => "CreateRoom",

--- a/forge-engine/crates/forge-server/src/connection.rs
+++ b/forge-engine/crates/forge-server/src/connection.rs
@@ -477,6 +477,8 @@ fn handle_client_message(
             );
         }
 
+        ClientMessage::Ping => {}
+
         ClientMessage::ListRooms => {
             let rooms: Vec<_> = state
                 .rooms

--- a/src/platform/web.ts
+++ b/src/platform/web.ts
@@ -547,6 +547,7 @@ class WebServerApi implements IServerApi {
   private serverPassword: string | null = null;
   private bots = new Map<string, BotEntry>();
   private wasmReady: Promise<typeof import("@/wasm/forge_wasm")> | null = null;
+  private keepaliveTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(eventBus: WebEventBus) {
     this.eventBus = eventBus;
@@ -585,6 +586,7 @@ class WebServerApi implements IServerApi {
           username: params.username,
           password: params.password,
         });
+        this.startKeepalive();
         resolve();
       };
 
@@ -609,7 +611,22 @@ class WebServerApi implements IServerApi {
     });
   }
 
+  private startKeepalive(): void {
+    this.stopKeepalive();
+    this.keepaliveTimer = setInterval(() => {
+      if (this.ws?.readyState === WebSocket.OPEN) this.send({ type: "Ping" });
+    }, 30_000);
+  }
+
+  private stopKeepalive(): void {
+    if (this.keepaliveTimer !== null) {
+      clearInterval(this.keepaliveTimer);
+      this.keepaliveTimer = null;
+    }
+  }
+
   async disconnect(): Promise<void> {
+    this.stopKeepalive();
     for (const username of [...this.bots.keys()]) {
       await this.removeAiBot(username);
     }


### PR DESCRIPTION
## Problem
Players report being unable to stay connected — kicked from the lobby and dropped mid-game. The relay logs show:

```
[recv] idle timeout from 'Jaco21' (no frames for 90s)
[cleanup] 'Jaco21' removed (was not in a room)
```

`forge-server` drops any connection with no inbound frame for 90s (`READ_IDLE_TIMEOUT`). It sends a WS Ping every 25s and relies on the browser's automatic Pong to reset the read timer — but those WebSocket **control frames don't reliably survive the reverse-proxy hop**, so a client that isn't actively sending app frames (sitting in the lobby, or waiting through a long opponent turn) hits the 90s timeout and gets disconnected. Active in-game clients survive because their real messages reset the timer.

## Fix
Application-level heartbeat on the Text-frame path the rest of the protocol already uses (auth/game messages flow through the proxy fine):
- `protocol`: add `ClientMessage::Ping`
- `forge-server`: handle it as a no-op — its arrival alone resets the read timer
- web client: send `{type:"Ping"}` every 30s while the socket is open; cleared on disconnect

The existing WS-level ping/pong stays; we just stop depending on control-frame plumbing for liveness. 30s interval gives 3 beats inside the 90s window.

## Test plan
- [ ] Deploy → sit in the lobby > 90s without interacting → stay connected
- [ ] In a 2-player game, let one player idle through the other's long turn → no drop
- [ ] forge-server logs no longer show `idle timeout` for connected clients

## Build artifacts
- [ ] Build macOS .dmg
- [ ] Build Windows .exe