### PR TITLE
fix: hosted play-vs-ai — let the user set format and start, not the node

### DIFF
--- a/forge-engine/crates/forge-server/src/lobby.rs
+++ b/forge-engine/crates/forge-server/src/lobby.rs
@@ -279,7 +279,7 @@ pub fn set_format_sync(
             .get_mut(&room_id)
             .ok_or_else(|| ServerError::RoomNotFound(room_id.clone()))?;
 
-        if !room.is_host(player_id) {
+        if !room.is_controller(player_id) {
             return Err(ServerError::NotHost);
         }
 

--- a/forge-engine/crates/forge-server/src/room.rs
+++ b/forge-engine/crates/forge-server/src/room.rs
@@ -310,3 +310,34 @@ impl Room {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn room(host_plays: bool) -> Room {
+        Room::new(
+            "r".into(),
+            "room".into(),
+            "host".into(),
+            "host".into(),
+            4,
+            GameFormat::Commander,
+            EngineKind::Java,
+            host_plays,
+            None,
+            None,
+        )
+    }
+
+    #[test]
+    fn first_user_is_controller_in_hosted_room() {
+        let mut r = room(false);
+        assert!(r.is_host("host"));
+        assert!(!r.is_controller("host"));
+        r.add_player("human".into(), "human".into()).unwrap();
+        assert!(r.is_controller("human"));
+        r.add_player("bot".into(), "bot".into()).unwrap();
+        assert!(!r.is_controller("bot"));
+    }
+}

--- a/forge-engine/crates/self-hosted-node/src/main.rs
+++ b/forge-engine/crates/self-hosted-node/src/main.rs
@@ -573,13 +573,6 @@ async fn handle_state_update(
                     info!(observer = %client.username, "received removeBot request");
                     stop_bot(bot_state);
                 }
-                Some("startGame") => {
-                    info!(observer = %client.username, "received startGame request");
-                    let format = payload
-                        .get("format")
-                        .and_then(|value| serde_json::from_value::<GameFormat>(value.clone()).ok());
-                    client.send(&ClientMessage::StartGame { format }).await?;
-                }
                 Some("spawnBot") => {
                     let effective_room_id = requested_room_id.as_deref().unwrap_or(room_id);
                     if effective_room_id == room_id {

--- a/src/game/hostedAiPlay.ts
+++ b/src/game/hostedAiPlay.ts
@@ -72,13 +72,7 @@ export async function startHostedAiGame(request: HostedAiGameRequest): Promise<H
   );
 
   const gameStarted = waitForGameStarted(room.room_id);
-  await platform.server.sendRoomMessage(
-    createRoomRelayEnvelope({
-      protocol: SELF_HOSTED_NODE_RELAY_PROTOCOL,
-      roomId: room.room_id,
-      payload: { type: "startGame", format },
-    }),
-  );
+  await platform.server.startGame({ format });
 
   const payload = await gameStarted;
   const enginePlayerIndex = payload.player_order.indexOf(username);


### PR DESCRIPTION
## Summary

Make hosted "Play vs AI" driven by the **user**, not the node:

- **relay** (`lobby.rs`): `set_format_sync` gates on `is_controller` instead of `is_host`, matching `start_game_sync`.
- **node** (`self-hosted-node/main.rs`): drop the `startGame` relay-message handler — the node no longer mediates start.
- **web** (`hostedAiPlay.ts`): the human (the controller) calls `server.startGame({ format })` directly instead of routing a relay envelope through the node.

## Why

The first seated user is the **controller** (drives format/start); the engine holder is the **host**. They coincide in a self-created room but diverge in a `hosted` (self-hosted-node) room: the node holds the engine as a *non-seated observer* (host), and the first human to join is the controller. So:

- `set_format` required `is_host` → the human couldn't set the format (`not_host`).
- start went through the node, which sent `StartGame` as a non-controller → `not_host`.

Now the controlling player sets the format and starts the game directly, and the node just reacts to `GameStarted` to spin up the engine. Keeps Anacleto's "first user is the controller" model; normal rooms unaffected (controller == host there). The node's `auto_start` self-play path is untouched (gated by `config.auto_start`).

## Test plan

- `cargo test -p forge-server` — `first_user_is_controller_in_hosted_room` passes.
- `cargo check -p self-hosted-node` — 0 errors.
- `tsc` — clean.
- Manual: hosted Play-vs-AI — change format in lobby, start, play a game to completion.

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
