### PR TITLE
fix(deploy): init forge submodule in preview-deploy

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -62,11 +62,6 @@ jobs:
           git fetch origin "pull/${PR_NUMBER}/head" --force
           git checkout --detach --force ${PR_SHA}
 
-          # Forge is a git submodule; checkout only moves the gitlink. The
-          # web/server Dockerfiles COPY from forge/forge-gui/res/{cardsfolder,
-          # tokenscripts}, so without an explicit submodule update the build
-          # fails with "/forge/forge-gui/res/cardsfolder: not found". Mirrors
-          # the same step deploy.sh runs on prod.
           git submodule sync --recursive
           git submodule update --init --recursive --depth 1
 

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -62,6 +62,14 @@ jobs:
           git fetch origin "pull/${PR_NUMBER}/head" --force
           git checkout --detach --force ${PR_SHA}
 
+          # Forge is a git submodule; checkout only moves the gitlink. The
+          # web/server Dockerfiles COPY from forge/forge-gui/res/{cardsfolder,
+          # tokenscripts}, so without an explicit submodule update the build
+          # fails with "/forge/forge-gui/res/cardsfolder: not found". Mirrors
+          # the same step deploy.sh runs on prod.
+          git submodule sync --recursive
+          git submodule update --init --recursive --depth 1
+
           docker compose -p manabrew-staging -f compose.staging.yml up -d --build --remove-orphans
           # Record which PR owns the single slot so another PR's teardown
           # doesn't kill this preview.


### PR DESCRIPTION
## Summary
- Add `git submodule sync --recursive` + `git submodule update --init --recursive --depth 1` after the PR checkout in `.github/workflows/preview-deploy.yml`.

## Why
Every PR preview deploy after #52 has been failing the Docker build at:
```
#42 [manabrew-staging builder 16/18] COPY forge/forge-gui/res/tokenscripts/ ...
ERROR: ... "/forge/forge-gui/res/tokenscripts": not found
#43 [manabrew-staging builder 15/18] COPY forge/forge-gui/res/cardsfolder/ ...
ERROR: ... "/forge/forge-gui/res/cardsfolder": not found
```

`forge/` is a git submodule (`.gitmodules` → `witchesofthehill/forge.git#manabrew`). A plain `git fetch` + `git checkout` only moves the gitlink — it doesn't populate the submodule working tree. `Dockerfile.web` and the forge-server `Dockerfile` both `COPY forge/forge-gui/res/...`, so the build aborts before any layer runs.

#56 already added the same submodule init to `deploy.sh` for prod. The preview workflow has its own checkout script and was never updated, so the two scripts diverged. This patch brings them in line.

## Test plan
- [ ] Once merged to main, the next PR labelled `deploy-preview` should reach the `caddy` / `forge-server` build stages instead of erroring on the COPY layer.
- [ ] Verify staging.manabrew.app still comes up after a deploy.

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main