### PR TITLE
feat: implement smart prio for java engine

### DIFF
--- a/forge-engine/crates/forge-agent-interface/src/java_prompt_normalizer.rs
+++ b/forge-engine/crates/forge-agent-interface/src/java_prompt_normalizer.rs
@@ -468,7 +468,7 @@ pub fn translate_java_player_action(action: &PlayerAction) -> Result<JavaAction,
                     id: card_id.clone(),
                 },
             },
-            TargetAnyChoice::None => JavaAction::Pass,
+            TargetAnyChoice::None => JavaAction::Pass { until_phase: None },
         },
         PlayerAction::TargetSpell { spell_id } => JavaAction::TargetChoice {
             target: JavaTarget {
@@ -512,7 +512,10 @@ pub fn translate_java_player_action(action: &PlayerAction) -> Result<JavaAction,
         },
         PlayerAction::PayManaCost { auto } => JavaAction::PayMana { auto: *auto },
         PlayerAction::CancelManaCost => JavaAction::CancelMana,
-        PlayerAction::Pass { .. } | PlayerAction::Concede => JavaAction::Pass,
+        PlayerAction::Pass { until_phase } => JavaAction::Pass {
+            until_phase: until_phase.clone(),
+        },
+        PlayerAction::Concede => JavaAction::Pass { until_phase: None },
         other => {
             return Err(JavaActionError {
                 action_type: player_action_label(other),

--- a/forge-engine/crates/forge-agent-interface/src/java_raw.rs
+++ b/forge-engine/crates/forge-agent-interface/src/java_raw.rs
@@ -550,7 +550,10 @@ pub enum JavaRawStackEntry {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum JavaAction {
-    Pass,
+    Pass {
+        #[serde(rename = "until", skip_serializing_if = "Option::is_none", default)]
+        until_phase: Option<String>,
+    },
     ChooseAction {
         index: usize,
     },

--- a/forge-engine/crates/self-hosted-node/src/config.rs
+++ b/forge-engine/crates/self-hosted-node/src/config.rs
@@ -48,8 +48,7 @@ struct PresetDeckCard {
 
 impl Config {
     pub fn from_env() -> Self {
-        let username = env_first("SELF_HOSTED_NODE_USERNAME", "FORGE_ROOM_NODE_USERNAME")
-            .unwrap_or_else(|| default_username("self-hosted-node"));
+        let username = format!("self-hosted-node-{}", uuid::Uuid::new_v4());
         let bot_username = env_first("SELF_HOSTED_NODE_BOT_USERNAME", "FORGE_ROOM_BOT_USERNAME")
             .unwrap_or_else(|| format!("{username}-bot"));
         let host_deck_id = env_first("SELF_HOSTED_NODE_DECK", "FORGE_ROOM_NODE_DECK")
@@ -277,13 +276,6 @@ fn infer_commander_name(deck_id: &str) -> Option<&'static str> {
         "real_teval_commander" => None,
         _ => None,
     }
-}
-
-fn default_username(prefix: &str) -> String {
-    let host = env::var("HOSTNAME")
-        .or_else(|_| env::var("COMPUTERNAME"))
-        .unwrap_or_else(|_| "local".to_string());
-    format!("{prefix}-{host}")
 }
 
 fn env_first(primary: &str, fallback: &str) -> Option<String> {

--- a/forge-engine/crates/self-hosted-node/src/engine_backend/java_backend.rs
+++ b/forge-engine/crates/self-hosted-node/src/engine_backend/java_backend.rs
@@ -873,8 +873,20 @@ fn auto_java_action(prompt: &JavaRawPrompt) -> JavaAction {
         if let Some(index) = actions.iter().find_map(|action| action.index) {
             return JavaAction::ChooseAction { index };
         }
+        return JavaAction::Pass {
+            until_phase: bot_pass_until(prompt),
+        };
     }
-    JavaAction::Pass
+    JavaAction::Pass { until_phase: None }
+}
+
+#[cfg(feature = "java-forge")]
+fn bot_pass_until(prompt: &JavaRawPrompt) -> Option<String> {
+    if prompt.snapshot.active_player == Some(prompt.player) {
+        None
+    } else {
+        Some("cleanup".to_string())
+    }
 }
 
 #[cfg(feature = "java-forge")]

--- a/forge-harness/src/main/java/forge/harness/AGENTS.md
+++ b/forge-harness/src/main/java/forge/harness/AGENTS.md
@@ -15,7 +15,7 @@ Dependency rule (do not violate): `parity → common`, `host → common`, `Main 
 
 - **common** — anything used by both engines: RNG (`CountingRandom`), logging (`DecisionLog`, `ParityLog`), snapshot base (`SnapshotExtractor`), GUI bootstrap (`HeadlessGuiBase`), deterministic ordering / id mapping / reset (`ParityOrder`, `ParityCardMap`, `ForgeEngineReset`), and the shared decision/cost/play plumbing (`ActionSpace`, `ChoiceSpace`, `CombatChoiceSpace`, `AutoPay`, `HarnessCostPlumbing`, `HarnessPlayPlumbing`, `HarnessPlayHooks`).
 - **parity** — `DeterministicController`, `DeterministicLobbyPlayer`, `GuiRepro`, `PresetDecks`.
-- **host** — `ManaBrewEngineAdapter` (the in-process facade Rust j4rs talks to), `ManaBrewInteractiveSession`, `ManaBrewInteractiveController`, `ManaBrewInteractiveLobbyPlayer`, `InteractiveSnapshotExtractor`.
+- **host** — `ManaBrewEngineAdapter` (the in-process facade Rust j4rs talks to), `ManaBrewInteractiveSession`, `ManaBrewInteractiveController`, `ManaBrewInteractiveLobbyPlayer`, `InteractiveSnapshotExtractor`, `PriorityFastForward` (skips a priority window with no roundtrip when the player has a standing pass-until; mirrors `forge-engine` `priority.rs`).
 
 ## Boundary API discipline
 

--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveController.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveController.java
@@ -61,6 +61,7 @@ public final class ManaBrewInteractiveController extends PlayerController implem
     private final HarnessCostPlumbing costPlumbing;
     private final AutoPay autoPay;
     private final HarnessPlayPlumbing playPlumbing;
+    private String passUntilPhase;
 
     public ManaBrewInteractiveController(
             final Game game,
@@ -119,6 +120,11 @@ public final class ManaBrewInteractiveController extends PlayerController implem
 
     @Override
     public List<SpellAbility> chooseSpellAbilityToPlay() {
+        final String until = passUntilPhase;
+        passUntilPhase = null;
+        if (until != null && PriorityFastForward.shouldSkip(game, until)) {
+            return null;
+        }
         while (true) {
             final List<SpellAbility> all = ChoiceSpace.sortNative(
                     new ArrayList<>(ActionSpace.getPossibleActions(player, true)),
@@ -129,6 +135,7 @@ public final class ManaBrewInteractiveController extends PlayerController implem
                 game.getStack().undo();
                 continue;
             }
+            passUntilPhase = choice.untilPhase();
             final SpellAbility selected = choice.action();
             return selected == null ? null : Lists.newArrayList(selected);
         }

--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveSession.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveSession.java
@@ -134,10 +134,12 @@ public final class ManaBrewInteractiveSession {
     static final class PriorityChoice {
         private final PriorityActionKind kind;
         private final SpellAbility action;
+        private final String untilPhase;
 
-        private PriorityChoice(final PriorityActionKind kind, final SpellAbility action) {
+        private PriorityChoice(final PriorityActionKind kind, final SpellAbility action, final String untilPhase) {
             this.kind = kind;
             this.action = action;
+            this.untilPhase = untilPhase;
         }
 
         PriorityActionKind kind() {
@@ -146,6 +148,10 @@ public final class ManaBrewInteractiveSession {
 
         SpellAbility action() {
             return action;
+        }
+
+        String untilPhase() {
+            return untilPhase;
         }
     }
 
@@ -162,21 +168,24 @@ public final class ManaBrewInteractiveSession {
                 action = actions.take();
             } catch (InterruptedException error) {
                 Thread.currentThread().interrupt();
-                return new PriorityChoice(PriorityActionKind.PASS, null);
+                return new PriorityChoice(PriorityActionKind.PASS, null, null);
             }
             final String kind = action.has("kind") ? action.get("kind").getAsString() : "";
             if ("pass".equals(kind) || "pass_priority".equals(kind)) {
-                return new PriorityChoice(PriorityActionKind.PASS, null);
+                final String until = action.has("until") && !action.get("until").isJsonNull()
+                        ? action.get("until").getAsString()
+                        : null;
+                return new PriorityChoice(PriorityActionKind.PASS, null, until);
             }
             if ("untap_land".equals(kind)) {
-                return new PriorityChoice(PriorityActionKind.UNDO, null);
+                return new PriorityChoice(PriorityActionKind.UNDO, null, null);
             }
             if ("choose_action".equals(kind)) {
                 final int index = action.get("index").getAsInt();
                 if (index < 0 || index >= actionsForPrompt.size()) {
                     throw new IllegalArgumentException("action index out of range: " + index);
                 }
-                return new PriorityChoice(PriorityActionKind.ACTION, actionsForPrompt.get(index));
+                return new PriorityChoice(PriorityActionKind.ACTION, actionsForPrompt.get(index), null);
             }
             if ("tap_land".equals(kind)) {
                 if (!action.has("manaAbilityIndex") || action.get("manaAbilityIndex").isJsonNull()) {
@@ -186,11 +195,11 @@ public final class ManaBrewInteractiveSession {
                 if (index < 0 || index >= actionsForPrompt.size()) {
                     throw new IllegalArgumentException("tap_land index out of range: " + index);
                 }
-                return new PriorityChoice(PriorityActionKind.ACTION, actionsForPrompt.get(index));
+                return new PriorityChoice(PriorityActionKind.ACTION, actionsForPrompt.get(index), null);
             }
             throw new UnsupportedOperationException("unsupported action kind: " + kind);
         }
-        return new PriorityChoice(PriorityActionKind.PASS, null);
+        return new PriorityChoice(PriorityActionKind.PASS, null, null);
     }
 
     enum ManaPaymentKind { TAP, UNTAP, PAY, CANCEL }

--- a/forge-harness/src/main/java/forge/harness/host/PriorityFastForward.java
+++ b/forge-harness/src/main/java/forge/harness/host/PriorityFastForward.java
@@ -1,0 +1,66 @@
+package forge.harness.host;
+
+import forge.game.Game;
+import forge.game.combat.Combat;
+import forge.game.phase.PhaseType;
+
+final class PriorityFastForward {
+    private PriorityFastForward() {}
+
+    static boolean shouldSkip(final Game game, final String untilPhase) {
+        if (untilPhase == null) {
+            return false;
+        }
+        final PhaseType target = parseStep(untilPhase);
+        if (target == null) {
+            return false;
+        }
+        final PhaseType current = game.getPhaseHandler().getPhase();
+        if (current == null) {
+            return false;
+        }
+        if (isActiveCombat(game, current)) {
+            return false;
+        }
+        if (!game.getStack().isEmpty()) {
+            return false;
+        }
+        return current.isBefore(target);
+    }
+
+    private static boolean isActiveCombat(final Game game, final PhaseType current) {
+        final Combat combat = game.getCombat();
+        if (combat == null || combat.getAttackers().isEmpty()) {
+            return false;
+        }
+        switch (current) {
+            case COMBAT_DECLARE_ATTACKERS:
+            case COMBAT_DECLARE_BLOCKERS:
+            case COMBAT_FIRST_STRIKE_DAMAGE:
+            case COMBAT_DAMAGE:
+            case COMBAT_END:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static PhaseType parseStep(final String step) {
+        switch (step) {
+            case "untap": return PhaseType.UNTAP;
+            case "upkeep": return PhaseType.UPKEEP;
+            case "draw": return PhaseType.DRAW;
+            case "main1": return PhaseType.MAIN1;
+            case "begin_combat": return PhaseType.COMBAT_BEGIN;
+            case "declare_attackers": return PhaseType.COMBAT_DECLARE_ATTACKERS;
+            case "declare_blockers": return PhaseType.COMBAT_DECLARE_BLOCKERS;
+            case "first_strike_damage": return PhaseType.COMBAT_FIRST_STRIKE_DAMAGE;
+            case "combat_damage": return PhaseType.COMBAT_DAMAGE;
+            case "end_combat": return PhaseType.COMBAT_END;
+            case "main2": return PhaseType.MAIN2;
+            case "end": return PhaseType.END_OF_TURN;
+            case "cleanup": return PhaseType.CLEANUP;
+            default: return null;
+        }
+    }
+}

--- a/src-tauri/src/engine_backend/java_backend.rs
+++ b/src-tauri/src/engine_backend/java_backend.rs
@@ -160,8 +160,20 @@ fn auto_java_action(prompt: &JavaRawPrompt) -> JavaAction {
         if let Some(index) = actions.iter().find_map(|action| action.index) {
             return JavaAction::ChooseAction { index };
         }
+        return JavaAction::Pass {
+            until_phase: bot_pass_until(prompt),
+        };
     }
-    JavaAction::Pass
+    JavaAction::Pass { until_phase: None }
+}
+
+#[cfg(feature = "java-forge")]
+fn bot_pass_until(prompt: &JavaRawPrompt) -> Option<String> {
+    if prompt.snapshot.active_player == Some(prompt.player) {
+        None
+    } else {
+        Some("cleanup".to_string())
+    }
 }
 
 #[cfg(feature = "java-forge")]


### PR DESCRIPTION
## Summary
Java now finally implements the same smart prio contract of the rust handler, skipping network roundtrips and speeding up the experience.

## Build artifacts
<!--
  Check the boxes below to build the corresponding installer on merge to main
  (uploaded to the Actions run, 30-day retention).
  Leave unchecked to skip — faster CI, no binaries produced.
  Tag pushes (v*) always build both and publish a GitHub Release regardless.
-->
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
