### PR TITLE
fix(engine): emit game-over prompt from java-hosted sessions

### DIFF
--- a/forge-engine/crates/forge-agent-interface/src/java_prompt_normalizer.rs
+++ b/forge-engine/crates/forge-agent-interface/src/java_prompt_normalizer.rs
@@ -15,6 +15,19 @@ use crate::prompt::{
     PlayerAction, TargetAnyChoice,
 };
 
+pub fn make_java_game_over_prompt(
+    snapshot: &JavaRawSnapshot,
+    session_id: Option<&str>,
+) -> AgentPrompt {
+    let game_view = build_game_view(snapshot, session_id, 0, &[]);
+    AgentPrompt {
+        deciding_player_id: String::new(),
+        display_events: Vec::new(),
+        source_card_id: None,
+        inner: AgentPromptInner::GameOver { game_view },
+    }
+}
+
 pub fn normalize_java_prompt(prompt: JavaRawPrompt) -> AgentPrompt {
     let JavaRawPrompt {
         session_id,

--- a/src-tauri/src/engine_backend/java_backend.rs
+++ b/src-tauri/src/engine_backend/java_backend.rs
@@ -17,10 +17,12 @@ use serde_json::Value;
 use crate::preset_decks::CardIdentity;
 #[cfg(feature = "java-forge")]
 use forge_agent_interface::java_prompt_normalizer::{
-    normalize_java_prompt, translate_java_player_action,
+    make_java_game_over_prompt, normalize_java_prompt, translate_java_player_action,
 };
 #[cfg(feature = "java-forge")]
-use forge_agent_interface::java_raw::{JavaAction, JavaRawPrompt, JavaRawPromptBody};
+use forge_agent_interface::java_raw::{
+    JavaAction, JavaRawPrompt, JavaRawPromptBody, JavaRawSnapshot,
+};
 use forge_agent_interface::prompt::{AgentPrompt, PlayerAction};
 
 pub fn unsupported_error() -> String {
@@ -146,6 +148,10 @@ fn run_game_inner(
             .unwrap_or(false)
         {
             eprintln!("[java_game_thread] Java Forge session reached game over");
+            let raw_snapshot: JavaRawSnapshot = serde_json::from_str(&snapshot_json)
+                .map_err(|err| format!("failed to parse java snapshot for game-over: {err}"))?;
+            let prompt = make_java_game_over_prompt(&raw_snapshot, Some(&session_id));
+            let _ = prompt_tx.send(prompt);
             session.end_game()?;
             return Ok(());
         }


### PR DESCRIPTION
## Summary
- Emit `AgentPromptInner::GameOver` from the Java backend poll loop when the snapshot reports `game_over`, so the existing `GameOverScreen` and 3s auto-return-to-lobby fire for Java-hosted rooms.
- Add `make_java_game_over_prompt` helper in `forge-agent-interface` that builds the prompt from the final `JavaRawSnapshot` (winner index, conceded players) — no new DTO fields, just a thin wrapper over the existing `build_game_view`.

## Why
In Java-hosted rooms (`MANABREW_ENGINE_BACKEND=java-forge`), the poll loop in `src-tauri/src/engine_backend/java_backend.rs` detected `snapshot.game_over == true`, called `session.end_game()`, and exited the thread **without ever sending a prompt**. The client's `useGameEventListeners` therefore never saw `AgentPromptInner::GameOver`, so `GameOverScreen` never rendered and the player was stuck in a dead game view. Multiplayer (commander) was equally broken because the remote-prompt relay had nothing to forward.

Mirrors the Rust engine's emit on `GameNotification::GameOver` (`forge-agent-interface/src/agent_impl/mod.rs:1423`). The Java snapshot already carries `game_over`, `winner`, and per-player `has_conceded`; the existing normalizer at `java_prompt_normalizer.rs:744-752` maps them into `GameViewDto` correctly — so this PR is purely the missing emit site, no Java changes, no DTO changes.

Out of scope (deferred per discussion): the spectate option on the game-over screen. Multiplayer game-over also returns to lobby for now.

## Test plan
- [x] `cargo check -p forge-agent-interface --features java-forge -p manabrew` — clean
- [x] `cargo fmt` passes via pre-commit lint-staged
- [ ] Manual: `MANABREW_ENGINE_BACKEND=java-forge yarn tauri dev`, start a 1v1 game, play to lethal — `GameOverScreen` shows `You Win!` / `You Lose!` with final life and turn, then navigates to `/lobby` after 3s. Terminal logs `[java_game_thread] Java Forge session reached game over`.
- [ ] Manual: same flow but concede via the player panel — `You conceded` heading, then auto-return to lobby.
- [ ] Manual: Java-hosted commander pod (3+ seats) — host and every remote seat show `GameOverScreen` with correct winner/conceder text, each auto-returns to its lobby. Remote console logs `[MP] remote_prompt gameOver for player-N`.

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main