### PR TITLE
fix(lobby): let host set room format on enter, not just at game start

### DIFF
--- a/forge-engine/crates/forge-agent-interface/src/protocol.rs
+++ b/forge-engine/crates/forge-agent-interface/src/protocol.rs
@@ -120,6 +120,10 @@ pub enum ClientMessage {
         commander_name: Option<String>,
     },
 
+    SetFormat {
+        format: GameFormat,
+    },
+
     StartGame {
         #[serde(default)]
         format: Option<GameFormat>,

--- a/forge-engine/crates/forge-server/src/connection.rs
+++ b/forge-engine/crates/forge-server/src/connection.rs
@@ -760,6 +760,33 @@ fn handle_client_message(
             }
         }
 
+        ClientMessage::SetFormat { format } => {
+            info!("[lobby] '{}' set format={:?}", username, format);
+            match lobby::set_format_sync(state, player_id, format) {
+                Ok(room_id) => {
+                    if let Some(room) = state.rooms.get(&room_id) {
+                        broadcast_to_room(
+                            state,
+                            &room_id,
+                            &ServerMessage::RoomUpdate {
+                                room: room.to_room_info(),
+                            },
+                        );
+                    }
+                }
+                Err(e) => {
+                    warn!("[lobby] '{}' set format failed: {}", username, e);
+                    send_msg(
+                        sender,
+                        &ServerMessage::Error {
+                            code: e.code().into(),
+                            message: e.to_string(),
+                        },
+                    );
+                }
+            }
+        }
+
         ClientMessage::StartGame { format } => {
             info!("[game] '{}' starting game", username);
             match lobby::start_game_sync(state, player_id, format) {
@@ -918,6 +945,7 @@ fn client_msg_type(msg: &ClientMessage) -> &'static str {
         ClientMessage::LeaveRoom => "LeaveRoom",
         ClientMessage::SetReady { .. } => "SetReady",
         ClientMessage::SetDeckSelection { .. } => "SetDeckSelection",
+        ClientMessage::SetFormat { .. } => "SetFormat",
         ClientMessage::StartGame { .. } => "StartGame",
         ClientMessage::EndGame => "EndGame",
         ClientMessage::BroadcastState { .. } => "BroadcastState",

--- a/forge-engine/crates/forge-server/src/lobby.rs
+++ b/forge-engine/crates/forge-server/src/lobby.rs
@@ -260,6 +260,39 @@ pub struct StartedGame {
     pub room_info: RoomInfo,
 }
 
+pub fn set_format_sync(
+    state: &Arc<ServerState>,
+    player_id: &str,
+    format: GameFormat,
+) -> Result<String, ServerError> {
+    let room_id = {
+        state
+            .players
+            .get(player_id)
+            .and_then(|p| p.room_id.clone())
+            .ok_or(ServerError::NotInRoom)?
+    };
+
+    {
+        let mut room = state
+            .rooms
+            .get_mut(&room_id)
+            .ok_or_else(|| ServerError::RoomNotFound(room_id.clone()))?;
+
+        if !room.is_host(player_id) {
+            return Err(ServerError::NotHost);
+        }
+
+        if room.status != RoomStatus::Lobby {
+            return Err(ServerError::GameAlreadyStarted);
+        }
+
+        room.format = format;
+    }
+
+    Ok(room_id)
+}
+
 pub fn start_game_sync(
     state: &Arc<ServerState>,
     player_id: &str,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -96,6 +96,7 @@ pub fn run() {
             server_commands::server_leave_room,
             server_commands::server_set_ready,
             server_commands::server_set_deck_selection,
+            server_commands::server_set_format,
             server_commands::server_start_game,
             server_commands::server_end_game,
             server_commands::server_broadcast_state,

--- a/src-tauri/src/server_commands.rs
+++ b/src-tauri/src/server_commands.rs
@@ -163,6 +163,20 @@ pub async fn server_set_deck_selection(
 }
 
 #[tauri::command]
+pub async fn server_set_format(
+    client: State<'_, ServerClient>,
+    format: String,
+) -> Result<(), String> {
+    send_server_message(
+        &client,
+        serde_json::json!({
+            "type": "SetFormat",
+            "format": format,
+        }),
+    )
+}
+
+#[tauri::command]
 pub async fn server_start_game(
     client: State<'_, ServerClient>,
     format: Option<String>,

--- a/src/components/lobby/TablesList.tsx
+++ b/src/components/lobby/TablesList.tsx
@@ -2,10 +2,29 @@ import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Hand, Users, Swords, Shield, LogOut, Bot, X } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Hand, Users, Swords, Shield, LogOut, Bot, X, ChevronDown } from "lucide-react";
 import { GameIcon } from "@/components/game/GameIcon";
-import type { RoomInfo } from "@/types/server";
+import type { GameFormat, RoomInfo } from "@/types/server";
 import { cn } from "@/lib/utils";
+
+const HOST_SELECTABLE_FORMATS: GameFormat[] = [
+  "Any",
+  "Standard",
+  "Pioneer",
+  "Modern",
+  "Legacy",
+  "Vintage",
+  "Pauper",
+  "Commander",
+  "Brawl",
+  "Oathbreaker",
+];
 
 interface TablesListProps {
   rooms: RoomInfo[];
@@ -18,6 +37,7 @@ interface TablesListProps {
   onJoinRoom: (roomId: string) => Promise<void>;
   onLeaveRoom: () => void;
   onSetReady: (ready: boolean) => void;
+  onSetFormat?: (format: GameFormat) => void;
   onOpenDeckDialog: () => void;
   onStartGame: () => void;
   onStartTabletop?: () => void;
@@ -38,6 +58,7 @@ export function TablesList({
   onJoinRoom,
   onLeaveRoom,
   onSetReady,
+  onSetFormat,
   onOpenDeckDialog,
   onStartGame,
   onStartTabletop,
@@ -101,15 +122,45 @@ export function TablesList({
                     {currentRoom.sealed_config.set_code}
                   </Badge>
                 )}
-                <Badge variant="outline" className="text-[10px]">
-                  {isOpenFormat && currentRoom.draft_config
-                    ? currentRoom.draft_config.cube_id
-                      ? "Cube"
-                      : "Draft"
-                    : isOpenFormat && currentRoom.sealed_config
-                      ? "Sealed"
-                      : currentRoom.format}
-                </Badge>
+                {isHost &&
+                currentRoom.status === "Lobby" &&
+                onSetFormat &&
+                !currentRoom.draft_config &&
+                !currentRoom.sealed_config ? (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        type="button"
+                        className="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-0.5 text-[10px] font-medium hover:bg-muted/60"
+                      >
+                        {currentRoom.format}
+                        <ChevronDown className="h-2.5 w-2.5" />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      {HOST_SELECTABLE_FORMATS.map((f) => (
+                        <DropdownMenuItem
+                          key={f}
+                          onSelect={() => onSetFormat(f)}
+                          disabled={f === currentRoom.format}
+                          className="text-xs"
+                        >
+                          {f}
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                ) : (
+                  <Badge variant="outline" className="text-[10px]">
+                    {isOpenFormat && currentRoom.draft_config
+                      ? currentRoom.draft_config.cube_id
+                        ? "Cube"
+                        : "Draft"
+                      : isOpenFormat && currentRoom.sealed_config
+                        ? "Sealed"
+                        : currentRoom.format}
+                  </Badge>
+                )}
                 <Badge
                   variant={currentRoom.status === "Lobby" ? "outline" : "secondary"}
                   className="text-[10px]"

--- a/src/platform/tauri.ts
+++ b/src/platform/tauri.ts
@@ -27,6 +27,7 @@ import type {
   SetReadyParams,
   SetDeckSelectionParams,
   StartServerGameParams,
+  SetFormatParams,
   SpawnAiBotParams,
 } from "./types";
 import type { RoomRelayEnvelope } from "@/types/server";
@@ -129,6 +130,10 @@ class TauriServerApi implements IServerApi {
 
   async setDeckSelection(params: SetDeckSelectionParams): Promise<void> {
     return invoke<void>("server_set_deck_selection", { ...params });
+  }
+
+  async setFormat(params: SetFormatParams): Promise<void> {
+    return invoke<void>("server_set_format", { ...params });
   }
 
   async startGame(params?: StartServerGameParams): Promise<void> {

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -84,6 +84,10 @@ export interface StartServerGameParams {
   format?: GameFormat;
 }
 
+export interface SetFormatParams {
+  format: GameFormat;
+}
+
 export type BotAgentKind = "simple";
 
 export interface SpawnAiBotParams extends SetDeckSelectionParams {
@@ -138,6 +142,7 @@ export interface IServerApi {
   leaveRoom(): Promise<void>;
   setReady(params: SetReadyParams): Promise<void>;
   setDeckSelection(params: SetDeckSelectionParams): Promise<void>;
+  setFormat(params: SetFormatParams): Promise<void>;
   startGame(params?: StartServerGameParams): Promise<void>;
   endGame(): Promise<void>;
   broadcastState(state: Record<string, unknown>): Promise<void>;

--- a/src/platform/web.ts
+++ b/src/platform/web.ts
@@ -22,6 +22,7 @@ import type {
   SetReadyParams,
   SetDeckSelectionParams,
   StartServerGameParams,
+  SetFormatParams,
   SpawnAiBotParams,
 } from "./types";
 import { SERVER_ERROR_CODE } from "@/types/server";
@@ -793,6 +794,10 @@ class WebServerApi implements IServerApi {
       deck: params.deck,
       commander_name: params.commanderName,
     });
+  }
+
+  async setFormat(params: SetFormatParams): Promise<void> {
+    this.send({ type: "SetFormat", format: params.format });
   }
 
   async startGame(params?: StartServerGameParams): Promise<void> {

--- a/src/stores/useServerStore.ts
+++ b/src/stores/useServerStore.ts
@@ -71,6 +71,7 @@ interface ServerState {
   leaveRoom(): Promise<void>;
   setReady(ready: boolean): Promise<void>;
   setDeckSelection(deckName: string, deck: Deck, commanderName?: string): Promise<void>;
+  setFormat(format: GameFormat): Promise<void>;
   startGame(format?: GameFormat): Promise<void>;
   endGame(): Promise<void>;
 
@@ -197,6 +198,12 @@ export const useServerStore = create<ServerState>()(
           deck,
           commanderName: commanderName ?? null,
         });
+      },
+
+      async setFormat(format) {
+        const platform = getPlatform();
+        if (!platform.server) return;
+        await platform.server.setFormat({ format });
       },
 
       async startGame(format) {

--- a/src/views/Lobby.tsx
+++ b/src/views/Lobby.tsx
@@ -120,6 +120,7 @@ export default function Lobby() {
     leaveRoom,
     setDeckSelection,
     setReady,
+    setFormat,
     startGame,
   } = useServerStore();
   const prefs = usePreferencesStore();
@@ -585,6 +586,7 @@ export default function Lobby() {
             onJoinRoom={joinRoom}
             onLeaveRoom={leaveRoom}
             onSetReady={setReady}
+            onSetFormat={setFormat}
             onOpenDeckDialog={() => setDeckDialogOpen(true)}
             onStartGame={startGame}
             onStartTabletop={handleStartTabletop}


### PR DESCRIPTION
## Summary

- New `SetFormat` client message + `lobby::set_format_sync` (host-only, lobby-only) that flips `room.format` and broadcasts `RoomUpdate`.
- Format badge in `TablesList` becomes a `DropdownMenu` for the host while the room is in `Lobby`; non-host viewers see the static badge.
- Wires through `platform/{types,tauri,web}.ts` + `useServerStore` + `Lobby.tsx`.

## Why

Fixes #81. Post-#82, rooms are created `GameFormat::Any` and only commit to a format at `startGame`. That works for solo play-vs-ai (one click picks format + deck together) but breaks shared human rooms — joiners pick decks before start with no format to validate against, so the deck picker can't filter to legal decks and players find out at start time. The fix gives the host an explicit lobby-time format selector, matching the shape sketched in the issue.

Server stays minimal: `set_format_sync` only flips `room.format` and rebroadcasts. Stale deck selections aren't cleared — the existing start-time validation catches them, and aggressive server-side clearing would surprise players mid-lobby. UI-side deck-picker filtering on the new format is a natural follow-up (room.format already drives it elsewhere).

## Test plan

- `yarn tsc --noEmit` — clean
- `yarn prettier --check` + `yarn eslint` on the touched files — clean
- `cargo check -p forge-agent-interface` — clean
- `cargo fmt --check` on touched Rust files — clean
- `cargo check -p forge-server` blocks on a pre-existing `forge-engine-core` compile error on main (unresolved `parse_script_svar_numeric_expression` / `SemanticParamValue::ProducedMana` in the SVar parsing rewrite — predates this branch). The lobby/connection/protocol additions mirror `SetReady` / `SetDeckSelection` patterns 1:1, so verified by pattern-match.
- **Manual** (pending): host creates an `Any` room, opens the format dropdown on the current-room card, picks a format, confirms peers see the `RoomUpdate` and can ready up with format-appropriate decks.

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main