### PR TITLE
fix: include mana abilities on interactive controller action space

### DIFF
--- a/forge-engine/crates/forge-agent-interface/src/java_prompt_normalizer.rs
+++ b/forge-engine/crates/forge-agent-interface/src/java_prompt_normalizer.rs
@@ -38,7 +38,10 @@ pub fn normalize_java_prompt(prompt: JavaRawPrompt) -> AgentPrompt {
 
     let mut source_card_id = None;
     let inner = match body {
-        JavaRawPromptBody::Priority { actions } => build_choose_action(&game_view, &actions),
+        JavaRawPromptBody::Priority {
+            actions,
+            untappable_land_ids,
+        } => build_choose_action(&game_view, &actions, untappable_land_ids),
         JavaRawPromptBody::ChooseDiscard { cards, min, max } => AgentPromptInner::ChooseDiscard {
             game_view,
             hand_card_ids: card_ids(&cards),
@@ -560,7 +563,11 @@ struct NormalizedAction {
     kind: Option<&'static str>,
 }
 
-fn build_choose_action(game_view: &GameViewDto, raw_actions: &[JavaRawAction]) -> AgentPromptInner {
+fn build_choose_action(
+    game_view: &GameViewDto,
+    raw_actions: &[JavaRawAction],
+    untappable_land_ids: Vec<String>,
+) -> AgentPromptInner {
     let actions = to_actions(raw_actions);
 
     let mut playable_options = Vec::new();
@@ -631,7 +638,7 @@ fn build_choose_action(game_view: &GameViewDto, raw_actions: &[JavaRawAction]) -
             .collect(),
         playable_options,
         tappable_land_ids,
-        untappable_land_ids: Vec::new(),
+        untappable_land_ids,
         activatable_ability_ids,
         mana_ability_options,
         available_player_actions: Vec::new(),

--- a/forge-engine/crates/forge-agent-interface/src/java_raw.rs
+++ b/forge-engine/crates/forge-agent-interface/src/java_raw.rs
@@ -20,6 +20,8 @@ pub enum JavaRawPromptBody {
     Priority {
         #[serde(default)]
         actions: Vec<JavaRawAction>,
+        #[serde(rename = "untappableLandIds", default)]
+        untappable_land_ids: Vec<String>,
     },
     ChooseDiscard {
         #[serde(default)]

--- a/forge-engine/crates/self-hosted-node/src/engine_backend/java_backend.rs
+++ b/forge-engine/crates/self-hosted-node/src/engine_backend/java_backend.rs
@@ -869,7 +869,7 @@ fn wait_for_prompt<B: JavaBridge>(
 
 #[cfg(feature = "java-forge")]
 fn auto_java_action(prompt: &JavaRawPrompt) -> JavaAction {
-    if let JavaRawPromptBody::Priority { actions } = &prompt.body {
+    if let JavaRawPromptBody::Priority { actions, .. } = &prompt.body {
         if let Some(index) = actions.iter().find_map(|action| action.index) {
             return JavaAction::ChooseAction { index };
         }

--- a/forge-harness/src/main/java/forge/harness/common/ActionSpace.java
+++ b/forge-harness/src/main/java/forge/harness/common/ActionSpace.java
@@ -81,7 +81,7 @@ public final class ActionSpace {
         return out;
     }
 
-    public static List<SpellAbility> getPossibleActions(final Player player) {
+    public static List<SpellAbility> getPossibleActions(final Player player, final boolean includeManaAbilities) {
         final Game game = player.getGame();
         final Set<Card> candidates = new LinkedHashSet<>();
 
@@ -123,9 +123,7 @@ public final class ActionSpace {
                 if (!canPayMana) {
                     continue;
                 }
-                // Keep action space focused on actionable plays/abilities.
-                // Mana abilities are excluded to avoid redundant/noisy parity choices.
-                if (sa.isManaAbility()) {
+                if (!includeManaAbilities && sa.isManaAbility()) {
                     continue;
                 }
                 if (!validTargets) {

--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveController.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveController.java
@@ -119,11 +119,32 @@ public final class ManaBrewInteractiveController extends PlayerController implem
 
     @Override
     public List<SpellAbility> chooseSpellAbilityToPlay() {
-        final List<SpellAbility> all = ChoiceSpace.sortNative(
-                new ArrayList<>(ActionSpace.getPossibleActions(player, true)),
-                ParityOrder.actionComparator());
-        final SpellAbility selected = session.awaitPriorityAction(me(), all);
-        return selected == null ? null : Lists.newArrayList(selected);
+        while (true) {
+            final List<SpellAbility> all = ChoiceSpace.sortNative(
+                    new ArrayList<>(ActionSpace.getPossibleActions(player, true)),
+                    ParityOrder.actionComparator());
+            final ManaBrewInteractiveSession.PriorityChoice choice =
+                    session.awaitPriorityAction(me(), all, undoableManaSources());
+            if (choice.kind() == ManaBrewInteractiveSession.PriorityActionKind.UNDO) {
+                game.getStack().undo();
+                continue;
+            }
+            final SpellAbility selected = choice.action();
+            return selected == null ? null : Lists.newArrayList(selected);
+        }
+    }
+
+    private List<Card> undoableManaSources() {
+        if (!game.getStack().canUndo(player)) {
+            return new ArrayList<>();
+        }
+        final List<Card> sources = new ArrayList<>();
+        for (final Card card : player.getCardsIn(ZoneType.Battlefield)) {
+            if (game.getStack().filterUndoStackByHost(card).iterator().hasNext()) {
+                sources.add(card);
+            }
+        }
+        return sources;
     }
 
     @Override

--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveController.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveController.java
@@ -120,7 +120,7 @@ public final class ManaBrewInteractiveController extends PlayerController implem
     @Override
     public List<SpellAbility> chooseSpellAbilityToPlay() {
         final List<SpellAbility> all = ChoiceSpace.sortNative(
-                new ArrayList<>(ActionSpace.getPossibleActions(player)),
+                new ArrayList<>(ActionSpace.getPossibleActions(player, true)),
                 ParityOrder.actionComparator());
         final SpellAbility selected = session.awaitPriorityAction(me(), all);
         return selected == null ? null : Lists.newArrayList(selected);

--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveSession.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveSession.java
@@ -129,27 +129,54 @@ public final class ManaBrewInteractiveSession {
         return "";
     }
 
-    SpellAbility awaitPriorityAction(final int playerId, final List<SpellAbility> actionsForPrompt) {
+    enum PriorityActionKind { ACTION, PASS, UNDO }
+
+    static final class PriorityChoice {
+        private final PriorityActionKind kind;
+        private final SpellAbility action;
+
+        private PriorityChoice(final PriorityActionKind kind, final SpellAbility action) {
+            this.kind = kind;
+            this.action = action;
+        }
+
+        PriorityActionKind kind() {
+            return kind;
+        }
+
+        SpellAbility action() {
+            return action;
+        }
+    }
+
+    PriorityChoice awaitPriorityAction(
+            final int playerId,
+            final List<SpellAbility> actionsForPrompt,
+            final List<Card> untappableCards
+    ) {
         requireAttached();
-        publishPriorityPrompt(playerId, actionsForPrompt);
+        publishPriorityPrompt(playerId, actionsForPrompt, untappableCards);
         while (!closed && !game.isGameOver()) {
             final JsonObject action;
             try {
                 action = actions.take();
             } catch (InterruptedException error) {
                 Thread.currentThread().interrupt();
-                return null;
+                return new PriorityChoice(PriorityActionKind.PASS, null);
             }
             final String kind = action.has("kind") ? action.get("kind").getAsString() : "";
             if ("pass".equals(kind) || "pass_priority".equals(kind)) {
-                return null;
+                return new PriorityChoice(PriorityActionKind.PASS, null);
+            }
+            if ("untap_land".equals(kind)) {
+                return new PriorityChoice(PriorityActionKind.UNDO, null);
             }
             if ("choose_action".equals(kind)) {
                 final int index = action.get("index").getAsInt();
                 if (index < 0 || index >= actionsForPrompt.size()) {
                     throw new IllegalArgumentException("action index out of range: " + index);
                 }
-                return actionsForPrompt.get(index);
+                return new PriorityChoice(PriorityActionKind.ACTION, actionsForPrompt.get(index));
             }
             if ("tap_land".equals(kind)) {
                 if (!action.has("manaAbilityIndex") || action.get("manaAbilityIndex").isJsonNull()) {
@@ -159,11 +186,11 @@ public final class ManaBrewInteractiveSession {
                 if (index < 0 || index >= actionsForPrompt.size()) {
                     throw new IllegalArgumentException("tap_land index out of range: " + index);
                 }
-                return actionsForPrompt.get(index);
+                return new PriorityChoice(PriorityActionKind.ACTION, actionsForPrompt.get(index));
             }
             throw new UnsupportedOperationException("unsupported action kind: " + kind);
         }
-        return null;
+        return new PriorityChoice(PriorityActionKind.PASS, null);
     }
 
     enum ManaPaymentKind { TAP, UNTAP, PAY, CANCEL }
@@ -994,7 +1021,11 @@ public final class ManaBrewInteractiveSession {
         }
     }
 
-    private void publishPriorityPrompt(final int playerId, final List<SpellAbility> actionsForPrompt) {
+    private void publishPriorityPrompt(
+            final int playerId,
+            final List<SpellAbility> actionsForPrompt,
+            final List<Card> untappableCards
+    ) {
         JsonObject prompt = new JsonObject();
         prompt.addProperty("kind", "priority");
         prompt.addProperty("sessionId", sessionId);
@@ -1023,6 +1054,13 @@ public final class ManaBrewInteractiveSession {
             options.add(option);
         }
         prompt.add("actions", options);
+
+        final com.google.gson.JsonArray untappable = new com.google.gson.JsonArray();
+        for (final Card card : untappableCards) {
+            untappable.add(SnapshotExtractor.javaCardId(card));
+        }
+        prompt.add("untappableLandIds", untappable);
+
         latestPromptJson = prompt.toString();
     }
 

--- a/forge-harness/src/main/java/forge/harness/parity/DeterministicController.java
+++ b/forge-harness/src/main/java/forge/harness/parity/DeterministicController.java
@@ -320,7 +320,7 @@ public class DeterministicController extends PlayerController implements Harness
         }
         captureDeepCheckpoint("main_action");
         final List<SpellAbility> all = filterFailedPaymentActions(ChoiceSpace.sortNative(
-                new ArrayList<>(ActionSpace.getPossibleActions(player)),
+                new ArrayList<>(ActionSpace.getPossibleActions(player, false)),
                 ParityOrder.actionComparator()));
         if (!all.isEmpty()) {
             onCallback("$ACTION_SPACE", formatActionSpace(all, player));

--- a/src-tauri/src/engine_backend/java_backend.rs
+++ b/src-tauri/src/engine_backend/java_backend.rs
@@ -156,7 +156,7 @@ fn run_game_inner(
 
 #[cfg(feature = "java-forge")]
 fn auto_java_action(prompt: &JavaRawPrompt) -> JavaAction {
-    if let JavaRawPromptBody::Priority { actions } = &prompt.body {
+    if let JavaRawPromptBody::Priority { actions, .. } = &prompt.body {
         if let Some(index) = actions.iter().find_map(|action| action.index) {
             return JavaAction::ChooseAction { index };
         }


### PR DESCRIPTION
## Why
- Java action space doesn't currently include mana abilities which doesn't let me tap for mana outside of a payment session

## Build artifacts
<!--
  Check the boxes below to build the corresponding installer on merge to main
  (uploaded to the Actions run, 30-day retention).
  Leave unchecked to skip — faster CI, no binaries produced.
  Tag pushes (v*) always build both and publish a GitHub Release regardless.
-->
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
