### PR TITLE
fix(deploy): init forge submodule on the deploy host

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -60,6 +60,12 @@ PREV=$(git rev-parse --short HEAD)
 git pull origin main --ff-only >> "$RAW_LOG" 2>&1
 CURR=$(git rev-parse --short HEAD)
 
+# Forge is a git submodule (engine + cardsfolder). Pulling main only moves the
+# gitlink pointer; the working tree must be checked out explicitly or the wasm
+# / cardset build fails with "cardsfolder does not exist: forge/forge-gui/res".
+git submodule sync --recursive >> "$RAW_LOG" 2>&1 || true
+git submodule update --init --recursive >> "$RAW_LOG" 2>&1
+
 if [ "$PREV" = "$CURR" ]; then
     echo "😴 No new commits. Nothing to deploy."
     exit 0


### PR DESCRIPTION
Hotfix for the failing **Wasm deploy** on main. `deploy.sh` did `git pull --ff-only` but never checked out the forge submodule, so the deploy host's `forge/forge-gui/res/cardsfolder` was empty and the wasm/cardset build failed. Adds `git submodule sync/update --init --recursive` after the pull.

Note: on the first deploy after this lands, if the host's old vendored `forge/` files linger and block the submodule clone, clear them once on the host.