### PR TITLE
fix(server): clean up relay sessions when websocket writes fail

### DIFF
--- a/forge-engine/crates/forge-server/src/cleanup.rs
+++ b/forge-engine/crates/forge-server/src/cleanup.rs
@@ -1,0 +1,258 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tracing::{info, warn};
+
+use crate::connection::broadcast_to_room;
+use crate::protocol::{RoomStatus, ServerMessage};
+use crate::room::Room;
+use crate::state::ServerState;
+
+const CLEANUP_INTERVAL: Duration = Duration::from_secs(60);
+const STALE_CONNECTED_TIMEOUT: Duration = Duration::from_secs(180);
+const IN_GAME_DISCONNECTED_GRACE: Duration = Duration::from_secs(3600);
+
+pub async fn cleanup_loop(state: Arc<ServerState>) {
+    let mut ticker = tokio::time::interval(CLEANUP_INTERVAL);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        ticker.tick().await;
+        cleanup_stale_state(&state);
+    }
+}
+
+fn cleanup_stale_state(state: &Arc<ServerState>) {
+    let now = Instant::now();
+    let stale_players = state
+        .players
+        .iter()
+        .filter_map(|entry| {
+            let player = entry.value();
+            (player.connected && now.duration_since(player.last_seen) >= STALE_CONNECTED_TIMEOUT)
+                .then(|| {
+                    (
+                        entry.key().clone(),
+                        player.username.clone(),
+                        player.generation,
+                    )
+                })
+        })
+        .collect::<Vec<_>>();
+
+    for (player_id, username, generation) in stale_players {
+        warn!(
+            "[cleanup] '{}' had no websocket frames for {}s -- marking disconnected",
+            username,
+            STALE_CONNECTED_TIMEOUT.as_secs()
+        );
+        mark_disconnected(state, &player_id, generation);
+    }
+
+    let rooms_to_remove = state
+        .rooms
+        .iter()
+        .filter_map(|entry| {
+            let room = entry.value();
+            match room.status {
+                RoomStatus::Lobby => room
+                    .connected_player_ids()
+                    .is_empty()
+                    .then(|| entry.key().clone()),
+                RoomStatus::InGame => {
+                    in_game_room_expired(state, room, now).then(|| entry.key().clone())
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+
+    for room_id in rooms_to_remove {
+        info!(
+            "[cleanup] removing stale room {}",
+            &room_id[..8.min(room_id.len())]
+        );
+        remove_room_and_clear_sessions(state, &room_id);
+    }
+}
+
+fn in_game_room_expired(state: &Arc<ServerState>, room: &Room, now: Instant) -> bool {
+    if !room.all_disconnected() {
+        return false;
+    }
+
+    let disconnected_at = room
+        .players
+        .iter()
+        .map(|slot| slot.player_id.as_str())
+        .chain(
+            room.observers
+                .iter()
+                .map(|observer| observer.player_id.as_str()),
+        )
+        .map(|player_id| state.players.get(player_id).and_then(|p| p.disconnected_at))
+        .collect::<Option<Vec<_>>>();
+
+    disconnected_at
+        .filter(|times| !times.is_empty())
+        .and_then(|times| times.into_iter().max())
+        .is_some_and(|latest| now.duration_since(latest) >= IN_GAME_DISCONNECTED_GRACE)
+}
+
+pub fn mark_disconnected(state: &Arc<ServerState>, player_id: &str, our_generation: u64) {
+    let (username, room_id) = {
+        if let Some(mut player) = state.players.get_mut(player_id) {
+            if player.generation != our_generation {
+                info!(
+                    "[disconnect] '{}' old connection cleaned up (session reclaimed by new connection)",
+                    player.username
+                );
+                return;
+            }
+            player.connected = false;
+            player.disconnected_at = Some(Instant::now());
+            (player.username.clone(), player.room_id.clone())
+        } else {
+            return;
+        }
+    };
+
+    if let Some(rid) = &room_id {
+        let room_status = state.rooms.get(rid).map(|r| r.status.clone());
+
+        match room_status {
+            Some(RoomStatus::InGame) => {
+                let host_without_player = state
+                    .rooms
+                    .get(rid)
+                    .map(|room| room.is_host(player_id) && !room.host_is_player())
+                    .unwrap_or(false);
+                if host_without_player {
+                    info!(
+                        "[cleanup] hosted in-game room {} lost its non-playing host -- removing",
+                        &rid[..8]
+                    );
+                    remove_room_and_clear_sessions(state, rid);
+                    return;
+                }
+
+                if let Some(mut room) = state.rooms.get_mut(rid) {
+                    room.set_connected(player_id, false);
+                } else {
+                    return;
+                }
+
+                info!(
+                    "[disconnect] '{}' marked disconnected in in-game room {} (session preserved)",
+                    username,
+                    &rid[..8]
+                );
+                broadcast_to_room(
+                    state,
+                    rid,
+                    &ServerMessage::PlayerDisconnected {
+                        username: username.clone(),
+                    },
+                );
+
+                if let Some(room) = state.rooms.get(rid) {
+                    broadcast_to_room(
+                        state,
+                        rid,
+                        &ServerMessage::RoomUpdate {
+                            room: room.to_room_info(),
+                        },
+                    );
+                }
+            }
+            Some(RoomStatus::Lobby) => {
+                info!(
+                    "[disconnect] '{}' disconnected from lobby room {} -- treating as leave",
+                    username,
+                    &rid[..8]
+                );
+
+                let remove_hosted_room = state
+                    .rooms
+                    .get(rid)
+                    .map(|room| room.is_host(player_id) && !room.host_is_player())
+                    .unwrap_or(false);
+                if remove_hosted_room {
+                    info!(
+                        "[cleanup] hosted lobby room {} lost its non-playing host -- removing",
+                        &rid[..8]
+                    );
+                    remove_room_and_clear_sessions(state, rid);
+                    return;
+                }
+
+                let room_empty = {
+                    if let Some(mut room) = state.rooms.get_mut(rid) {
+                        room.remove_participant(player_id);
+                        room.is_empty()
+                    } else {
+                        false
+                    }
+                };
+
+                if let Some(mut player) = state.players.get_mut(player_id) {
+                    player.room_id = None;
+                }
+
+                if room_empty {
+                    info!(
+                        "[cleanup] lobby room {} is now empty -- removing",
+                        &rid[..8]
+                    );
+                    remove_room_and_clear_sessions(state, rid);
+                } else {
+                    broadcast_to_room(
+                        state,
+                        rid,
+                        &ServerMessage::PlayerLeft {
+                            room_id: rid.clone(),
+                            username: username.clone(),
+                        },
+                    );
+                    if let Some(room) = state.rooms.get(rid) {
+                        broadcast_to_room(
+                            state,
+                            rid,
+                            &ServerMessage::RoomUpdate {
+                                room: room.to_room_info(),
+                            },
+                        );
+                    }
+                }
+
+                info!("[cleanup] '{}' removed (disconnected from lobby)", username);
+                state.players.remove(player_id);
+            }
+            None => {
+                info!("[cleanup] '{}' removed (room no longer exists)", username);
+                state.players.remove(player_id);
+            }
+        }
+    } else {
+        info!("[cleanup] '{}' removed (was not in a room)", username);
+        state.players.remove(player_id);
+    }
+}
+
+pub fn remove_room_and_clear_sessions(state: &Arc<ServerState>, room_id: &str) {
+    state.rooms.remove(room_id);
+    let player_ids = state
+        .players
+        .iter()
+        .filter_map(|entry| {
+            entry
+                .value()
+                .room_id
+                .as_deref()
+                .is_some_and(|rid| rid == room_id)
+                .then(|| entry.key().clone())
+        })
+        .collect::<Vec<_>>();
+    for player_id in player_ids {
+        state.players.remove(&player_id);
+    }
+}

--- a/forge-engine/crates/forge-server/src/connection.rs
+++ b/forge-engine/crates/forge-server/src/connection.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use futures_util::{SinkExt, StreamExt};
 use tokio::sync::mpsc;
@@ -20,8 +20,8 @@ type WsSender = futures_util::stream::SplitSink<
 type WsReceiver =
     futures_util::stream::SplitStream<tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>>;
 
-const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(25);
-const READ_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
+pub(crate) const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(25);
+pub(crate) const READ_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
 
 /// Background task: drains channel and writes to the WebSocket sink.
 async fn write_loop(mut rx: mpsc::UnboundedReceiver<Message>, mut sink: WsSender) {
@@ -210,6 +210,12 @@ pub async fn handle_connection(
             }
         };
 
+        if let Some(mut player) = state.players.get_mut(&player_id) {
+            if player.generation == generation {
+                player.last_seen = Instant::now();
+            }
+        }
+
         match frame {
             Message::Text(text) => {
                 let client_msg: ClientMessage = match serde_json::from_str(&text) {
@@ -319,6 +325,8 @@ async fn authenticate(
                     player.sender = sender.clone();
                     player.connected = true;
                     player.generation = new_gen;
+                    player.last_seen = Instant::now();
+                    player.disconnected_at = None;
                 }
 
                 let reply = ServerMessage::AuthResult {
@@ -385,6 +393,8 @@ async fn authenticate(
                             player.sender = sender.clone();
                             player.connected = true;
                             player.generation = new_gen;
+                            player.last_seen = Instant::now();
+                            player.disconnected_at = None;
                         }
 
                         let reply = ServerMessage::AuthResult {
@@ -448,6 +458,8 @@ async fn authenticate(
                     sender: sender.clone(),
                     connected: true,
                     generation,
+                    last_seen: Instant::now(),
+                    disconnected_at: None,
                 },
             );
 
@@ -816,7 +828,7 @@ fn handle_client_message(
     }
 }
 
-fn mark_disconnected(state: &Arc<ServerState>, player_id: &str, our_generation: u64) {
+pub(crate) fn mark_disconnected(state: &Arc<ServerState>, player_id: &str, our_generation: u64) {
     let (username, room_id) = {
         if let Some(mut player) = state.players.get_mut(player_id) {
             if player.generation != our_generation {
@@ -827,6 +839,7 @@ fn mark_disconnected(state: &Arc<ServerState>, player_id: &str, our_generation: 
                 return;
             }
             player.connected = false;
+            player.disconnected_at = Some(Instant::now());
             (player.username.clone(), player.room_id.clone())
         } else {
             return;
@@ -853,34 +866,9 @@ fn mark_disconnected(state: &Arc<ServerState>, player_id: &str, our_generation: 
                     return;
                 }
 
-                let all_disconnected = if let Some(mut room) = state.rooms.get_mut(rid) {
+                if let Some(mut room) = state.rooms.get_mut(rid) {
                     room.set_connected(player_id, false);
-                    room.all_disconnected()
                 } else {
-                    return;
-                };
-
-                if all_disconnected {
-                    info!(
-                        "[cleanup] in-game room {} has no connected players -- removing",
-                        &rid[..8]
-                    );
-                    state.rooms.remove(rid);
-                    let player_ids = state
-                        .players
-                        .iter()
-                        .filter_map(|entry| {
-                            entry
-                                .value()
-                                .room_id
-                                .as_deref()
-                                .is_some_and(|room_id| room_id == rid)
-                                .then(|| entry.key().clone())
-                        })
-                        .collect::<Vec<_>>();
-                    for player_id in player_ids {
-                        state.players.remove(&player_id);
-                    }
                     return;
                 }
 
@@ -990,7 +978,7 @@ fn get_username(state: &Arc<ServerState>, player_id: &str) -> String {
         .unwrap_or_default()
 }
 
-fn remove_room_and_clear_sessions(state: &Arc<ServerState>, room_id: &str) {
+pub(crate) fn remove_room_and_clear_sessions(state: &Arc<ServerState>, room_id: &str) {
     state.rooms.remove(room_id);
     let player_ids = state
         .players

--- a/forge-engine/crates/forge-server/src/connection.rs
+++ b/forge-engine/crates/forge-server/src/connection.rs
@@ -7,9 +7,10 @@ use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::Message;
 use tracing::{debug, info, warn};
 
+use crate::cleanup::mark_disconnected;
 use crate::error::ServerError;
 use crate::lobby;
-use crate::protocol::{ClientMessage, RoomStatus, ServerMessage};
+use crate::protocol::{ClientMessage, ServerMessage};
 use crate::state::{ConnectedPlayer, ServerState};
 
 type WsSender = futures_util::stream::SplitSink<
@@ -828,173 +829,12 @@ fn handle_client_message(
     }
 }
 
-pub(crate) fn mark_disconnected(state: &Arc<ServerState>, player_id: &str, our_generation: u64) {
-    let (username, room_id) = {
-        if let Some(mut player) = state.players.get_mut(player_id) {
-            if player.generation != our_generation {
-                info!(
-                    "[disconnect] '{}' old connection cleaned up (session reclaimed by new connection)",
-                    player.username
-                );
-                return;
-            }
-            player.connected = false;
-            player.disconnected_at = Some(Instant::now());
-            (player.username.clone(), player.room_id.clone())
-        } else {
-            return;
-        }
-    };
-
-    if let Some(rid) = &room_id {
-        let room_status = state.rooms.get(rid).map(|r| r.status.clone());
-
-        match room_status {
-            Some(RoomStatus::InGame) => {
-                // InGame: always preserve session for reconnection.
-                let host_without_player = state
-                    .rooms
-                    .get(rid)
-                    .map(|room| room.is_host(player_id) && !room.host_is_player())
-                    .unwrap_or(false);
-                if host_without_player {
-                    info!(
-                        "[cleanup] hosted in-game room {} lost its non-playing host -- removing",
-                        &rid[..8]
-                    );
-                    remove_room_and_clear_sessions(state, rid);
-                    return;
-                }
-
-                if let Some(mut room) = state.rooms.get_mut(rid) {
-                    room.set_connected(player_id, false);
-                } else {
-                    return;
-                }
-
-                info!(
-                    "[disconnect] '{}' marked disconnected in in-game room {} (session preserved)",
-                    username,
-                    &rid[..8]
-                );
-                broadcast_to_room(
-                    state,
-                    rid,
-                    &ServerMessage::PlayerDisconnected {
-                        username: username.clone(),
-                    },
-                );
-
-                if let Some(room) = state.rooms.get(rid) {
-                    broadcast_to_room(
-                        state,
-                        rid,
-                        &ServerMessage::RoomUpdate {
-                            room: room.to_room_info(),
-                        },
-                    );
-                }
-            }
-            Some(RoomStatus::Lobby) => {
-                // Lobby: treat like a leave — remove player, clean up room, free username
-                info!(
-                    "[disconnect] '{}' disconnected from lobby room {} -- treating as leave",
-                    username,
-                    &rid[..8]
-                );
-
-                let remove_hosted_room = state
-                    .rooms
-                    .get(rid)
-                    .map(|room| room.is_host(player_id) && !room.host_is_player())
-                    .unwrap_or(false);
-                if remove_hosted_room {
-                    info!(
-                        "[cleanup] hosted lobby room {} lost its non-playing host -- removing",
-                        &rid[..8]
-                    );
-                    remove_room_and_clear_sessions(state, rid);
-                    return;
-                }
-
-                let room_empty = {
-                    if let Some(mut room) = state.rooms.get_mut(rid) {
-                        room.remove_participant(player_id);
-                        room.is_empty()
-                    } else {
-                        false
-                    }
-                };
-
-                if let Some(mut player) = state.players.get_mut(player_id) {
-                    player.room_id = None;
-                }
-
-                if room_empty {
-                    info!(
-                        "[cleanup] lobby room {} is now empty -- removing",
-                        &rid[..8]
-                    );
-                    remove_room_and_clear_sessions(state, rid);
-                } else {
-                    broadcast_to_room(
-                        state,
-                        rid,
-                        &ServerMessage::PlayerLeft {
-                            room_id: rid.clone(),
-                            username: username.clone(),
-                        },
-                    );
-                    if let Some(room) = state.rooms.get(rid) {
-                        broadcast_to_room(
-                            state,
-                            rid,
-                            &ServerMessage::RoomUpdate {
-                                room: room.to_room_info(),
-                            },
-                        );
-                    }
-                }
-
-                info!("[cleanup] '{}' removed (disconnected from lobby)", username);
-                state.players.remove(player_id);
-            }
-            None => {
-                info!("[cleanup] '{}' removed (room no longer exists)", username);
-                state.players.remove(player_id);
-            }
-        }
-    } else {
-        info!("[cleanup] '{}' removed (was not in a room)", username);
-        state.players.remove(player_id);
-    }
-}
-
 fn get_username(state: &Arc<ServerState>, player_id: &str) -> String {
     state
         .players
         .get(player_id)
         .map(|p| p.username.clone())
         .unwrap_or_default()
-}
-
-pub(crate) fn remove_room_and_clear_sessions(state: &Arc<ServerState>, room_id: &str) {
-    state.rooms.remove(room_id);
-    let player_ids = state
-        .players
-        .iter()
-        .filter_map(|entry| {
-            entry
-                .value()
-                .room_id
-                .as_deref()
-                .is_some_and(|rid| rid == room_id)
-                .then(|| entry.key().clone())
-        })
-        .collect::<Vec<_>>();
-    for player_id in player_ids {
-        state.players.remove(&player_id);
-    }
 }
 
 fn msg_type_of(msg: &ServerMessage) -> &'static str {

--- a/forge-engine/crates/forge-server/src/connection.rs
+++ b/forge-engine/crates/forge-server/src/connection.rs
@@ -131,13 +131,15 @@ pub async fn handle_connection(
     let (sink, mut receiver) = ws_stream.split();
     let (tx, rx) = mpsc::unbounded_channel();
 
-    let write_task = tokio::spawn(write_loop(rx, sink));
+    let mut write_task = tokio::spawn(write_loop(rx, sink));
 
     let (player_id, username, reconnected, generation) =
         match authenticate(&mut receiver, &tx, &state).await {
             Ok(result) => result,
             Err(e) => {
                 warn!("[auth] failed from {}: {}", addr, e);
+                drop(tx);
+                let _ = write_task.await;
                 return Err(e);
             }
         };
@@ -170,23 +172,40 @@ pub async fn handle_connection(
         }
     });
 
+    let mut write_task_done = false;
+
     loop {
-        let frame = match tokio::time::timeout(READ_IDLE_TIMEOUT, receiver.next()).await {
-            Ok(Some(Ok(f))) => f,
-            Ok(Some(Err(e))) => {
-                warn!("[recv] read error from '{}': {}", username, e);
-                break;
-            }
-            Ok(None) => {
-                info!("[recv] '{}' stream closed", username);
-                break;
-            }
-            Err(_) => {
-                warn!(
-                    "[recv] idle timeout from '{}' (no frames for {}s)",
-                    username,
-                    READ_IDLE_TIMEOUT.as_secs()
-                );
+        let read = tokio::time::timeout(READ_IDLE_TIMEOUT, receiver.next());
+        let frame = tokio::select! {
+            frame = read => match frame {
+                Ok(Some(Ok(f))) => f,
+                Ok(Some(Err(e))) => {
+                    warn!("[recv] read error from '{}': {}", username, e);
+                    break;
+                }
+                Ok(None) => {
+                    info!("[recv] '{}' stream closed", username);
+                    break;
+                }
+                Err(_) => {
+                    warn!(
+                        "[recv] idle timeout from '{}' (no frames for {}s)",
+                        username,
+                        READ_IDLE_TIMEOUT.as_secs()
+                    );
+                    break;
+                }
+            },
+            result = &mut write_task => {
+                write_task_done = true;
+                match result {
+                    Ok(()) => {
+                        warn!("[send] writer stopped for '{}'", username);
+                    }
+                    Err(e) => {
+                        warn!("[send] writer task failed for '{}': {}", username, e);
+                    }
+                }
                 break;
             }
         };
@@ -231,8 +250,10 @@ pub async fn handle_connection(
     // ServerState for reconnection, so rx may never close on abrupt disconnects.
     heartbeat_task.abort();
     drop(tx);
-    write_task.abort();
-    let _ = write_task.await;
+    if !write_task_done {
+        write_task.abort();
+        let _ = write_task.await;
+    }
     Ok(())
 }
 
@@ -667,13 +688,8 @@ fn handle_client_message(
                 deck_name,
                 deck.cards.len()
             );
-            match lobby::set_deck_selection_sync(
-                state,
-                player_id,
-                deck_name,
-                deck,
-                commander_name,
-            ) {
+            match lobby::set_deck_selection_sync(state, player_id, deck_name, deck, commander_name)
+            {
                 Ok(room_id) => {
                     if let Some(room) = state.rooms.get(&room_id) {
                         broadcast_to_room(

--- a/forge-engine/crates/forge-server/src/lib.rs
+++ b/forge-engine/crates/forge-server/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cleanup;
 pub mod config;
 pub mod connection;
 pub mod error;

--- a/forge-engine/crates/forge-server/src/lobby.rs
+++ b/forge-engine/crates/forge-server/src/lobby.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use crate::error::ServerError;
 use crate::protocol::{GameFormat, PlayerDeckInfo, RoomInfo, RoomStatus};
-use forge_agent_interface::deck_dto::Deck;
 use crate::room::Room;
 use crate::state::ServerState;
+use forge_agent_interface::deck_dto::Deck;
 
 pub fn create_room_sync(
     state: &Arc<ServerState>,

--- a/forge-engine/crates/forge-server/src/main.rs
+++ b/forge-engine/crates/forge-server/src/main.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+mod cleanup;
 mod config;
 mod connection;
 mod error;

--- a/forge-engine/crates/forge-server/src/server.rs
+++ b/forge-engine/crates/forge-server/src/server.rs
@@ -1,11 +1,17 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use tokio::net::TcpListener;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
-use crate::connection::handle_connection;
+use crate::connection::{handle_connection, mark_disconnected, remove_room_and_clear_sessions};
+use crate::protocol::RoomStatus;
 use crate::state::ServerState;
+
+const CLEANUP_INTERVAL: Duration = Duration::from_secs(60);
+const STALE_CONNECTED_TIMEOUT: Duration = Duration::from_secs(180);
+const IN_GAME_DISCONNECTED_GRACE: Duration = Duration::from_secs(3600);
 
 pub async fn run_server(state: Arc<ServerState>, addr: SocketAddr) {
     let listener = TcpListener::bind(addr)
@@ -15,6 +21,8 @@ pub async fn run_server(state: Arc<ServerState>, addr: SocketAddr) {
     info!("[server] Forge Server listening on ws://{}", addr);
     info!("[server] Server key: {}", mask_key(&state.server_key));
     info!("[server] Max rooms: {}", state.max_rooms);
+
+    tokio::spawn(cleanup_loop(state.clone()));
 
     loop {
         match listener.accept().await {
@@ -32,6 +40,90 @@ pub async fn run_server(state: Arc<ServerState>, addr: SocketAddr) {
             }
         }
     }
+}
+
+async fn cleanup_loop(state: Arc<ServerState>) {
+    let mut ticker = tokio::time::interval(CLEANUP_INTERVAL);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        ticker.tick().await;
+        cleanup_stale_state(&state);
+    }
+}
+
+fn cleanup_stale_state(state: &Arc<ServerState>) {
+    let now = Instant::now();
+    let stale_players = state
+        .players
+        .iter()
+        .filter_map(|entry| {
+            let player = entry.value();
+            (player.connected && now.duration_since(player.last_seen) >= STALE_CONNECTED_TIMEOUT)
+                .then(|| {
+                    (
+                        entry.key().clone(),
+                        player.username.clone(),
+                        player.generation,
+                    )
+                })
+        })
+        .collect::<Vec<_>>();
+
+    for (player_id, username, generation) in stale_players {
+        warn!(
+            "[cleanup] '{}' had no websocket frames for {}s -- marking disconnected",
+            username,
+            STALE_CONNECTED_TIMEOUT.as_secs()
+        );
+        mark_disconnected(state, &player_id, generation);
+    }
+
+    let rooms_to_remove = state
+        .rooms
+        .iter()
+        .filter_map(|entry| {
+            let room = entry.value();
+            match room.status {
+                RoomStatus::Lobby => room
+                    .connected_player_ids()
+                    .is_empty()
+                    .then(|| entry.key().clone()),
+                RoomStatus::InGame => {
+                    in_game_room_expired(state, entry.key(), now).then(|| entry.key().clone())
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+
+    for room_id in rooms_to_remove {
+        info!(
+            "[cleanup] removing stale room {}",
+            &room_id[..8.min(room_id.len())]
+        );
+        remove_room_and_clear_sessions(state, &room_id);
+    }
+}
+
+fn in_game_room_expired(state: &Arc<ServerState>, room_id: &str, now: Instant) -> bool {
+    let disconnected_at = state
+        .players
+        .iter()
+        .filter_map(|entry| {
+            (entry.value().room_id.as_deref() == Some(room_id)).then(|| {
+                if entry.value().connected {
+                    None
+                } else {
+                    entry.value().disconnected_at
+                }
+            })
+        })
+        .collect::<Option<Vec<_>>>();
+
+    disconnected_at
+        .filter(|times| !times.is_empty())
+        .and_then(|times| times.into_iter().max())
+        .is_some_and(|latest| now.duration_since(latest) >= IN_GAME_DISCONNECTED_GRACE)
 }
 
 fn mask_key(key: &str) -> String {

--- a/forge-engine/crates/forge-server/src/server.rs
+++ b/forge-engine/crates/forge-server/src/server.rs
@@ -1,17 +1,12 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 
 use tokio::net::TcpListener;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
-use crate::connection::{handle_connection, mark_disconnected, remove_room_and_clear_sessions};
-use crate::protocol::RoomStatus;
+use crate::cleanup::cleanup_loop;
+use crate::connection::handle_connection;
 use crate::state::ServerState;
-
-const CLEANUP_INTERVAL: Duration = Duration::from_secs(60);
-const STALE_CONNECTED_TIMEOUT: Duration = Duration::from_secs(180);
-const IN_GAME_DISCONNECTED_GRACE: Duration = Duration::from_secs(3600);
 
 pub async fn run_server(state: Arc<ServerState>, addr: SocketAddr) {
     let listener = TcpListener::bind(addr)
@@ -40,90 +35,6 @@ pub async fn run_server(state: Arc<ServerState>, addr: SocketAddr) {
             }
         }
     }
-}
-
-async fn cleanup_loop(state: Arc<ServerState>) {
-    let mut ticker = tokio::time::interval(CLEANUP_INTERVAL);
-    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-
-    loop {
-        ticker.tick().await;
-        cleanup_stale_state(&state);
-    }
-}
-
-fn cleanup_stale_state(state: &Arc<ServerState>) {
-    let now = Instant::now();
-    let stale_players = state
-        .players
-        .iter()
-        .filter_map(|entry| {
-            let player = entry.value();
-            (player.connected && now.duration_since(player.last_seen) >= STALE_CONNECTED_TIMEOUT)
-                .then(|| {
-                    (
-                        entry.key().clone(),
-                        player.username.clone(),
-                        player.generation,
-                    )
-                })
-        })
-        .collect::<Vec<_>>();
-
-    for (player_id, username, generation) in stale_players {
-        warn!(
-            "[cleanup] '{}' had no websocket frames for {}s -- marking disconnected",
-            username,
-            STALE_CONNECTED_TIMEOUT.as_secs()
-        );
-        mark_disconnected(state, &player_id, generation);
-    }
-
-    let rooms_to_remove = state
-        .rooms
-        .iter()
-        .filter_map(|entry| {
-            let room = entry.value();
-            match room.status {
-                RoomStatus::Lobby => room
-                    .connected_player_ids()
-                    .is_empty()
-                    .then(|| entry.key().clone()),
-                RoomStatus::InGame => {
-                    in_game_room_expired(state, entry.key(), now).then(|| entry.key().clone())
-                }
-            }
-        })
-        .collect::<Vec<_>>();
-
-    for room_id in rooms_to_remove {
-        info!(
-            "[cleanup] removing stale room {}",
-            &room_id[..8.min(room_id.len())]
-        );
-        remove_room_and_clear_sessions(state, &room_id);
-    }
-}
-
-fn in_game_room_expired(state: &Arc<ServerState>, room_id: &str, now: Instant) -> bool {
-    let disconnected_at = state
-        .players
-        .iter()
-        .filter_map(|entry| {
-            (entry.value().room_id.as_deref() == Some(room_id)).then(|| {
-                if entry.value().connected {
-                    None
-                } else {
-                    entry.value().disconnected_at
-                }
-            })
-        })
-        .collect::<Option<Vec<_>>>();
-
-    disconnected_at
-        .filter(|times| !times.is_empty())
-        .and_then(|times| times.into_iter().max())
-        .is_some_and(|latest| now.duration_since(latest) >= IN_GAME_DISCONNECTED_GRACE)
 }
 
 fn mask_key(key: &str) -> String {

--- a/forge-engine/crates/forge-server/src/state.rs
+++ b/forge-engine/crates/forge-server/src/state.rs
@@ -1,4 +1,5 @@
 use dashmap::DashMap;
+use std::time::Instant;
 use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::Message;
 
@@ -11,6 +12,8 @@ pub struct ConnectedPlayer {
     pub sender: mpsc::UnboundedSender<Message>,
     pub connected: bool,
     pub generation: u64,
+    pub last_seen: Instant,
+    pub disconnected_at: Option<Instant>,
 }
 
 pub struct ServerState {


### PR DESCRIPTION
## Build artifacts
<!--
  Check the boxes below to build the corresponding installer on merge to main
  (uploaded to the Actions run, 30-day retention).
  Leave unchecked to skip — faster CI, no binaries produced.
  Tag pushes (v*) always build both and publish a GitHub Release regardless.
-->
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
