### PR TITLE
fix(server): clean up relay sessions when websocket writes fail

### DIFF
--- a/forge-engine/crates/forge-server/src/connection.rs
+++ b/forge-engine/crates/forge-server/src/connection.rs
@@ -131,13 +131,15 @@ pub async fn handle_connection(
     let (sink, mut receiver) = ws_stream.split();
     let (tx, rx) = mpsc::unbounded_channel();
 
-    let write_task = tokio::spawn(write_loop(rx, sink));
+    let mut write_task = tokio::spawn(write_loop(rx, sink));
 
     let (player_id, username, reconnected, generation) =
         match authenticate(&mut receiver, &tx, &state).await {
             Ok(result) => result,
             Err(e) => {
                 warn!("[auth] failed from {}: {}", addr, e);
+                drop(tx);
+                let _ = write_task.await;
                 return Err(e);
             }
         };
@@ -170,23 +172,40 @@ pub async fn handle_connection(
         }
     });
 
+    let mut write_task_done = false;
+
     loop {
-        let frame = match tokio::time::timeout(READ_IDLE_TIMEOUT, receiver.next()).await {
-            Ok(Some(Ok(f))) => f,
-            Ok(Some(Err(e))) => {
-                warn!("[recv] read error from '{}': {}", username, e);
-                break;
-            }
-            Ok(None) => {
-                info!("[recv] '{}' stream closed", username);
-                break;
-            }
-            Err(_) => {
-                warn!(
-                    "[recv] idle timeout from '{}' (no frames for {}s)",
-                    username,
-                    READ_IDLE_TIMEOUT.as_secs()
-                );
+        let read = tokio::time::timeout(READ_IDLE_TIMEOUT, receiver.next());
+        let frame = tokio::select! {
+            frame = read => match frame {
+                Ok(Some(Ok(f))) => f,
+                Ok(Some(Err(e))) => {
+                    warn!("[recv] read error from '{}': {}", username, e);
+                    break;
+                }
+                Ok(None) => {
+                    info!("[recv] '{}' stream closed", username);
+                    break;
+                }
+                Err(_) => {
+                    warn!(
+                        "[recv] idle timeout from '{}' (no frames for {}s)",
+                        username,
+                        READ_IDLE_TIMEOUT.as_secs()
+                    );
+                    break;
+                }
+            },
+            result = &mut write_task => {
+                write_task_done = true;
+                match result {
+                    Ok(()) => {
+                        warn!("[send] writer stopped for '{}'", username);
+                    }
+                    Err(e) => {
+                        warn!("[send] writer task failed for '{}': {}", username, e);
+                    }
+                }
                 break;
             }
         };
@@ -231,8 +250,10 @@ pub async fn handle_connection(
     // ServerState for reconnection, so rx may never close on abrupt disconnects.
     heartbeat_task.abort();
     drop(tx);
-    write_task.abort();
-    let _ = write_task.await;
+    if !write_task_done {
+        write_task.abort();
+        let _ = write_task.await;
+    }
     Ok(())
 }
 
@@ -667,13 +688,8 @@ fn handle_client_message(
                 deck_name,
                 deck.cards.len()
             );
-            match lobby::set_deck_selection_sync(
-                state,
-                player_id,
-                deck_name,
-                deck,
-                commander_name,
-            ) {
+            match lobby::set_deck_selection_sync(state, player_id, deck_name, deck, commander_name)
+            {
                 Ok(room_id) => {
                     if let Some(room) = state.rooms.get(&room_id) {
                         broadcast_to_room(

--- a/forge-engine/crates/forge-server/src/lobby.rs
+++ b/forge-engine/crates/forge-server/src/lobby.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use crate::error::ServerError;
 use crate::protocol::{GameFormat, PlayerDeckInfo, RoomInfo, RoomStatus};
-use forge_agent_interface::deck_dto::Deck;
 use crate::room::Room;
 use crate::state::ServerState;
+use forge_agent_interface::deck_dto::Deck;
 
 pub fn create_room_sync(
     state: &Arc<ServerState>,


### PR DESCRIPTION
## Build artifacts
<!--
  Check the boxes below to build the corresponding installer on merge to main
  (uploaded to the Actions run, 30-day retention).
  Leave unchecked to skip — faster CI, no binaries produced.
  Tag pushes (v*) always build both and publish a GitHub Release regardless.
-->
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
