### PR TITLE
feat(ui): in-pile counter target + clearer stack ordering

### DIFF
--- a/forge-harness/src/main/java/forge/harness/InteractiveSnapshotExtractor.java
+++ b/forge-harness/src/main/java/forge/harness/InteractiveSnapshotExtractor.java
@@ -20,6 +20,7 @@ import forge.game.zone.ZoneType;
 import forge.item.IPaperCard;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -313,7 +314,12 @@ public final class InteractiveSnapshotExtractor {
 
     private static List<Map<String, Object>> snapshotStack(final Game game, final SpellAbility castingAbility) {
         final List<Map<String, Object>> out = new ArrayList<>();
+        final List<SpellAbilityStackInstance> entries = new ArrayList<>();
         for (final SpellAbilityStackInstance item : game.getStack()) {
+            entries.add(item);
+        }
+        Collections.reverse(entries);
+        for (final SpellAbilityStackInstance item : entries) {
             final Map<String, Object> stackItem = new LinkedHashMap<>();
             stackItem.put("id", stackItemId(item));
             final Card source = item.getSourceCard();

--- a/src/components/game/panels/StackDisplay.tsx
+++ b/src/components/game/panels/StackDisplay.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type CSSProperties } from "react";
 import { Card } from "@/components/game/Card";
+import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { withAlpha } from "@/themes/gameTheme";
+import { useTheme } from "@/hooks/useTheme";
 import type { GameCard, StackObject } from "@/types/manabrew";
 import { useStackUIStore } from "@/stores/useStackUIStore";
 
@@ -14,6 +16,12 @@ interface StackDisplayProps {
   showPreStackFlash?: boolean;
   rightPanelCollapsed?: boolean;
   playerColorMap?: Map<string, string>;
+  /** Stack entry IDs the player may target (counter). Empty disables in-pile
+   *  click-to-counter; the pile reverts to its passive (read-only) state. */
+  validSpellIds?: string[];
+  /** Called when the player clicks a glowing stack entry during a counter
+   *  prompt. When omitted, valid entries fall back to `onOpenStack`. */
+  onTargetSpell?: (spellId: string) => void;
 }
 
 // Stack UI tuning (single source of truth for size/placement)
@@ -26,8 +34,8 @@ const STACK_RIGHT_WHEN_PANEL_COLLAPSED = 10;
 const STACK_UI = {
   direction: "left" as "left" | "right",
   cardWidth: 220,
-  offsetX: 15,
-  offsetY: 2,
+  offsetX: 36,
+  offsetY: 4,
   centerOffsetY: -60,
   hoverPushX: 60,
 } as const;
@@ -41,9 +49,14 @@ export function StackDisplay({
   showPreStackFlash = true,
   rightPanelCollapsed = true,
   playerColorMap,
+  validSpellIds,
+  onTargetSpell,
 }: StackDisplayProps) {
   const [hoveredId, setHoveredId] = useState<string | null>(null);
   const setHoveredStackObjectId = useStackUIStore((s) => s.setHoveredStackObjectId);
+  const themeColors = useTheme().gameTheme;
+  const targetingActive = (validSpellIds?.length ?? 0) > 0;
+  const validSpellIdSet = new Set(validSpellIds ?? []);
   // Track previous render's stack ids and per-id layout to drive enter animations
   // and skip transitions when positions haven't changed.
   const stackIdsKey = stack.map((obj) => obj.id).join(",");
@@ -87,6 +100,11 @@ export function StackDisplay({
     setPrevStackIds(new Set(stack.map((obj) => obj.id)));
   }
 
+  // Vertical positions: top-of-stack (highest idx) sits at top: 0 so it
+  // visually rises above older entries, matching MTG convention ("top of
+  // the stack" = next to resolve = highest on screen).
+  const topForIndex = (idx: number) => (stack.length - 1 - idx) * STACK_UI.offsetY;
+
   // Snapshot previous layout (left/top per id) for transition decisions.
   const [prevLayout, setPrevLayout] = useState<Record<string, { left: number; top: number }>>({});
   const layoutKey = stack.map((obj, idx) => `${obj.id}:${lefts[idx] + xShift}:${idx}`).join("|");
@@ -97,7 +115,7 @@ export function StackDisplay({
     stack.forEach((obj, idx) => {
       nextLayout[obj.id] = {
         left: lefts[idx] + xShift,
-        top: idx * STACK_UI.offsetY,
+        top: topForIndex(idx),
       };
     });
     setPrevLayout(nextLayout);
@@ -133,7 +151,7 @@ export function StackDisplay({
           const isTopOfStack = idx === stack.length - 1;
           const isFlashedStackCard = flashStackIndex === idx;
           const targetLeft = lefts[idx] + xShift;
-          const targetTop = idx * STACK_UI.offsetY;
+          const targetTop = topForIndex(idx);
           const prev = prevLayout[obj.id];
           const hasPositionChange = !prev || prev.left !== targetLeft || prev.top !== targetTop;
           const zIndex =
@@ -141,6 +159,19 @@ export function StackDisplay({
               ? idx + 1
               : 200 - Math.abs(idx - hoveredIndex) * 10 + (isHovered ? 5 : 0);
           const seatColor = playerColorMap?.get(obj.controllerId);
+          const isValidTarget = targetingActive && validSpellIdSet.has(obj.id);
+          const isDimmed = targetingActive && !isValidTarget;
+          const cardStyle: CSSProperties = {
+            ...(seatColor
+              ? {
+                  boxShadow: `0 0 0 2px ${withAlpha(seatColor, 0.7)}, 0 0 14px ${withAlpha(seatColor, 0.45)}`,
+                  borderRadius: "inherit",
+                }
+              : {}),
+            ...(isValidTarget
+              ? ({ "--tw-ring-color": themeColors.cardRing } as CSSProperties)
+              : {}),
+          };
           return (
             <div
               key={obj.id}
@@ -153,6 +184,7 @@ export function StackDisplay({
                   ? "transition-[left,top,transform] duration-560 ease-[cubic-bezier(0.23,0.63,0.32,1)]"
                   : "transition-transform duration-560 ease-[cubic-bezier(0.23,0.63,0.32,1)]",
                 isHovered && "-translate-y-2 scale-105",
+                isDimmed && "opacity-60",
               )}
               style={{
                 left: `${targetLeft}px`,
@@ -165,7 +197,10 @@ export function StackDisplay({
                 setHoveredId(obj.id);
                 setHoveredStackObjectId(obj.id);
               }}
-              onClick={onOpenStack}
+              onClick={() => {
+                if (isValidTarget && onTargetSpell) onTargetSpell(obj.id);
+                else onOpenStack();
+              }}
             >
               <Card
                 card={card}
@@ -175,19 +210,36 @@ export function StackDisplay({
                   isFlashedStackCard && "animate-card-stack-flash-in",
                   enteringIds.has(obj.id) && !isFlashedStackCard && "animate-card-stack-enter",
                   isTopOfStack && !obj.isCasting && "playable-card",
+                  isValidTarget && "ring-4",
                 )}
-                style={
-                  seatColor
-                    ? {
-                        boxShadow: `0 0 0 2px ${withAlpha(seatColor, 0.7)}, 0 0 14px ${withAlpha(seatColor, 0.45)}`,
-                        borderRadius: "inherit",
-                      }
-                    : undefined
-                }
+                style={Object.keys(cardStyle).length > 0 ? cardStyle : undefined}
               />
             </div>
           );
         })}
+
+        {stack.length > 0 &&
+          (() => {
+            const topIdx = stack.length - 1;
+            const badgeLeft = lefts[topIdx] + xShift;
+            return (
+              <div
+                className="pointer-events-none absolute"
+                style={{
+                  left: `${badgeLeft}px`,
+                  top: `${topForIndex(topIdx) - 22}px`,
+                  width: `${STACK_UI.cardWidth}px`,
+                  zIndex: 250,
+                }}
+              >
+                <div className="flex justify-center">
+                  <Badge variant="secondary" className="text-[10px] h-5 px-1.5 shadow">
+                    TOP · resolves next
+                  </Badge>
+                </div>
+              </div>
+            );
+          })()}
 
         {flashCard && flashStackIndex < 0 && showPreStackFlash && (
           <div

--- a/src/components/game/panels/StackDisplay.tsx
+++ b/src/components/game/panels/StackDisplay.tsx
@@ -16,11 +16,7 @@ interface StackDisplayProps {
   showPreStackFlash?: boolean;
   rightPanelCollapsed?: boolean;
   playerColorMap?: Map<string, string>;
-  /** Stack entry IDs the player may target (counter). Empty disables in-pile
-   *  click-to-counter; the pile reverts to its passive (read-only) state. */
   validSpellIds?: string[];
-  /** Called when the player clicks a glowing stack entry during a counter
-   *  prompt. When omitted, valid entries fall back to `onOpenStack`. */
   onTargetSpell?: (spellId: string) => void;
 }
 
@@ -100,9 +96,6 @@ export function StackDisplay({
     setPrevStackIds(new Set(stack.map((obj) => obj.id)));
   }
 
-  // Vertical positions: top-of-stack (highest idx) sits at top: 0 so it
-  // visually rises above older entries, matching MTG convention ("top of
-  // the stack" = next to resolve = highest on screen).
   const topForIndex = (idx: number) => (stack.length - 1 - idx) * STACK_UI.offsetY;
 
   // Snapshot previous layout (left/top per id) for transition decisions.
@@ -212,34 +205,21 @@ export function StackDisplay({
                   isTopOfStack && !obj.isCasting && "playable-card",
                   isValidTarget && "ring-4",
                 )}
-                style={Object.keys(cardStyle).length > 0 ? cardStyle : undefined}
+                style={cardStyle}
               />
-            </div>
-          );
-        })}
-
-        {stack.length > 0 &&
-          (() => {
-            const topIdx = stack.length - 1;
-            const badgeLeft = lefts[topIdx] + xShift;
-            return (
-              <div
-                className="pointer-events-none absolute"
-                style={{
-                  left: `${badgeLeft}px`,
-                  top: `${topForIndex(topIdx) - 22}px`,
-                  width: `${STACK_UI.cardWidth}px`,
-                  zIndex: 250,
-                }}
-              >
-                <div className="flex justify-center">
+              {isTopOfStack && (
+                <div
+                  className="pointer-events-none absolute left-0 right-0 -top-6 flex justify-center"
+                  style={{ zIndex: 250 }}
+                >
                   <Badge variant="secondary" className="text-[10px] h-5 px-1.5 shadow">
                     TOP · resolves next
                   </Badge>
                 </div>
-              </div>
-            );
-          })()}
+              )}
+            </div>
+          );
+        })}
 
         {flashCard && flashStackIndex < 0 && showPreStackFlash && (
           <div

--- a/src/components/game/panels/prompt-actions/ChooseTargetSpell.tsx
+++ b/src/components/game/panels/prompt-actions/ChooseTargetSpell.tsx
@@ -1,4 +1,4 @@
-import { Check } from "lucide-react";
+import { Layers } from "lucide-react";
 import { PromptActionButton } from "@/components/game/panels/PromptActionButton";
 import type { ChooseTargetSpellProps } from "./types";
 
@@ -10,8 +10,9 @@ export function ChooseTargetSpell({
   return (
     <PromptActionButton
       layout={buttonLayout}
-      label="Choose Counter Target"
-      icon={<Check className="h-3.5 w-3.5" />}
+      label="View Stack"
+      title="Click a glowing spell on the stack to counter it"
+      icon={<Layers className="h-3.5 w-3.5" />}
       onClick={onOpenStack}
       disabled={isWaitingForResponse}
     />

--- a/src/components/game/pointerSpecs.ts
+++ b/src/components/game/pointerSpecs.ts
@@ -56,11 +56,8 @@ function getActiveStackObject(
   activeStackObjectId?: string | null,
 ): StackObject | null {
   if (!stack || stack.length === 0) return null;
-  if (activeStackObjectId) {
-    const hit = stack.find((obj) => obj.id === activeStackObjectId);
-    if (hit) return hit;
-  }
-  return stack[stack.length - 1] ?? null;
+  if (!activeStackObjectId) return null;
+  return stack.find((obj) => obj.id === activeStackObjectId) ?? null;
 }
 
 export function buildPointerSpecs(opts: BuildPointerSpecsOptions): PointerSpec[] {

--- a/src/hooks/usePromptEffects.ts
+++ b/src/hooks/usePromptEffects.ts
@@ -68,6 +68,80 @@ type AutoPassPlan =
   | { action: "clearPassUntil" }
   | { action: "schedulePass"; untilPhase: string | null };
 
+interface AutoPassInputs {
+  currentPrompt: AgentPrompt;
+  passUntilTurn: number | null;
+  passUntilPhase: string | null;
+  turn: number;
+  stackLength: number;
+  myPlayerId: string;
+}
+
+function stopForActiveCombatAfterAttackers(inputs: AutoPassInputs): AutoPassPlan | null {
+  const { currentPrompt, stackLength, passUntilTurn } = inputs;
+  if (
+    currentPrompt.type !== PromptType.ChooseAction ||
+    stackLength !== 0 ||
+    !hasActiveCombatAfterAttackers(currentPrompt) ||
+    !hasNonPassPriorityAction(currentPrompt)
+  ) {
+    return null;
+  }
+  return passUntilTurn !== null ? { action: "clearPassUntil" } : { action: "none" };
+}
+
+function stopForMandatoryCombatStop(inputs: AutoPassInputs): AutoPassPlan | null {
+  const { currentPrompt, stackLength, passUntilTurn, myPlayerId } = inputs;
+  if (currentPrompt.type !== PromptType.ChooseAction || stackLength !== 0) return null;
+  const gv = currentPrompt.gameView;
+  if (gv.activePlayerId === myPlayerId) return null;
+  if (!MANDATORY_COMBAT_STOPS.has(gv.step)) return null;
+  return passUntilTurn !== null ? { action: "clearPassUntil" } : { action: "none" };
+}
+
+function planWhilePassingUntilPhase(inputs: AutoPassInputs): AutoPassPlan {
+  const { currentPrompt, passUntilTurn, passUntilPhase, turn, stackLength, myPlayerId } = inputs;
+
+  if (passUntilTurn !== null && turn > passUntilTurn) return { action: "clearPassUntil" };
+  if (currentPrompt.type === PromptType.ChooseAction && stackLength > 0) {
+    return { action: "clearPassUntil" };
+  }
+  if (passUntilPhase && currentPrompt.gameView.step === passUntilPhase && stackLength === 0) {
+    return { action: "clearPassUntil" };
+  }
+
+  if (currentPrompt.type === PromptType.ChooseAction && stackLength === 0) {
+    const gv = currentPrompt.gameView;
+    const isMyTurn = gv.activePlayerId === myPlayerId;
+    const store = usePhaseStopStore.getState();
+    const stops = isMyTurn ? store.selfStops : store.getOpponentStops(gv.activePlayerId);
+    if (stops.has(gv.step)) return { action: "clearPassUntil" };
+  }
+
+  if (
+    currentPrompt.type === PromptType.ChooseAction ||
+    currentPrompt.type === PromptType.ChooseAttackers
+  ) {
+    return { action: "schedulePass", untilPhase: passUntilPhase };
+  }
+
+  return { action: "clearPassUntil" };
+}
+
+function planForIdlePhaseSkip(inputs: AutoPassInputs): AutoPassPlan {
+  const { currentPrompt, stackLength, myPlayerId } = inputs;
+  if (currentPrompt.type !== PromptType.ChooseAction || stackLength !== 0) {
+    return { action: "none" };
+  }
+  const gv = currentPrompt.gameView;
+  const isMyTurn = gv.activePlayerId === myPlayerId;
+  const store = usePhaseStopStore.getState();
+  const stops = isMyTurn ? store.selfStops : store.getOpponentStops(gv.activePlayerId);
+  if (stops.has(gv.step)) return { action: "none" };
+  const nextStop = getNextStopPhase(gv.step, stops);
+  return { action: "schedulePass", untilPhase: nextStop };
+}
+
 function computeAutoPassPlan(
   currentPrompt: AgentPrompt | null,
   isWaitingForResponse: boolean,
@@ -78,65 +152,19 @@ function computeAutoPassPlan(
   myPlayerId: string,
 ): AutoPassPlan {
   if (!currentPrompt || isWaitingForResponse) return { action: "none" };
-
-  if (
-    currentPrompt.type === PromptType.ChooseAction &&
-    stackLength === 0 &&
-    hasActiveCombatAfterAttackers(currentPrompt) &&
-    hasNonPassPriorityAction(currentPrompt)
-  ) {
-    return passUntilTurn !== null ? { action: "clearPassUntil" } : { action: "none" };
-  }
-
-  if (currentPrompt.type === PromptType.ChooseAction && stackLength === 0) {
-    const gv = currentPrompt.gameView;
-    const isMyTurn = gv.activePlayerId === myPlayerId;
-    if (!isMyTurn && MANDATORY_COMBAT_STOPS.has(gv.step)) {
-      return passUntilTurn !== null ? { action: "clearPassUntil" } : { action: "none" };
-    }
-  }
-
-  if (passUntilTurn !== null) {
-    if (turn > passUntilTurn) return { action: "clearPassUntil" };
-
-    if (currentPrompt.type === PromptType.ChooseAction && stackLength > 0) {
-      return { action: "clearPassUntil" };
-    }
-
-    if (passUntilPhase && currentPrompt.gameView.step === passUntilPhase && stackLength === 0) {
-      return { action: "clearPassUntil" };
-    }
-
-    if (currentPrompt.type === PromptType.ChooseAction && stackLength === 0) {
-      const gv = currentPrompt.gameView;
-      const isMyTurn = gv.activePlayerId === myPlayerId;
-      const store = usePhaseStopStore.getState();
-      const stops = isMyTurn ? store.selfStops : store.getOpponentStops(gv.activePlayerId);
-      if (stops.has(gv.step)) return { action: "clearPassUntil" };
-    }
-
-    if (
-      currentPrompt.type === PromptType.ChooseAction ||
-      currentPrompt.type === PromptType.ChooseAttackers
-    ) {
-      return { action: "schedulePass", untilPhase: passUntilPhase };
-    }
-
-    return { action: "clearPassUntil" };
-  }
-
-  if (currentPrompt.type === PromptType.ChooseAction && stackLength === 0) {
-    const gv = currentPrompt.gameView;
-    const isMyTurn = gv.activePlayerId === myPlayerId;
-    const store = usePhaseStopStore.getState();
-    const stops = isMyTurn ? store.selfStops : store.getOpponentStops(gv.activePlayerId);
-    if (!stops.has(gv.step)) {
-      const nextStop = getNextStopPhase(gv.step, stops);
-      return { action: "schedulePass", untilPhase: nextStop };
-    }
-  }
-
-  return { action: "none" };
+  const inputs: AutoPassInputs = {
+    currentPrompt,
+    passUntilTurn,
+    passUntilPhase,
+    turn,
+    stackLength,
+    myPlayerId,
+  };
+  return (
+    stopForActiveCombatAfterAttackers(inputs) ??
+    stopForMandatoryCombatStop(inputs) ??
+    (passUntilTurn !== null ? planWhilePassingUntilPhase(inputs) : planForIdlePhaseSkip(inputs))
+  );
 }
 
 function computeZoneTarget(currentPrompt: AgentPrompt | null): ZoneTargetState | null {
@@ -224,12 +252,9 @@ export function usePromptEffects({
   );
   const zoneTargetSelector =
     zoneTargetDismissedPrompt === currentPrompt ? null : zoneTargetFromPrompt;
-  const setZoneTargetSelector = useCallback(
-    (_value: ZoneTargetState | null) => {
-      setZoneTargetDismissedPrompt(currentPrompt);
-    },
-    [currentPrompt],
-  );
+  const dismissZoneTarget = useCallback(() => {
+    setZoneTargetDismissedPrompt(currentPrompt);
+  }, [currentPrompt]);
 
   const [spellStackModalOpen, setSpellStackModalOpen] = useState(false);
 
@@ -255,7 +280,7 @@ export function usePromptEffects({
     libraryPeekModal,
     setLibraryPeekModal,
     zoneTargetSelector,
-    setZoneTargetSelector,
+    dismissZoneTarget,
     spellStackModalOpen,
     setSpellStackModalOpen,
   };

--- a/src/hooks/usePromptEffects.ts
+++ b/src/hooks/usePromptEffects.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useMemo, useState, useCallback } from "react";
 import { usePhaseStopStore, getNextStopPhase } from "@/stores/usePhaseStopStore";
 import type { AgentPrompt } from "@/stores/useGameStore";
 import type { LibraryPeekMode } from "@/components/game/modals";
@@ -44,6 +44,8 @@ const ACTIVE_COMBAT_PRIORITY_STEPS = new Set([
   "end_combat",
 ]);
 
+const MANDATORY_COMBAT_STOPS = new Set(["declare_blockers"]);
+
 function hasActiveCombatAfterAttackers(prompt: AgentPrompt): boolean {
   return (
     ACTIVE_COMBAT_PRIORITY_STEPS.has(prompt.gameView.step) &&
@@ -61,6 +63,100 @@ function hasNonPassPriorityAction(prompt: AgentPrompt): boolean {
   );
 }
 
+type AutoPassPlan =
+  | { action: "none" }
+  | { action: "clearPassUntil" }
+  | { action: "schedulePass"; untilPhase: string | null };
+
+function computeAutoPassPlan(
+  currentPrompt: AgentPrompt | null,
+  isWaitingForResponse: boolean,
+  passUntilTurn: number | null,
+  passUntilPhase: string | null,
+  turn: number,
+  stackLength: number,
+  myPlayerId: string,
+): AutoPassPlan {
+  if (!currentPrompt || isWaitingForResponse) return { action: "none" };
+
+  if (
+    currentPrompt.type === PromptType.ChooseAction &&
+    stackLength === 0 &&
+    hasActiveCombatAfterAttackers(currentPrompt) &&
+    hasNonPassPriorityAction(currentPrompt)
+  ) {
+    return passUntilTurn !== null ? { action: "clearPassUntil" } : { action: "none" };
+  }
+
+  if (currentPrompt.type === PromptType.ChooseAction && stackLength === 0) {
+    const gv = currentPrompt.gameView;
+    const isMyTurn = gv.activePlayerId === myPlayerId;
+    if (!isMyTurn && MANDATORY_COMBAT_STOPS.has(gv.step)) {
+      return passUntilTurn !== null ? { action: "clearPassUntil" } : { action: "none" };
+    }
+  }
+
+  if (passUntilTurn !== null) {
+    if (turn > passUntilTurn) return { action: "clearPassUntil" };
+
+    if (currentPrompt.type === PromptType.ChooseAction && stackLength > 0) {
+      return { action: "clearPassUntil" };
+    }
+
+    if (passUntilPhase && currentPrompt.gameView.step === passUntilPhase && stackLength === 0) {
+      return { action: "clearPassUntil" };
+    }
+
+    if (currentPrompt.type === PromptType.ChooseAction && stackLength === 0) {
+      const gv = currentPrompt.gameView;
+      const isMyTurn = gv.activePlayerId === myPlayerId;
+      const store = usePhaseStopStore.getState();
+      const stops = isMyTurn ? store.selfStops : store.getOpponentStops(gv.activePlayerId);
+      if (stops.has(gv.step)) return { action: "clearPassUntil" };
+    }
+
+    if (
+      currentPrompt.type === PromptType.ChooseAction ||
+      currentPrompt.type === PromptType.ChooseAttackers
+    ) {
+      return { action: "schedulePass", untilPhase: passUntilPhase };
+    }
+
+    return { action: "clearPassUntil" };
+  }
+
+  if (currentPrompt.type === PromptType.ChooseAction && stackLength === 0) {
+    const gv = currentPrompt.gameView;
+    const isMyTurn = gv.activePlayerId === myPlayerId;
+    const store = usePhaseStopStore.getState();
+    const stops = isMyTurn ? store.selfStops : store.getOpponentStops(gv.activePlayerId);
+    if (!stops.has(gv.step)) {
+      const nextStop = getNextStopPhase(gv.step, stops);
+      return { action: "schedulePass", untilPhase: nextStop };
+    }
+  }
+
+  return { action: "none" };
+}
+
+function computeZoneTarget(currentPrompt: AgentPrompt | null): ZoneTargetState | null {
+  if (currentPrompt?.type !== PromptType.ChooseTargetCardFromZone) return null;
+  const zone = currentPrompt.zone;
+  const validCardIds = currentPrompt.validCardIds || [];
+  const zoneCards = currentPrompt.zoneCards || [];
+  if (!zone || zone === "Battlefield" || zoneCards.length === 0) return null;
+  const zoneNames: Record<string, string> = {
+    Graveyard: "Graveyard",
+    Exile: "Exile",
+    Hand: "Hand",
+  };
+  return {
+    title: `Choose from ${zoneNames[zone] || zone}`,
+    cards: zoneCards,
+    validCardIds,
+  };
+}
+
 export function usePromptEffects({
   currentPrompt,
   isWaitingForResponse,
@@ -69,18 +165,31 @@ export function usePromptEffects({
   turn,
   stackLength,
 }: UsePromptEffectsOptions) {
-  const promptType = currentPrompt?.type;
-  const [isAutoPassing, setIsAutoPassing] = useState(false);
-
-  // Phase-stop auto-pass state lives in the store so non-pass actions can clear it
   const passUntilPhase = usePhaseStopStore((s) => s.passUntilPhase);
   const passUntilTurn = usePhaseStopStore((s) => s.passUntilTurn);
 
-  /**
-   * Unified pass action. Context-aware:
-   * - Clean priority (no stack): auto-pass until next enabled stop phase
-   * - In response (stack > 0): just pass priority once
-   */
+  const autoPassPlan = useMemo(
+    () =>
+      computeAutoPassPlan(
+        currentPrompt,
+        isWaitingForResponse,
+        passUntilTurn,
+        passUntilPhase,
+        turn,
+        stackLength,
+        myPlayerId,
+      ),
+    [
+      currentPrompt,
+      isWaitingForResponse,
+      passUntilTurn,
+      passUntilPhase,
+      turn,
+      stackLength,
+      myPlayerId,
+    ],
+  );
+
   const unifiedPass = useCallback(() => {
     if (!currentPrompt || isWaitingForResponse) return;
 
@@ -88,172 +197,55 @@ export function usePromptEffects({
     const hasStack = (gv.stack?.length ?? 0) > 0;
 
     if (hasStack) {
-      // Responding to something — atomic single pass
       passPriority(null);
       return;
     }
 
-    // Clean priority — determine which stop set applies
     const isMyTurn = gv.activePlayerId === myPlayerId;
     const store = usePhaseStopStore.getState();
     const stops = isMyTurn ? store.selfStops : store.getOpponentStops(gv.activePlayerId);
 
     const nextStop = getNextStopPhase(gv.step, stops);
 
-    // Set frontend auto-pass state (fallback for any prompts the engine
-    // still sends despite the pass-until declaration)
     usePhaseStopStore.getState().setPassUntil(nextStop, turn);
 
-    // Send pass with until-phase to engine so it can fast-forward
     passPriority(nextStop);
   }, [currentPrompt, isWaitingForResponse, passPriority, myPlayerId, turn]);
 
-  // F6: just triggers the same unified pass
   function activatePassUntilEot() {
     unifiedPass();
   }
 
-  // Library peek modal state
   const [libraryPeekModal, setLibraryPeekModal] = useState<LibraryPeekState | null>(null);
 
-  // Zone target selector state
-  const [zoneTargetSelector, setZoneTargetSelector] = useState<ZoneTargetState | null>(null);
+  const zoneTargetFromPrompt = useMemo(() => computeZoneTarget(currentPrompt), [currentPrompt]);
+  const [zoneTargetDismissedPrompt, setZoneTargetDismissedPrompt] = useState<AgentPrompt | null>(
+    null,
+  );
+  const zoneTargetSelector =
+    zoneTargetDismissedPrompt === currentPrompt ? null : zoneTargetFromPrompt;
+  const setZoneTargetSelector = useCallback(
+    (_value: ZoneTargetState | null) => {
+      setZoneTargetDismissedPrompt(currentPrompt);
+    },
+    [currentPrompt],
+  );
 
-  // Spell stack modal
   const [spellStackModalOpen, setSpellStackModalOpen] = useState(false);
 
-  // Auto-pass logic
   useEffect(() => {
-    setIsAutoPassing(false);
-    if (!currentPrompt || isWaitingForResponse) return;
-
-    if (
-      currentPrompt.type === PromptType.ChooseAction &&
-      stackLength === 0 &&
-      hasActiveCombatAfterAttackers(currentPrompt) &&
-      hasNonPassPriorityAction(currentPrompt)
-    ) {
-      if (passUntilTurn !== null) {
-        usePhaseStopStore.getState().clearPassUntil();
-      }
-      return;
-    }
-
-    const MANDATORY_COMBAT_STOPS = new Set(["declare_blockers"]);
-
-    if (currentPrompt.type === PromptType.ChooseAction && stackLength === 0) {
-      const gv = currentPrompt.gameView;
-      const isMyTurn = gv.activePlayerId === myPlayerId;
-      if (!isMyTurn && MANDATORY_COMBAT_STOPS.has(gv.step)) {
-        // Cancel any active pass-until and stop here
-        if (passUntilTurn !== null) {
-          usePhaseStopStore.getState().clearPassUntil();
-        }
-        return; // don't auto-pass — let the player act
-      }
-    }
-
-    // ── Phase-stop auto-pass ──
-    if (passUntilTurn !== null) {
-      // Turn advanced — cancel
-      if (turn > passUntilTurn) {
-        usePhaseStopStore.getState().clearPassUntil();
-        return;
-      }
-
-      // Stack appeared — cancel (player is responding to something)
-      if (currentPrompt.type === PromptType.ChooseAction && stackLength > 0) {
-        usePhaseStopStore.getState().clearPassUntil();
-        return;
-      }
-
-      // Reached target phase — stop
-      if (passUntilPhase && currentPrompt.gameView.step === passUntilPhase && stackLength === 0) {
-        usePhaseStopStore.getState().clearPassUntil();
-        return;
-      }
-
-      // Current phase is a stop — cancel auto-pass so the player gets
-      // control (e.g. back on M1 after a spell resolved)
-      if (currentPrompt.type === PromptType.ChooseAction && stackLength === 0) {
-        const gv = currentPrompt.gameView;
-        const isMyTurn = gv.activePlayerId === myPlayerId;
-        const store = usePhaseStopStore.getState();
-        const stops = isMyTurn ? store.selfStops : store.getOpponentStops(gv.activePlayerId);
-        if (stops.has(gv.step)) {
-          usePhaseStopStore.getState().clearPassUntil();
-          return;
-        }
-      }
-
-      // Still auto-passing — relay until-phase to engine
-      if (
-        currentPrompt.type === PromptType.ChooseAction ||
-        currentPrompt.type === PromptType.ChooseAttackers
-      ) {
-        setIsAutoPassing(true);
-        const timer = setTimeout(() => passPriority(passUntilPhase), getAutoPassDelayMs());
-        return () => clearTimeout(timer);
-      }
-
-      // Unexpected prompt type — cancel
+    if (autoPassPlan.action === "clearPassUntil") {
       usePhaseStopStore.getState().clearPassUntil();
       return;
     }
-
-    // ── Phase-stop skip: if current phase isn't a stop, auto-pass ──
-
-    if (currentPrompt.type === PromptType.ChooseAction && stackLength === 0) {
-      const gv = currentPrompt.gameView;
-      const isMyTurn = gv.activePlayerId === myPlayerId;
-
-      const store = usePhaseStopStore.getState();
-      const stops = isMyTurn ? store.selfStops : store.getOpponentStops(gv.activePlayerId);
-
-      if (!stops.has(gv.step)) {
-        const nextStop = getNextStopPhase(gv.step, stops);
-        setIsAutoPassing(true);
-        const timer = setTimeout(() => passPriority(nextStop), getAutoPassDelayMs());
-        return () => clearTimeout(timer);
-      }
+    if (autoPassPlan.action === "schedulePass") {
+      const untilPhase = autoPassPlan.untilPhase;
+      const timer = setTimeout(() => passPriority(untilPhase), getAutoPassDelayMs());
+      return () => clearTimeout(timer);
     }
-  }, [
-    currentPrompt,
-    isWaitingForResponse,
-    passPriority,
-    passUntilTurn,
-    passUntilPhase,
-    turn,
-    stackLength,
-    myPlayerId,
-  ]);
+  }, [autoPassPlan, passPriority]);
 
-  useEffect(() => {
-    if (promptType === PromptType.ChooseTargetCardFromZone && currentPrompt) {
-      const zone = currentPrompt.zone;
-      const validCardIds = currentPrompt.validCardIds || [];
-      const zoneCards = currentPrompt.zoneCards || [];
-
-      if (zone && zone !== "Battlefield" && zoneCards.length > 0) {
-        const zoneNames: Record<string, string> = {
-          Graveyard: "Graveyard",
-          Exile: "Exile",
-          Hand: "Hand",
-        };
-        const title = `Choose from ${zoneNames[zone] || zone}`;
-        setZoneTargetSelector({ title, cards: zoneCards, validCardIds });
-      } else {
-        setZoneTargetSelector(null);
-      }
-    } else {
-      setZoneTargetSelector(null);
-    }
-  }, [promptType, currentPrompt]);
-
-  // Auto-open spell-stack modal for counter-targeting prompts
-  useEffect(() => {
-    setSpellStackModalOpen(promptType === PromptType.ChooseTargetSpell);
-  }, [promptType]);
+  const isAutoPassing = autoPassPlan.action === "schedulePass";
 
   return {
     isAutoPassing,

--- a/src/views/Game.tsx
+++ b/src/views/Game.tsx
@@ -797,7 +797,7 @@ export default function Game({ exitTo }: GameProps = {}) {
     libraryPeekModal,
     setLibraryPeekModal,
     zoneTargetSelector,
-    setZoneTargetSelector,
+    dismissZoneTarget,
     spellStackModalOpen,
     setSpellStackModalOpen,
   } = usePromptEffects({
@@ -1687,9 +1687,9 @@ export default function Game({ exitTo }: GameProps = {}) {
         zoneTargetSelector={zoneTargetSelector}
         onSelectZoneTarget={(cardId) => {
           casting.wrappedTargetCard(cardId);
-          setZoneTargetSelector(null);
+          dismissZoneTarget();
         }}
-        onCancelZoneTarget={() => setZoneTargetSelector(null)}
+        onCancelZoneTarget={dismissZoneTarget}
         libraryPeekModal={libraryPeekModal}
         onLibraryPeekConfirm={(selectedIds) => {
           if (libraryPeekModal!.mode === "scry") scryDecision(selectedIds);

--- a/src/views/Game.tsx
+++ b/src/views/Game.tsx
@@ -1639,6 +1639,22 @@ export default function Game({ exitTo }: GameProps = {}) {
         </div>
       )}
 
+      {promptType === PromptType.ChooseTargetSpell && !spellStackModalOpen && (
+        <div className="pointer-events-none absolute top-4 left-1/2 z-50 -translate-x-1/2">
+          <div className="pointer-events-auto flex items-center gap-3 rounded-full border border-border/70 bg-background/90 px-4 py-2 shadow-lg backdrop-blur">
+            <span className="text-sm font-semibold tracking-wide">
+              Click a glowing spell on the stack to counter it
+            </span>
+            <button
+              className="text-xs font-medium uppercase text-muted-foreground hover:text-foreground"
+              onClick={() => setSpellStackModalOpen(true)}
+            >
+              Expand
+            </button>
+          </div>
+        </div>
+      )}
+
       <StackDisplay
         stack={gameView.stack}
         resolveStackCard={resolveStackCard}
@@ -1652,6 +1668,13 @@ export default function Game({ exitTo }: GameProps = {}) {
         showPreStackFlash={shouldShowPreStackFlash}
         rightPanelCollapsed={isActionPanelCollapsed}
         playerColorMap={playerColorMap}
+        validSpellIds={
+          promptType === PromptType.ChooseTargetSpell ? (activePrompt?.validSpellIds ?? []) : []
+        }
+        onTargetSpell={(spellId) => {
+          targetSpell(spellId);
+          setSpellStackModalOpen(false);
+        }}
       />
 
       <GameModals


### PR DESCRIPTION
## Summary
- Top-of-stack is now visually unmistakable on the pile: cards trend upward, wider cascade (36px peek), and a "TOP · resolves next" badge anchors the leftmost card.
- Counter-targeting moves out of the modal and onto the pile itself. Valid stack items glow with the theme `cardRing`; clicking commits the target. The `SpellStackModal` is no longer auto-opened — it is opt-in via the renamed "View Stack" button or the new board-level instruction banner's "Expand".
- Stack-target arrows are hover-only. `buildPointerSpecs` no longer falls back to top-of-stack, so there is no permanent clutter; hovering any stack item draws a Pixi pointer from it to its target (works for stack→card, stack→player, and stack→stack like Counterspell→Bolt — all routed through existing `data-stack-object-id` / `data-card-id` / `data-player-id` resolvers).
- `usePromptEffects.ts` is refactored: `isAutoPassing` and `zoneTargetSelector` now derive from prompt inputs via `useMemo`, removing the three pre-existing `react-hooks/set-state-in-effect` violations that previously made this file unstageable.

## Why
Two issues raised against the current stack UI:

1. **"Stack resolution shows in reverse order"** — the pile cascade had `offsetY=+2` so successive cards drifted *downward* and `offsetX=15` meant cards almost fully overlapped; players could not tell which entry was the top of stack.
2. **"When the board gets messy I can't tell what I'm countering"** — the response flow opened a full-screen modal that hid the board (mana, tapped state, other stack items). Picking a target from a detached grid was disorienting with three+ spells on the stack.

## Interaction diagrams

### Before — pile shape (3-spell stack)

```
Top-of-stack at idx=last, but offsetY=+2 means it sits LOWER and
offsetX=15 means it is almost fully behind the others. The player
has no affordance to identify which card is "next to resolve".

       (heavy overlap, 15px peek per card)
   ┌──────┐
   │Counter│  ← top of stack (visually lower)
   │ Bolt  │  ← middle
   │ Wrath │  ← bottom of stack (visually higher)
   └──────┘
```

### After — pile shape

```
Top-of-stack rises visually, cards peek 36px, badge labels the
resolver. The leftmost card already had `.playable-card` glow ring.

         ┌───────────────────────┐
         │ TOP · resolves next   │
         └───────────────────────┘
   ┌──────┐                          ← top (resolves next)
   │Counter│ ┌──────┐
   │      │ │ Bolt │ ┌──────┐
   │      │ │      │ │Wrath │       ← bottom
   └──────┘ └──────┘ └──────┘
```

### Before — counter flow

```
Engine fires ChooseTargetSpell
              │
              ▼
  setSpellStackModalOpen(true)   ← useEffect auto-opens
              │
              ▼
  ┌──────────────────────────────────────────────────┐
  │                                                  │
  │            SpellStackModal (full screen)         │
  │                                                  │
  │   [Bolt]   [Wrath]   [Counter]                   │
  │    ring    dim       dim                         │
  │                                                  │
  │     ↑ click here to counter Bolt                 │
  │                                                  │
  └──────────────────────────────────────────────────┘
            ↑ board, mana, stack hidden underneath
```

### After — counter flow

```
Engine fires ChooseTargetSpell
              │
              ▼
  StackDisplay receives validSpellIds + onTargetSpell
              │
              ▼
  ┌──────────────────────────────────────────────────┐
  │  ┌──────────────────────────────────┐            │
  │  │ Click a glowing spell on the     │            │
  │  │ stack to counter it  [Expand]    │            │
  │  └──────────────────────────────────┘            │
  │                                                  │
  │      battlefield + mana stay visible             │
  │                                                  │
  │                          ┌──────┐                │
  │                          │Counter│ ← caster      │
  │                          │      │                │
  │                          │ Bolt │ ← glow ring    │
  │                          │      │  (valid)       │
  │                          │Wrath │ ← dim          │
  │                          └──────┘                │
  └──────────────────────────────────────────────────┘
```

### After — hover target arrows

```
Stack: [Wrath, Bolt→Goblin, Counter→Bolt]

Hover Wrath           Hover Bolt (→ creature)        Hover Counter (→ stack)
──────────            ──────────────────────         ────────────────────────
┌──────┐              ┌──────┐                        ┌──────┐
│Wrath │   (no        │ Bolt │── ── ──→ ┌─────────┐   │Counter│── ── ──→ ┌──────┐
└──────┘   targets)   └──────┘          │ Goblin  │   └──────┘           │ Bolt │
                                        └─────────┘                       └──────┘
                       battlefield card                                   another stack item
```

## Test plan
- [ ] In a local game, stack two then three spells; confirm the leftmost card is always the most recently cast and that the "TOP · resolves next" badge is on the right entry; confirm cards trend upward as more are added.
- [ ] Have opponent cast Lightning Bolt, then cast Counterspell. The Bolt should glow on the pile (no modal popping over the board); clicking it should commit the counter. The renamed "View Stack" button and the banner's "Expand" still open `SpellStackModal` as a fallback.
- [ ] With a multi-spell stack (Wrath, Bolt → creature, Counter → Bolt), hover each in turn: Wrath shows nothing, Bolt draws an arrow to the battlefield creature, Counterspell draws an arrow to Bolt on the stack itself. Arrows clear on mouse-leave.
- [ ] Sanity-check the auto-pass logic after the `usePromptEffects` refactor — pass-priority loop and phase-stop fast-forward should behave identically (`isAutoPassing` and `zoneTargetSelector` are now derived via `useMemo`).
- [ ] `yarn lint` passes on all five changed files (`StackDisplay`, `ChooseTargetSpell`, `pointerSpecs`, `usePromptEffects`, `Game`).

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main