### PR TITLE
fix(relay): diagnose + harden relay reliability on hetzner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,11 +2249,13 @@ dependencies = [
 name = "forge-server"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "dashmap 6.1.0",
  "forge-agent-interface",
  "futures-util",
  "serde",
  "serde_json",
+ "socket2 0.5.10",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -3144,7 +3146,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5220,7 +5222,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5257,7 +5259,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6356,6 +6358,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -6964,7 +6976,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.0.6+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -7177,7 +7189,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]

--- a/compose.production.yml
+++ b/compose.production.yml
@@ -32,12 +32,23 @@ services:
     environment:
       FORGE_HOST: "0.0.0.0"
       FORGE_PORT: "9443"
+      FORGE_HEALTH_PORT: "9444"
       FORGE_MAX_ROOMS: "100"
       FORGE_SERVER_KEY: "${FORGE_SERVER_KEY:?FORGE_SERVER_KEY is required}"
       RUST_LOG: "forge_server=info"
     expose:
       - "9443"
+      - "9444"
     restart: unless-stopped
+    mem_limit: 1g
+    cpus: 1.5
+    stop_grace_period: 30s
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:9444/health"]
+      interval: 15s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
 
   # Headless engine node hosting a room for web "Play vs AI". Opt-in: the
   # default deploy doesn't build/run it (Play-vs-AI works client-side). Start

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -32,12 +32,21 @@ services:
     environment:
       FORGE_HOST: "0.0.0.0"
       FORGE_PORT: "9443"
+      FORGE_HEALTH_PORT: "9444"
       FORGE_MAX_ROOMS: "100"
       FORGE_SERVER_KEY: "${FORGE_SERVER_KEY:?FORGE_SERVER_KEY is required}"
       RUST_LOG: "forge_server=info"
     expose:
       - "9443"
+      - "9444"
     restart: unless-stopped
+    stop_grace_period: 30s
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:9444/health"]
+      interval: 15s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
 
   # Hosted Java engine for the staging preview, so the Settings engine toggle
   # has a node to talk to. Its room is `hosted` (unlisted in the lobby).

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -245,3 +245,54 @@ docker compose -f forge-engine/crates/forge-server/compose.yml build --no-cache 
 # Check parity database
 docker compose -f forge-engine/crates/forge-server/compose.yml exec parity-dashboard sqlite3 /app/data/parity.db ".tables"
 ```
+
+## Investigating relay disconnects
+
+`forge-server` exposes a healthcheck on port 9444 (`/health`), and every
+disconnect emits a single tagged log line of the form
+`[disconnect] user='…' id=… reason=<…> connected_for_s=… room=…`. The reason
+attributes the drop to one of: `idle_timeout`, `read_error`, `stream_closed`,
+`client_close`, `writer_stopped`, `writer_failed`. Combined with the browser
+`[relay-disconnect]` console log on the client side, this is what we use to
+attribute "relay disconnected" reports to a specific cause.
+
+### Quick status
+
+```bash
+# Container health (look for "healthy"; "unhealthy" means /health failed
+# 3× in a row → Docker will restart it under restart: unless-stopped).
+docker compose -f compose.production.yml ps
+
+# Live resource usage. Sustained RSS near the 1g mem_limit, or CPU pinned
+# at 150%, indicates we're hitting the limits we set.
+docker stats --no-stream
+```
+
+### OOM kills
+
+```bash
+# Anything from oom_reaper or the kernel? Hetzner VMs surface OOM in dmesg
+# even when Docker's "OOMKilled: true" is missed.
+journalctl -u docker -k --since "1h ago" | grep -iE 'oom|killed process'
+```
+
+### Disconnect reason tally
+
+```bash
+# Histogram of disconnect reasons over the last hour. If `idle_timeout`
+# dominates we're losing connections in the network path (Hetzner NAT,
+# Caddy, kernel). If `client_close` dominates it's clean exits — not a
+# reliability problem.
+docker compose -f compose.production.yml logs --since 1h forge-server \
+  | grep '\[disconnect\]' \
+  | sed -n 's/.*reason=\([a-z_]*\).*/\1/p' \
+  | sort | uniq -c | sort -rn
+```
+
+### Health probe from outside
+
+```bash
+# Direct probe against the container's health port (only reachable from
+# inside the docker network):
+docker compose -f compose.production.yml exec forge-server curl -fsS http://localhost:9444/health
+```

--- a/forge-engine/crates/forge-agent-interface/src/protocol.rs
+++ b/forge-engine/crates/forge-agent-interface/src/protocol.rs
@@ -198,6 +198,10 @@ pub enum ServerMessage {
         code: String,
         message: String,
     },
+
+    ServerShuttingDown {
+        reconnect_in_s: u32,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/forge-engine/crates/forge-server/Cargo.toml
+++ b/forge-engine/crates/forge-server/Cargo.toml
@@ -18,3 +18,5 @@ uuid = { version = "1", features = ["v4"] }
 dashmap = "6"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+socket2 = "0.5"
+axum = "0.7"

--- a/forge-engine/crates/forge-server/Dockerfile
+++ b/forge-engine/crates/forge-server/Dockerfile
@@ -28,14 +28,19 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 FROM debian:bookworm-slim
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/local/bin/forge-server /usr/local/bin/forge-server
 
 ENV FORGE_HOST=0.0.0.0
 ENV FORGE_PORT=9443
+ENV FORGE_HEALTH_PORT=9444
 
 EXPOSE 9443
+EXPOSE 9444
+
+HEALTHCHECK --interval=15s --timeout=3s --start-period=5s --retries=3 \
+  CMD curl -fsS http://localhost:9444/health || exit 1
 
 ENTRYPOINT ["forge-server"]

--- a/forge-engine/crates/forge-server/src/config.rs
+++ b/forge-engine/crates/forge-server/src/config.rs
@@ -1,6 +1,7 @@
 pub struct ServerConfig {
     pub host: String,
     pub port: u16,
+    pub health_port: u16,
     pub max_rooms: usize,
     pub server_key: String,
 }
@@ -13,6 +14,10 @@ impl ServerConfig {
                 .ok()
                 .and_then(|p| p.parse().ok())
                 .unwrap_or(9443),
+            health_port: std::env::var("FORGE_HEALTH_PORT")
+                .ok()
+                .and_then(|p| p.parse().ok())
+                .unwrap_or(9444),
             max_rooms: std::env::var("FORGE_MAX_ROOMS")
                 .ok()
                 .and_then(|r| r.parse().ok())

--- a/forge-engine/crates/forge-server/src/connection.rs
+++ b/forge-engine/crates/forge-server/src/connection.rs
@@ -174,6 +174,8 @@ pub async fn handle_connection(
     });
 
     let mut write_task_done = false;
+    let connected_at = Instant::now();
+    let disconnect_reason: &str;
 
     loop {
         let read = tokio::time::timeout(READ_IDLE_TIMEOUT, receiver.next());
@@ -182,18 +184,15 @@ pub async fn handle_connection(
                 Ok(Some(Ok(f))) => f,
                 Ok(Some(Err(e))) => {
                     warn!("[recv] read error from '{}': {}", username, e);
+                    disconnect_reason = "read_error";
                     break;
                 }
                 Ok(None) => {
-                    info!("[recv] '{}' stream closed", username);
+                    disconnect_reason = "stream_closed";
                     break;
                 }
                 Err(_) => {
-                    warn!(
-                        "[recv] idle timeout from '{}' (no frames for {}s)",
-                        username,
-                        READ_IDLE_TIMEOUT.as_secs()
-                    );
+                    disconnect_reason = "idle_timeout";
                     break;
                 }
             },
@@ -201,10 +200,11 @@ pub async fn handle_connection(
                 write_task_done = true;
                 match result {
                     Ok(()) => {
-                        warn!("[send] writer stopped for '{}'", username);
+                        disconnect_reason = "writer_stopped";
                     }
                     Err(e) => {
                         warn!("[send] writer task failed for '{}': {}", username, e);
+                        disconnect_reason = "writer_failed";
                     }
                 }
                 break;
@@ -235,7 +235,7 @@ pub async fn handle_connection(
                 handle_client_message(&state, &player_id, &username, &tx, client_msg);
             }
             Message::Close(_) => {
-                info!("[recv] '{}' sent close frame", username);
+                disconnect_reason = "client_close";
                 break;
             }
             Message::Ping(data) => {
@@ -249,7 +249,19 @@ pub async fn handle_connection(
         }
     }
 
-    info!("[disconnect] '{}' (id={})", username, &player_id[..8]);
+    let connected_for_s = connected_at.elapsed().as_secs();
+    let room_id_for_log = state
+        .players
+        .get(&player_id)
+        .and_then(|p| p.room_id.clone());
+    info!(
+        "[disconnect] user='{}' id={} reason={} connected_for_s={} room={:?}",
+        username,
+        &player_id[..8],
+        disconnect_reason,
+        connected_for_s,
+        room_id_for_log,
+    );
     mark_disconnected(&state, &player_id, generation);
 
     // Tear down background tasks after we have marked the player disconnected.
@@ -855,6 +867,7 @@ fn msg_type_of(msg: &ServerMessage) -> &'static str {
         ServerMessage::StateUpdate { .. } => "StateUpdate",
         ServerMessage::TurnChanged { .. } => "TurnChanged",
         ServerMessage::Error { .. } => "Error",
+        ServerMessage::ServerShuttingDown { .. } => "ServerShuttingDown",
     }
 }
 

--- a/forge-engine/crates/forge-server/src/main.rs
+++ b/forge-engine/crates/forge-server/src/main.rs
@@ -24,11 +24,14 @@ async fn main() {
     let addr: SocketAddr = format!("{}:{}", config.host, config.port)
         .parse()
         .expect("Invalid address");
+    let health_addr: SocketAddr = format!("{}:{}", config.host, config.health_port)
+        .parse()
+        .expect("Invalid health address");
 
     let state = Arc::new(state::ServerState::new(
         config.server_key.clone(),
         config.max_rooms,
     ));
 
-    server::run_server(state, addr).await;
+    server::run_server(state, addr, health_addr).await;
 }

--- a/forge-engine/crates/forge-server/src/server.rs
+++ b/forge-engine/crates/forge-server/src/server.rs
@@ -1,14 +1,24 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
+use axum::{response::Json, routing::get, Router};
+use serde_json::{json, Value};
+use socket2::{SockRef, TcpKeepalive};
 use tokio::net::TcpListener;
-use tracing::{debug, error, info};
+use tokio::sync::Notify;
+use tokio_tungstenite::tungstenite::Message;
+use tracing::{debug, error, info, warn};
 
 use crate::cleanup::cleanup_loop;
 use crate::connection::handle_connection;
+use crate::protocol::ServerMessage;
 use crate::state::ServerState;
 
-pub async fn run_server(state: Arc<ServerState>, addr: SocketAddr) {
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(10);
+const SHUTDOWN_RECONNECT_HINT_S: u32 = 5;
+
+pub async fn run_server(state: Arc<ServerState>, addr: SocketAddr, health_addr: SocketAddr) {
     let listener = TcpListener::bind(addr)
         .await
         .expect("Failed to bind to address");
@@ -17,24 +27,163 @@ pub async fn run_server(state: Arc<ServerState>, addr: SocketAddr) {
     info!("[server] Server key: {}", mask_key(&state.server_key));
     info!("[server] Max rooms: {}", state.max_rooms);
 
-    tokio::spawn(cleanup_loop(state.clone()));
+    let shutdown = Arc::new(Notify::new());
 
+    tokio::spawn(cleanup_loop(state.clone()));
+    tokio::spawn(run_health_listener(state.clone(), health_addr));
+    tokio::spawn(wait_for_shutdown_signal(shutdown.clone()));
+
+    let accept = accept_loop(state.clone(), listener, shutdown.clone());
+
+    tokio::select! {
+        _ = accept => {}
+        _ = shutdown.notified() => {
+            info!("[server] shutdown signal received — draining");
+        }
+    }
+
+    drain_and_exit(state).await;
+}
+
+async fn accept_loop(state: Arc<ServerState>, listener: TcpListener, shutdown: Arc<Notify>) {
     loop {
-        match listener.accept().await {
-            Ok((stream, peer_addr)) => {
-                debug!("[server] accepted connection from {}", peer_addr);
-                let state = state.clone();
-                tokio::spawn(async move {
-                    if let Err(e) = handle_connection(stream, peer_addr, state).await {
-                        error!("[server] connection error from {}: {}", peer_addr, e);
-                    }
-                });
-            }
-            Err(e) => {
-                error!("[server] accept error: {}", e);
+        tokio::select! {
+            res = listener.accept() => match res {
+                Ok((stream, peer_addr)) => {
+                    debug!("[server] accepted connection from {}", peer_addr);
+                    apply_tcp_keepalive(&stream, peer_addr);
+                    let state = state.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_connection(stream, peer_addr, state).await {
+                            error!("[server] connection error from {}: {}", peer_addr, e);
+                        }
+                    });
+                }
+                Err(e) => {
+                    error!("[server] accept error: {}", e);
+                }
+            },
+            _ = shutdown.notified() => {
+                info!("[server] accept loop stopping");
+                return;
             }
         }
     }
+}
+
+fn apply_tcp_keepalive(stream: &tokio::net::TcpStream, peer_addr: SocketAddr) {
+    let keepalive = TcpKeepalive::new()
+        .with_time(Duration::from_secs(30))
+        .with_interval(Duration::from_secs(10));
+    if let Err(e) = SockRef::from(stream).set_tcp_keepalive(&keepalive) {
+        warn!(
+            "[server] failed to enable TCP keepalive on {}: {}",
+            peer_addr, e
+        );
+    }
+}
+
+async fn wait_for_shutdown_signal(shutdown: Arc<Notify>) {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut term = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("[server] failed to install SIGTERM handler: {}", e);
+                return;
+            }
+        };
+        let mut int = match signal(SignalKind::interrupt()) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("[server] failed to install SIGINT handler: {}", e);
+                return;
+            }
+        };
+        tokio::select! {
+            _ = term.recv() => info!("[server] SIGTERM received"),
+            _ = int.recv()  => info!("[server] SIGINT received"),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        if let Err(e) = tokio::signal::ctrl_c().await {
+            warn!("[server] ctrl_c handler error: {}", e);
+            return;
+        }
+        info!("[server] ctrl_c received");
+    }
+    shutdown.notify_waiters();
+}
+
+async fn drain_and_exit(state: Arc<ServerState>) {
+    let msg = ServerMessage::ServerShuttingDown {
+        reconnect_in_s: SHUTDOWN_RECONNECT_HINT_S,
+    };
+    let json = match serde_json::to_string(&msg) {
+        Ok(s) => s,
+        Err(e) => {
+            error!("[server] failed to serialize shutdown message: {}", e);
+            return;
+        }
+    };
+
+    let mut notified = 0usize;
+    for entry in state.players.iter() {
+        let player = entry.value();
+        if !player.connected {
+            continue;
+        }
+        if player.sender.send(Message::Text(json.clone())).is_ok() {
+            notified += 1;
+        }
+    }
+    info!(
+        "[server] broadcast ServerShuttingDown to {} players",
+        notified
+    );
+
+    tokio::time::sleep(SHUTDOWN_GRACE).await;
+    info!("[server] shutdown grace elapsed — exiting");
+}
+
+async fn run_health_listener(state: Arc<ServerState>, addr: SocketAddr) {
+    let app = Router::new()
+        .route("/health", get(health_handler))
+        .with_state(state);
+
+    let listener = match TcpListener::bind(addr).await {
+        Ok(l) => l,
+        Err(e) => {
+            error!("[server] failed to bind health listener on {}: {}", addr, e);
+            return;
+        }
+    };
+    info!("[server] health endpoint on http://{}/health", addr);
+
+    if let Err(e) = axum::serve(listener, app).await {
+        error!("[server] health listener stopped: {}", e);
+    }
+}
+
+async fn health_handler(
+    axum::extract::State(state): axum::extract::State<Arc<ServerState>>,
+) -> Json<Value> {
+    let connected_players = state.players.iter().filter(|e| e.value().connected).count();
+    Json(json!({
+        "status": "ok",
+        "rooms": state.rooms.len(),
+        "connected_players": connected_players,
+        "uptime_s": uptime_secs(),
+    }))
+}
+
+fn uptime_secs() -> u64 {
+    use std::sync::OnceLock;
+    use std::time::Instant;
+    static START: OnceLock<Instant> = OnceLock::new();
+    START.get_or_init(Instant::now).elapsed().as_secs()
 }
 
 fn mask_key(key: &str) -> String {

--- a/ops/Caddyfile
+++ b/ops/Caddyfile
@@ -81,7 +81,12 @@ manabrew.app {
 }
 
 relay.manabrew.app {
-    reverse_proxy forge-server:9443
+    reverse_proxy forge-server:9443 {
+        health_uri /health
+        health_port 9444
+        health_interval 15s
+        health_timeout 3s
+    }
 }
 
 # Per-PR preview slot (compose.staging.yml). 502 when none is deployed.
@@ -90,5 +95,10 @@ staging.manabrew.app {
 }
 
 relay-staging.manabrew.app {
-    reverse_proxy forge-server-staging:9443
+    reverse_proxy forge-server-staging:9443 {
+        health_uri /health
+        health_port 9444
+        health_interval 15s
+        health_timeout 3s
+    }
 }

--- a/src/components/game/GameBoard.tsx
+++ b/src/components/game/GameBoard.tsx
@@ -17,6 +17,7 @@ import { computeBaseLayout, SIZE_PARAMS } from "@/pixi/HandLayout";
 import type { HandActionOption } from "@/stores/useGameUIStore";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { cn } from "@/lib/utils";
+import { ReconnectBanner } from "@/components/lobby/ReconnectBanner";
 
 // Footprint of the bottom-right action cluster (PASS, Pass-Until-End,
 // phase buttons). Matches MainActionOverlay's `w-[300px]` + its visible
@@ -404,6 +405,10 @@ export function GameBoard({
       ref={boardRef}
       className="game-board-surface relative flex flex-col min-h-0 flex-1 overflow-visible"
     >
+      <div className="absolute top-2 left-1/2 -translate-x-1/2 z-50 pointer-events-none">
+        <ReconnectBanner className="shadow-sm bg-background/95" />
+      </div>
+
       {/* ── Split: opponent (top) / phase strip / me (bottom) ─── */}
 
       {/* Opponent half */}

--- a/src/components/lobby/ReconnectBanner.tsx
+++ b/src/components/lobby/ReconnectBanner.tsx
@@ -1,0 +1,31 @@
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useServerStore } from "@/stores/useServerStore";
+
+interface ReconnectBannerProps {
+  className?: string;
+}
+
+export function ReconnectBanner({ className }: ReconnectBannerProps) {
+  const reconnect = useServerStore((s) => s.reconnect);
+
+  if (reconnect.phase === "idle") return null;
+
+  const message =
+    reconnect.reason === "server-shutdown"
+      ? "Server updating, reconnecting…"
+      : `Reconnecting… (attempt ${reconnect.attempt})`;
+
+  return (
+    <div
+      role="status"
+      className={cn(
+        "flex items-center gap-2 px-3 py-1.5 rounded-md border bg-warning/10 text-warning border-warning/30 text-xs",
+        className,
+      )}
+    >
+      <Loader2 className="h-3 w-3 animate-spin" />
+      <span>{message}</span>
+    </div>
+  );
+}

--- a/src/platform/web.ts
+++ b/src/platform/web.ts
@@ -540,6 +540,8 @@ interface BotEntry {
   };
 }
 
+const RECONNECT_BACKOFF_MS = [1000, 2000, 4000, 8000, 16000, 30000];
+
 class WebServerApi implements IServerApi {
   private ws: WebSocket | null = null;
   private eventBus: WebEventBus;
@@ -548,6 +550,12 @@ class WebServerApi implements IServerApi {
   private bots = new Map<string, BotEntry>();
   private wasmReady: Promise<typeof import("@/wasm/forge_wasm")> | null = null;
   private keepaliveTimer: ReturnType<typeof setInterval> | null = null;
+  private connectParams: ServerConnectParams | null = null;
+  private connectedAt: number | null = null;
+  private manualDisconnect = false;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempt = 0;
+  private serverShutdownPending: { reconnectInS: number } | null = null;
 
   constructor(eventBus: WebEventBus) {
     this.eventBus = eventBus;
@@ -571,6 +579,13 @@ class WebServerApi implements IServerApi {
 
   async connect(params: ServerConnectParams): Promise<void> {
     await this.disconnect();
+    this.manualDisconnect = false;
+    this.connectParams = params;
+    this.reconnectAttempt = 0;
+    return this.openSocket(params);
+  }
+
+  private openSocket(params: ServerConnectParams): Promise<void> {
     const url = buildServerUrl(params);
     this.relayUrl = url;
     this.serverPassword = params.password;
@@ -579,7 +594,7 @@ class WebServerApi implements IServerApi {
       this.ws = new WebSocket(url);
 
       this.ws.onopen = () => {
-        // Send authentication immediately
+        this.connectedAt = Date.now();
         this.send({
           type: "Authenticate",
           username: params.username,
@@ -593,9 +608,8 @@ class WebServerApi implements IServerApi {
         reject(new Error(`Failed to connect to ${url}`));
       };
 
-      this.ws.onclose = () => {
-        this.eventBus.emit("server:disconnected", {});
-        this.ws = null;
+      this.ws.onclose = (event) => {
+        this.handleSocketClose(event);
       };
 
       this.ws.onmessage = (e: MessageEvent) => {
@@ -608,6 +622,86 @@ class WebServerApi implements IServerApi {
         }
       };
     });
+  }
+
+  private handleSocketClose(event: CloseEvent): void {
+    const connectedForS =
+      this.connectedAt !== null ? Math.round((Date.now() - this.connectedAt) / 1000) : null;
+    const shutdownPending = this.serverShutdownPending;
+    console.warn("[relay-disconnect]", {
+      code: event.code,
+      reason: event.reason,
+      wasClean: event.wasClean,
+      connected_for_s: connectedForS,
+      visibility: typeof document !== "undefined" ? document.visibilityState : "unknown",
+      hadServerShutdown: shutdownPending !== null,
+    });
+
+    this.stopKeepalive();
+    this.ws = null;
+    this.connectedAt = null;
+
+    if (this.manualDisconnect) {
+      this.eventBus.emit("server:disconnected", { terminal: true });
+      return;
+    }
+
+    if (this.connectParams === null) {
+      this.eventBus.emit("server:disconnected", { terminal: true });
+      return;
+    }
+
+    if (shutdownPending !== null) {
+      this.serverShutdownPending = null;
+      this.scheduleReconnect("server-shutdown", shutdownPending.reconnectInS * 1000);
+      return;
+    }
+
+    this.scheduleReconnect("network", this.nextBackoffMs());
+  }
+
+  private nextBackoffMs(): number {
+    const idx = Math.min(this.reconnectAttempt, RECONNECT_BACKOFF_MS.length - 1);
+    const base = RECONNECT_BACKOFF_MS[idx]!;
+    const jitter = base * (Math.random() * 0.4 - 0.2);
+    return Math.max(250, Math.round(base + jitter));
+  }
+
+  private scheduleReconnect(reason: "network" | "server-shutdown", delayMs: number): void {
+    this.clearReconnectTimer();
+    this.reconnectAttempt += 1;
+    this.eventBus.emit("server:reconnecting", {
+      phase: "reconnecting" as const,
+      attempt: this.reconnectAttempt,
+      delayMs,
+      reason,
+    });
+    this.reconnectTimer = setTimeout(() => {
+      void this.tryReconnect();
+    }, delayMs);
+  }
+
+  private async tryReconnect(): Promise<void> {
+    this.reconnectTimer = null;
+    const params = this.connectParams;
+    if (params === null || this.manualDisconnect) {
+      return;
+    }
+    try {
+      await this.openSocket(params);
+      this.reconnectAttempt = 0;
+      this.eventBus.emit("server:reconnecting", { phase: "idle" as const, attempt: 0 });
+    } catch (e) {
+      console.warn("[relay-disconnect] reconnect attempt failed", e);
+      this.scheduleReconnect("network", this.nextBackoffMs());
+    }
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
   }
 
   private startKeepalive(): void {
@@ -625,6 +719,11 @@ class WebServerApi implements IServerApi {
   }
 
   async disconnect(): Promise<void> {
+    this.manualDisconnect = true;
+    this.clearReconnectTimer();
+    this.serverShutdownPending = null;
+    this.reconnectAttempt = 0;
+    this.connectParams = null;
     this.stopKeepalive();
     for (const username of [...this.bots.keys()]) {
       await this.removeAiBot(username);
@@ -633,6 +732,7 @@ class WebServerApi implements IServerApi {
     this.ws = null;
     this.relayUrl = null;
     this.serverPassword = null;
+    this.connectedAt = null;
     if (!ws || ws.readyState === WebSocket.CLOSED) return;
     // Wait for the actual close event before resolving. Resolving on
     // ws.close() alone races against the server still cleaning up the
@@ -774,6 +874,18 @@ class WebServerApi implements IServerApi {
 
   private handleServerMessage(msg: Record<string, unknown>): void {
     const type = msg.type as string;
+
+    if (type === "ServerShuttingDown") {
+      const reconnectInS = typeof msg.reconnect_in_s === "number" ? msg.reconnect_in_s : 5;
+      this.serverShutdownPending = { reconnectInS };
+      this.eventBus.emit("server:reconnecting", {
+        phase: "reconnecting" as const,
+        attempt: this.reconnectAttempt + 1,
+        delayMs: reconnectInS * 1000,
+        reason: "server-shutdown" as const,
+      });
+      return;
+    }
 
     if (type === "StateUpdate" && msg.state) {
       const envelope = msg.state as StateEnvelope;

--- a/src/stores/useServerStore.ts
+++ b/src/stores/useServerStore.ts
@@ -17,10 +17,18 @@ import type {
   ReadyChangedPayload,
   GameStartedPayload,
   ServerErrorPayload,
+  ReconnectingPayload,
+  DisconnectedPayload,
 } from "@/types/server";
 import type { Deck } from "@/types/manabrew";
 
 export const DEFAULT_STARTING_LIFE = 20;
+
+export interface ReconnectState {
+  phase: "idle" | "reconnecting" | "failed";
+  attempt: number;
+  reason?: "network" | "server-shutdown";
+}
 
 interface ServerState {
   connected: boolean;
@@ -28,6 +36,7 @@ interface ServerState {
   error: string | null;
   playerId: string | null;
   username: string | null;
+  reconnect: ReconnectState;
 
   rooms: RoomInfo[];
   currentRoom: RoomInfo | null;
@@ -60,6 +69,7 @@ export const useServerStore = create<ServerState>()(
       error: null,
       playerId: null,
       username: null,
+      reconnect: { phase: "idle", attempt: 0 },
       rooms: [],
       currentRoom: null,
       players: [],
@@ -184,12 +194,31 @@ export const useServerStore = create<ServerState>()(
         unsubscribers.push(
           platform.events.on<AuthResultPayload>("server:auth_result", (payload) => {
             if (payload.success) {
-              set({ connected: true, connecting: false, error: null, playerId: payload.player_id });
+              set({
+                connected: true,
+                connecting: false,
+                error: null,
+                playerId: payload.player_id,
+                reconnect: { phase: "idle", attempt: 0 },
+              });
               get().listRooms();
               get().listPlayers();
             } else {
               set({ connecting: false, error: payload.error ?? "Authentication failed" });
             }
+          }),
+        );
+
+        unsubscribers.push(
+          platform.events.on<ReconnectingPayload>("server:reconnecting", (payload) => {
+            set({
+              reconnect: {
+                phase: payload.phase,
+                attempt: payload.attempt,
+                reason: payload.reason,
+              },
+              connected: payload.phase === "idle" ? get().connected : false,
+            });
           }),
         );
 
@@ -277,20 +306,23 @@ export const useServerStore = create<ServerState>()(
         );
 
         unsubscribers.push(
-          platform.events.on("server:disconnected", () => {
-            set({
-              connected: false,
-              connecting: false,
-              error: "Disconnected from server",
-              playerId: null,
-              currentRoom: null,
-              gameStarted: false,
-              playerOrder: [],
-              playerDecks: [],
-              startingLife: DEFAULT_STARTING_LIFE,
-              rooms: [],
-              players: [],
-            });
+          platform.events.on<DisconnectedPayload>("server:disconnected", (payload) => {
+            if (payload?.terminal) {
+              set({
+                connected: false,
+                connecting: false,
+                error: "Disconnected from server",
+                playerId: null,
+                currentRoom: null,
+                gameStarted: false,
+                playerOrder: [],
+                playerDecks: [],
+                startingLife: DEFAULT_STARTING_LIFE,
+                rooms: [],
+                players: [],
+                reconnect: { phase: "idle", attempt: 0 },
+              });
+            }
           }),
         );
 

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -159,3 +159,16 @@ export interface ServerErrorPayload {
   code: string;
   message: string;
 }
+
+export type ReconnectPhase = "idle" | "reconnecting" | "failed";
+
+export interface ReconnectingPayload {
+  phase: ReconnectPhase;
+  attempt: number;
+  delayMs?: number;
+  reason?: "network" | "server-shutdown";
+}
+
+export interface DisconnectedPayload {
+  terminal?: boolean;
+}

--- a/src/views/Lobby.tsx
+++ b/src/views/Lobby.tsx
@@ -3,6 +3,7 @@ import { UserList } from "@/components/lobby/UserList";
 import { ChatComponent } from "@/components/lobby/ChatComponent";
 import { CreateRoomDialog } from "@/components/lobby/CreateRoomDialog";
 import { CreateGameDialog } from "@/components/lobby/CreateGameDialog";
+import { ReconnectBanner } from "@/components/lobby/ReconnectBanner";
 import { Button } from "@/components/ui/button";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -319,6 +320,8 @@ export default function Lobby() {
       {/* ── Header ── */}
       <div className="px-4 py-3 border-b shrink-0 flex items-center gap-3">
         <div className="flex-1" />
+
+        <ReconnectBanner />
 
         {/* Connection status */}
         <div


### PR DESCRIPTION
## Summary

- Server `forge-server` now exposes `/health` (port 9444), reacts to SIGTERM/SIGINT with a `ServerShuttingDown` broadcast + 10s drain, enables TCP keepalive on accepted sockets, and emits a unified `[disconnect] reason=<…> connected_for_s=<…>` log so disconnects are attributable.
- Web client gains exponential-backoff auto-reconnect (1/2/4/8/16/30s, ±20% jitter), short-delay reconnect on `ServerShuttingDown`, browser `[relay-disconnect]` console telemetry, and a `ReconnectBanner` shown in the lobby header AND as an in-game overlay — `useServerStore` no longer nukes room/game state on transient disconnects.
- Infra: `mem_limit`, `cpus`, `stop_grace_period`, Docker `HEALTHCHECK`, Caddy `health_uri`/`health_port` probes on both relay vhosts.

## Why

Fixes #67. After moving production to a Hetzner VM, `relay.manabrew.app` disconnects at random and is hard to reconnect to. We had several plausible causes (every-deploy SIGKILL, no client auto-reconnect, Hetzner NAT idle drops, possible OOM, possible internal wedge) and no observability to attribute future incidents. This PR ships:

1. **Diagnostics** so the next incident points at a specific root cause: `/health`, the tagged `[disconnect]` log, browser telemetry, an operator runbook.
2. **Hardening** that's correct regardless of which cause dominates: client auto-reconnect, graceful shutdown, healthcheck-driven container liveness, resource limits, TCP keepalive.

The combination converts the "every push to main hard-cuts every session" baseline into a clean `ServerShuttingDown` → client backoff → re-auth flow (the server already supports session resume via `AuthResult.reconnected` and a 1h in-game grace period in `cleanup.rs`). Plan: `/Users/fede/.claude/plans/can-you-have-a-federated-peacock.md` (local).

## Test plan

Local (verified):
- `cargo build --release -p forge-server` clean.
- `curl http://127.0.0.1:19444/health` → `200` with `{"status":"ok","rooms":0,"connected_players":0,"uptime_s":0}`.
- SIGTERM → server logs `SIGTERM received` → `shutdown signal received — draining` → `broadcast ServerShuttingDown to N players` → exit.
- Node WebSocket client connected, then SIGTERM the server → client receives `{"type":"ServerShuttingDown","reconnect_in_s":5}` BEFORE the socket closes (`wasClean=false`, code 1006).
- Clean client `close(1000)` → server emits `[disconnect] user='closer' id=… reason=client_close connected_for_s=0 room=None`.
- `yarn tsc --noEmit`, eslint + prettier clean on touched files.

Operator cutover (deliberate because staging is currently unreliable; see plan):
- [ ] Merge → deploy → confirm `docker compose ps` reports `forge-server` as `healthy`.
- [ ] `docker logs --since 1h forge-server | grep '\[disconnect\]'` shows tagged reasons.
- [ ] After bundle reload, browser DevTools `[relay-disconnect]` logs appear when a drop happens, and the in-lobby/in-game banner shows "Server updating, reconnecting…" on the next deploy.
- [ ] Observe ~3 days; reason histogram drives any follow-up fix (Stage 3 of the plan).

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main