### PR TITLE
fix(ui): keep tapped same-name cards stacked

### DIFF
--- a/src/pixi/PixiGameScene.ts
+++ b/src/pixi/PixiGameScene.ts
@@ -1059,7 +1059,6 @@ export class PixiGameScene {
     if (topLevel.length < 2) return;
 
     const isStackable = (c: GameCard): boolean =>
-      !c.tapped &&
       !c.isAttacking &&
       !c.attachedTo &&
       !c.isBestowed &&
@@ -1068,15 +1067,16 @@ export class PixiGameScene {
       (!c.attachmentIds || c.attachmentIds.length === 0) &&
       !this.userPlacedCards.has(c.id);
 
-    const byName = new Map<string, GameCard[]>();
+    const byNameAndTap = new Map<string, GameCard[]>();
     for (const c of topLevel) {
       if (!isStackable(c)) continue;
-      const list = byName.get(c.name);
+      const key = `${c.tapped ? "t" : "u"}:${c.name}`;
+      const list = byNameAndTap.get(key);
       if (list) list.push(c);
-      else byName.set(c.name, [c]);
+      else byNameAndTap.set(key, [c]);
     }
 
-    for (const group of byName.values()) {
+    for (const group of byNameAndTap.values()) {
       if (group.length < 2) continue;
       const parent = group[0]!;
       for (let i = 1; i < group.length; i++) {


### PR DESCRIPTION
## Summary
- Battlefield name-grouping now stacks tapped permanents instead of splitting them into separate sprites.
- Groups are keyed by name **and** tap state, so tapped and untapped copies form separate stacks.

## Why
Fixes #60. Tapped same-name cards (e.g. 3 tapped Swamps) were excluded from stacking and rendered individually, while untapped copies stacked. `isStackable` dropped any `tapped` card, and the group key was the card name alone. Now tapped cards are stackable and the key includes tap state, so 2 tapped + 2 untapped Swamps render as two distinct stacks — matching the issue's expectation.

## Test plan
- `yarn lint` (eslint + prettier + tsc) clean on the change; pre-commit lint-staged + commitlint pass.
- `yarn build:wasm` + `yarn typecheck` green.
- Logic: `applyNameGrouping` groups by `${tapped}:${name}`; tapped/untapped never merge; existing exclusions (attacking, attached, bestowed, face-down, transformed, user-placed) unchanged.

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main