### PR TITLE
fix(node): pass instead of stalling when a bot can't answer a prompt

### DIFF
--- a/forge-engine/crates/forge-bot/src/state.rs
+++ b/forge-engine/crates/forge-bot/src/state.rs
@@ -4,7 +4,7 @@ use forge_agent_interface::prompt::AgentPrompt;
 use forge_agent_interface::protocol::{ClientMessage, ServerMessage, StateEnvelope};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 
 use crate::agent::{AgentKind, BotAgent};
 
@@ -157,31 +157,41 @@ impl BotState {
             return Vec::new();
         }
 
-        // Java-side prompts can arrive in shapes that don't deserialize as
-        // `AgentPrompt`; passing priority is always a safe default in that case.
-        let action_value =
-            if prompt.get("kind").and_then(serde_json::Value::as_str) == Some("priority") {
-                json!({ "kind": "pass" })
-            } else {
-                let parsed: AgentPrompt = match serde_json::from_value(prompt) {
-                    Ok(p) => p,
-                    Err(error) => {
-                        warn!(%error, "bot prompt payload was invalid");
-                        return Vec::new();
-                    }
-                };
-                let Some(action) = self.agent.decide(parsed) else {
-                    debug!("bot agent returned no action for prompt");
-                    return Vec::new();
-                };
-                match serde_json::to_value(action) {
-                    Ok(v) => {
-                        debug!(action = %v, "bot sending action");
-                        v
-                    }
-                    Err(_) => return Vec::new(),
+        // A bot that can't answer a prompt must still pass, or the game
+        // soft-locks waiting on it (#77) — never return without responding.
+        let action_value = if prompt.get("kind").and_then(serde_json::Value::as_str)
+            == Some("priority")
+        {
+            json!({ "kind": "pass" })
+        } else {
+            let action = match serde_json::from_value::<AgentPrompt>(prompt.clone()) {
+                Ok(parsed) => self.agent.decide(parsed).or_else(|| {
+                    error!(
+                        prompt_type,
+                        "bot agent returned no action for prompt; passing"
+                    );
+                    None
+                }),
+                Err(error) => {
+                    error!(%error, prompt_type, prompt = %prompt, "bot prompt payload did not deserialize; passing");
+                    None
                 }
             };
+            let serialized = action.and_then(|action| {
+                serde_json::to_value(action)
+                    .map_err(|error| {
+                        error!(%error, prompt_type, "bot action did not serialize; passing");
+                    })
+                    .ok()
+            });
+            match serialized {
+                Some(v) => {
+                    debug!(action = %v, "bot sending action");
+                    v
+                }
+                None => json!({ "kind": "pass", "type": "pass", "untilPhase": null }),
+            }
+        };
 
         let response = StateEnvelope::Response {
             from_player: for_player,


### PR DESCRIPTION
## Summary

- The relay bot (`forge-bot`) silently dropped any prompt it couldn't turn into an action — `AgentPrompt` deserialization failure, agent returning no decision, or action serialization failure each `return`ed without sending a response.
- All three paths now log at `error` level (including the offending prompt JSON on a deserialize miss) and fall back to a pass response both the rust engine and the java harness accept.

## Why

Fixes the soft-lock in #77. When a bot can't answer a prompt, the hosted Java engine blocks forever on that seat — the game hangs with no way forward. The reported repro is attacking a hosted-AI opponent for lethal: the AI's `declareBlockers` prompt went unanswered and combat never resolved.

This is a **defensive fix, not a root-cause fix**. I traced the full declare-blockers path (Java `declareBlockers` → `awaitBlockers` → `normalize_java_prompt` → bot `handle_envelope` → `SimpleAi` → `translate_java_player_action`) and it's correct on inspection — `SimpleAi` always returns `Some(DeclareBlockers { .. })`, so the most likely culprit is a silent `AgentPrompt` deserialize failure in `handle_envelope` that the old code swallowed with only a `warn!` and an empty return. This patch turns that (and the other two silent drops) into a loud log plus a game-advancing pass, so the game no longer hangs and the failing prompt is captured for a targeted follow-up.

## Test plan

- `cargo fmt --check` on the changed file — clean
- `cargo clippy -p forge-bot` — no new warnings from this change (the remaining warnings are pre-existing, in `forge-foundation` / `forge-carddb` / engine effect resolvers)
- **Manual (pending):** reproduce #77 (attack hosted-AI for lethal), confirm the game advances instead of hanging, and capture any `error!`-level bot log to pin the underlying prompt-shape failure for the root-cause PR.

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main