### PR TITLE
fix(ui): fix slop rendering RAF and FPS handling

### DIFF
--- a/src/pixi/ArrowLayer.ts
+++ b/src/pixi/ArrowLayer.ts
@@ -185,11 +185,13 @@ function particleAlpha(t: number): number {
 // ── Internal pool entry — one per active arrow ─────────────────────────────
 interface ArrowEntry {
   root: Container;
-  // Painterly: 2 strokes (under + core). Rune: 1 dashed stroke. Placement: 1 dashed.
   underGfx: Graphics;
   coreGfx: Graphics;
   headGfx: Graphics;
   particlesGfx: Graphics;
+  gradKey: string;
+  underGrad: FillGradient | null;
+  coreGrad: FillGradient | null;
 }
 
 export class ArrowLayer {
@@ -199,6 +201,7 @@ export class ArrowLayer {
   private pool: ArrowEntry[] = [];
   private elapsedMs = 0;
   private placementDashOffset = 0;
+  private clear = true;
 
   constructor() {
     this.root = new Container();
@@ -210,16 +213,17 @@ export class ArrowLayer {
     return this.root;
   }
 
+  get isClear(): boolean {
+    return this.clear;
+  }
+
   setTheme(theme: Theme): void {
     this.theme = theme;
     if (this.arrows.length > 0) this.redraw();
   }
 
-  /**
-   * Replace the active arrow set and advance time-based animations
-   * (placement marching-ants, painterly embers, rune motes).
-   */
   update(arrows: ArrowDef[], deltaMs = 0): void {
+    if (arrows.length === 0 && this.clear) return;
     this.elapsedMs += deltaMs;
     this.placementDashOffset =
       (this.placementDashOffset + (deltaMs / 1000) * PLACEMENT_DASH_SPEED_PX_PER_SEC) %
@@ -227,6 +231,7 @@ export class ArrowLayer {
     this.arrows = arrows;
     this.ensurePool(arrows.length);
     this.redraw();
+    this.clear = arrows.length === 0;
   }
 
   destroy(): void {
@@ -248,7 +253,16 @@ export class ArrowLayer {
       root.addChild(headGfx);
       root.addChild(particlesGfx);
       this.root.addChild(root);
-      this.pool.push({ root, underGfx, coreGfx, headGfx, particlesGfx });
+      this.pool.push({
+        root,
+        underGfx,
+        coreGfx,
+        headGfx,
+        particlesGfx,
+        gradKey: "",
+        underGrad: null,
+        coreGrad: null,
+      });
     }
   }
 
@@ -293,15 +307,19 @@ export class ArrowLayer {
         : this.theme.gameTheme.pointer.friendly;
     const hue = hexToNum(hueHex);
 
-    // Tapered gradient — same stops for under + core so the brushy fade
-    // reads from tail (faint) to tip (saturated).
-    const underGrad = new FillGradient(ax1, ay1, ax2, ay2);
-    const coreGrad = new FillGradient(ax1, ay1, ax2, ay2);
-    for (const [stop, alpha] of PAINTERLY_GRADIENT_STOPS) {
-      const rgba = hueAsRgba(hue, alpha);
-      underGrad.addColorStop(stop, rgba);
-      coreGrad.addColorStop(stop, rgba);
+    const gradKey = `${ax1.toFixed(1)},${ay1.toFixed(1)},${ax2.toFixed(1)},${ay2.toFixed(1)},${hue}`;
+    if (entry.gradKey !== gradKey || !entry.underGrad || !entry.coreGrad) {
+      entry.underGrad = new FillGradient(ax1, ay1, ax2, ay2);
+      entry.coreGrad = new FillGradient(ax1, ay1, ax2, ay2);
+      for (const [stop, alpha] of PAINTERLY_GRADIENT_STOPS) {
+        const rgba = hueAsRgba(hue, alpha);
+        entry.underGrad.addColorStop(stop, rgba);
+        entry.coreGrad.addColorStop(stop, rgba);
+      }
+      entry.gradKey = gradKey;
     }
+    const underGrad = entry.underGrad;
+    const coreGrad = entry.coreGrad;
 
     entry.underGfx
       .moveTo(curve.p0.x, curve.p0.y)

--- a/src/pixi/PixiArrowsCanvas.tsx
+++ b/src/pixi/PixiArrowsCanvas.tsx
@@ -3,6 +3,8 @@ import { Application, type Ticker } from "pixi.js";
 import { destroyPixiApp, installPixiPatches } from "./pixiPatches";
 import { ArrowLayer, type ArrowDef } from "./ArrowLayer";
 import { PointerLayer, type ResolvedPointer } from "./PointerLayer";
+import { PIXI_MAX_FPS } from "./constants";
+import { registerPixiApp } from "./visibility";
 
 installPixiPatches();
 import type { Theme } from "@/hooks/useTheme";
@@ -62,6 +64,7 @@ export function PixiArrowsCanvas({
   const arrowLayerRef = useRef<ArrowLayer | null>(null);
   const pointerLayerRef = useRef<PointerLayer | null>(null);
   const themeRef = useRef<Theme | null>(null);
+  const unregisterVisibilityRef = useRef<(() => void) | null>(null);
 
   // Latest inputs accessed inside the ticker callback without re-binding.
   const arrowSpecsRef = useRef<ArrowSpec[]>([]);
@@ -109,6 +112,9 @@ export function PixiArrowsCanvas({
     }
     if (!app.renderer) return false;
 
+    app.ticker.maxFPS = PIXI_MAX_FPS;
+    unregisterVisibilityRef.current = registerPixiApp(app);
+
     const arrowLayer = new ArrowLayer();
     arrowLayerRef.current = arrowLayer;
     app.stage.addChild(arrowLayer.graphics);
@@ -126,7 +132,15 @@ export function PixiArrowsCanvas({
     pointerLayer.setTheme(themeRef.current);
 
     app.ticker.add((ticker: Ticker) => {
-      if (!arrowLayerRef.current || !canvasRef.current) return;
+      const arrowLayer = arrowLayerRef.current;
+      const pointerLayer = pointerLayerRef.current;
+      if (!arrowLayer || !canvasRef.current) return;
+      const hasInputs =
+        arrowSpecsRef.current.length > 0 ||
+        pointerSpecsRef.current.length > 0 ||
+        castingArrowRef.current !== null;
+      if (!hasInputs && arrowLayer.isClear && (!pointerLayer || pointerLayer.isClear)) return;
+
       const opponentScenes: { playerId: string; scene: PixiGameScene }[] = [];
       const map = opponentSceneRefsRef.current;
       if (map) {
@@ -144,8 +158,8 @@ export function PixiArrowsCanvas({
         cursorViewportRef.current,
         endpointCacheRef.current,
       );
-      arrowLayerRef.current.update(arrows, ticker.deltaMS);
-      pointerLayerRef.current?.update(pointers, ticker.deltaMS);
+      arrowLayer.update(arrows, ticker.deltaMS);
+      pointerLayer?.update(pointers, ticker.deltaMS);
     });
 
     // Initial resize since we no longer use resizeTo. Renderer may have
@@ -164,9 +178,9 @@ export function PixiArrowsCanvas({
   useEffect(() => {
     let active = true;
     initApp().then((success) => {
-      // Effect was cleaned up while init was in flight — tear down the
-      // app we just created instead of leaking its WebGL context.
       if (!active) {
+        unregisterVisibilityRef.current?.();
+        unregisterVisibilityRef.current = null;
         destroyPixiApp(appRef.current);
         appRef.current = null;
         return;
@@ -179,6 +193,8 @@ export function PixiArrowsCanvas({
       arrowLayerRef.current = null;
       pointerLayerRef.current?.destroy();
       pointerLayerRef.current = null;
+      unregisterVisibilityRef.current?.();
+      unregisterVisibilityRef.current = null;
       destroyPixiApp(appRef.current);
       appRef.current = null;
       markReady(false);

--- a/src/pixi/PixiGameCanvas.tsx
+++ b/src/pixi/PixiGameCanvas.tsx
@@ -25,8 +25,10 @@ import {
   FPS_SAMPLE_INTERVAL_MS,
   HAND_ACTIONS_CLEAR_DELAY_MS,
   HAND_ACTIONS_GAP_PX,
+  PIXI_MAX_FPS,
   Z_HAND_ACTIONS_MENU,
 } from "./constants";
+import { registerPixiApp } from "./visibility";
 
 interface PixiGameCanvasProps {
   battlefield: BattlefieldState;
@@ -102,6 +104,7 @@ export function PixiGameCanvas({
 }: PixiGameCanvasProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const appRef = useRef<Application | null>(null);
+  const unregisterVisibilityRef = useRef<(() => void) | null>(null);
   const [scene, setScene] = useState<PixiGameScene | null>(null);
   const sceneRef = useRef<PixiGameScene | null>(null);
   const callbacksRef = useRef(callbacks);
@@ -171,6 +174,9 @@ export function PixiGameCanvas({
       return;
     }
 
+    app.ticker.maxFPS = PIXI_MAX_FPS;
+    unregisterVisibilityRef.current = registerPixiApp(app);
+
     const newScene = new PixiGameScene(
       app,
       {
@@ -223,6 +229,8 @@ export function PixiGameCanvas({
       if (!active) {
         sceneRef.current?.destroy();
         sceneRef.current = null;
+        unregisterVisibilityRef.current?.();
+        unregisterVisibilityRef.current = null;
         destroyPixiApp(appRef.current);
         appRef.current = null;
         setScene(null);
@@ -233,6 +241,8 @@ export function PixiGameCanvas({
       cancelHandHoverClear();
       sceneRef.current?.destroy();
       sceneRef.current = null;
+      unregisterVisibilityRef.current?.();
+      unregisterVisibilityRef.current = null;
       destroyPixiApp(appRef.current);
       appRef.current = null;
       setScene(null);

--- a/src/pixi/PixiGameScene.ts
+++ b/src/pixi/PixiGameScene.ts
@@ -2501,7 +2501,9 @@ export class PixiGameScene {
   private resolveAndDrawArrows(): void {
     const hasAny = this.arrowSpecs.length > 0 || this.castingArrow !== null;
     if (!hasAny) {
-      if (this.arrowLayer) this.arrowLayer.update([], this.app.ticker.deltaMS);
+      if (this.arrowLayer && !this.arrowLayer.isClear) {
+        this.arrowLayer.update([], this.app.ticker.deltaMS);
+      }
       return;
     }
     // Cache the canvas rect once so each DOM query doesn't re-trigger layout.

--- a/src/pixi/PixiPhaseStripCanvas.tsx
+++ b/src/pixi/PixiPhaseStripCanvas.tsx
@@ -6,6 +6,8 @@
 import { useRef, useEffect, useEffectEvent, useCallback, useState } from "react";
 import { Application } from "pixi.js";
 import { destroyPixiApp, installPixiPatches } from "./pixiPatches";
+import { PIXI_MAX_FPS } from "./constants";
+import { registerPixiApp } from "./visibility";
 installPixiPatches();
 import { PhaseStripLayer, type PhaseStripState, type PhaseStripCallbacks } from "./PhaseStripLayer";
 import { getTheme } from "@/hooks/useTheme";
@@ -21,6 +23,7 @@ export function PixiPhaseStripCanvas({ state, callbacks, className }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const appRef = useRef<Application | null>(null);
   const stripRef = useRef<PhaseStripLayer | null>(null);
+  const unregisterVisibilityRef = useRef<(() => void) | null>(null);
 
   const [ready, setReady] = useState(false);
 
@@ -53,6 +56,9 @@ export function PixiPhaseStripCanvas({ state, callbacks, className }: Props) {
       appRef.current = null;
       return false;
     }
+
+    app.ticker.maxFPS = PIXI_MAX_FPS;
+    unregisterVisibilityRef.current = registerPixiApp(app);
 
     const theme = getTheme();
     const strip = new PhaseStripLayer(theme);
@@ -87,6 +93,8 @@ export function PixiPhaseStripCanvas({ state, callbacks, className }: Props) {
       active = false;
       stripRef.current?.destroy();
       stripRef.current = null;
+      unregisterVisibilityRef.current?.();
+      unregisterVisibilityRef.current = null;
       destroyPixiApp(appRef.current);
       appRef.current = null;
       markReady(false);

--- a/src/pixi/PointerLayer.ts
+++ b/src/pixi/PointerLayer.ts
@@ -221,6 +221,7 @@ export class PointerLayer {
   private textures: Partial<Record<TargetingIntent, Texture>> = {};
   private elapsedMs = 0;
   private ready = false;
+  private clear = true;
 
   constructor() {
     this.root = new Container();
@@ -266,6 +267,7 @@ export class PointerLayer {
 
   /** Replace the live pointer set and tick the animation. */
   update(pointers: ResolvedPointer[], deltaMs: number): void {
+    if (pointers.length === 0 && this.clear) return;
     this.elapsedMs += deltaMs;
     this.ensurePool(pointers.length);
 
@@ -282,6 +284,11 @@ export class PointerLayer {
         entry.sourceGlow.visible = false;
       }
     }
+    this.clear = pointers.length === 0;
+  }
+
+  get isClear(): boolean {
+    return this.clear;
   }
 
   private ensurePool(count: number): void {

--- a/src/pixi/constants.ts
+++ b/src/pixi/constants.ts
@@ -58,6 +58,7 @@ export const STACK_SEED_TTL_MS = 1000;
 export const HAND_ACTIONS_GAP_PX = 15;
 // How often we flush FPS samples to the dev store.
 export const FPS_SAMPLE_INTERVAL_MS = 500;
+export const PIXI_MAX_FPS = 60;
 
 // ── Animation ──────────────────────────────────────────────────────────────
 export const BATTLEFIELD_LERP = 0.15;

--- a/src/pixi/visibility.ts
+++ b/src/pixi/visibility.ts
@@ -1,0 +1,38 @@
+import type { Application } from "pixi.js";
+
+const apps = new Set<Application>();
+let installed = false;
+let paused = false;
+
+function shouldPause(): boolean {
+  return document.hidden || !document.hasFocus();
+}
+
+function sync(): void {
+  const next = shouldPause();
+  if (next === paused) return;
+  paused = next;
+  for (const app of apps) {
+    if (!app.ticker) continue;
+    if (paused) app.ticker.stop();
+    else app.ticker.start();
+  }
+}
+
+function install(): void {
+  if (installed) return;
+  installed = true;
+  document.addEventListener("visibilitychange", sync);
+  window.addEventListener("blur", sync);
+  window.addEventListener("focus", sync);
+  paused = shouldPause();
+}
+
+export function registerPixiApp(app: Application): () => void {
+  install();
+  apps.add(app);
+  if (paused && app.ticker) app.ticker.stop();
+  return () => {
+    apps.delete(app);
+  };
+}


### PR DESCRIPTION
## Why
- leaving the play area whilst arrows are being rendered in battle will make your PC catch fire

## Solution
- Cap the god damn FPS
- Don't spam rendering if unfocused
- Don't render giga expensive animation for the arrows

## Build artifacts
<!--
  Check the boxes below to build the corresponding installer on merge to main
  (uploaded to the Actions run, 30-day retention).
  Leave unchecked to skip — faster CI, no binaries produced.
  Tag pushes (v*) always build both and publish a GitHub Release regardless.
-->
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
