### PR TITLE
feat(editor): warn on cards the engine doesn't implement

### DIFF
--- a/src-tauri/src/card_db.rs
+++ b/src-tauri/src/card_db.rs
@@ -78,7 +78,14 @@ pub fn get_card_name_index() -> &'static std::collections::HashSet<String> {
 }
 
 pub fn card_name_known(name: &str) -> bool {
-    get_card_name_index().contains(&name.to_lowercase())
+    let index = get_card_name_index();
+    if index.contains(&name.to_lowercase()) {
+        return true;
+    }
+    if let Some((front, _)) = name.split_once(" // ") {
+        return index.contains(&front.to_lowercase());
+    }
+    false
 }
 
 /// mmap the archive, parse it through `CardDatabase::load_from_archive`,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -70,6 +70,11 @@ pub fn get_preset_decks() -> Vec<PresetDeckInfo> {
 }
 
 #[tauri::command]
+pub fn is_card_supported(name: String) -> bool {
+    crate::card_db::card_name_known(&name)
+}
+
+#[tauri::command]
 pub async fn start_multiplayer_game(
     app: AppHandle,
     gm: State<'_, GameManager>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -85,6 +85,7 @@ pub fn run() {
             commands::restore_snapshot,
             commands::get_prompt,
             commands::get_preset_decks,
+            commands::is_card_supported,
             server_commands::server_connect,
             server_commands::server_disconnect,
             server_commands::server_spawn_ai_bot,

--- a/src/components/editor/DeckBuilder.tsx
+++ b/src/components/editor/DeckBuilder.tsx
@@ -92,6 +92,7 @@ import {
   setLastSavedSnapshotRef,
 } from "./deckBuilder.unsavedChanges";
 import { useScryfallStore } from "@/stores/useScryfallStore";
+import { useUnsupportedCards } from "@/hooks/useUnsupportedCards";
 
 // ─── Quick Search ─────────────────────────────────────────────────────────────
 
@@ -484,17 +485,22 @@ export function DeckBuilder({
   })();
 
   // Filter
+  const unsupportedNames = useUnsupportedCards(currentDeck);
+  const hasUnsupportedCards = unsupportedNames.size > 0;
+
   // Compute deck legality for conditional save button
   const deckFormat = getFormat(currentDeck.format ?? "standard");
-  const isDeckLegal = deckFormat
-    ? validateDeckSections(
-        {
-          deck: currentDeck,
-          commanderName: currentDeck.commanders?.[0]?.name,
-        },
-        deckFormat,
-      ).legal
-    : false;
+  const isDeckLegal =
+    !hasUnsupportedCards &&
+    (deckFormat
+      ? validateDeckSections(
+          {
+            deck: currentDeck,
+            commanderName: currentDeck.commanders?.[0]?.name,
+          },
+          deckFormat,
+        ).legal
+      : false);
 
   const filterLc = deckFilter.toLowerCase();
   const filteredMain = useMemo(
@@ -788,6 +794,10 @@ export function DeckBuilder({
   }
 
   function handleSave() {
+    if (hasUnsupportedCards) {
+      handleSaveDraft();
+      return;
+    }
     saveCurrentDeck();
     const snapshot = buildDeckSnapshot(currentDeck);
     setLastSavedSnapshot(snapshot);
@@ -799,7 +809,13 @@ export function DeckBuilder({
     const snapshot = buildDeckSnapshot({ ...currentDeck, draft: true });
     setLastSavedSnapshot(snapshot);
     setUnsavedState(snapshot, snapshot);
-    toast.success(`Draft "${currentDeck.name}" saved`);
+    if (hasUnsupportedCards) {
+      toast.warning(
+        `Saved "${currentDeck.name}" as draft — ${unsupportedNames.size} card${unsupportedNames.size === 1 ? "" : "s"} not implemented by the engine`,
+      );
+    } else {
+      toast.success(`Draft "${currentDeck.name}" saved`);
+    }
   }
 
   /**
@@ -992,7 +1008,11 @@ export function DeckBuilder({
               size="sm"
               variant="outline"
               className="h-7 shrink-0 gap-1 text-xs border-warning/50 text-warning hover:bg-warning/10"
-              title="Deck has errors — save as draft (not playable)"
+              title={
+                hasUnsupportedCards
+                  ? `${unsupportedNames.size} card${unsupportedNames.size === 1 ? "" : "s"} not implemented by the engine — draft only, can't be played`
+                  : "Deck has errors — save as draft (not playable)"
+              }
               onClick={handleSaveDraft}
             >
               <FileBox className="h-3.5 w-3.5" />
@@ -1343,7 +1363,7 @@ export function DeckBuilder({
           </div>
         )}
 
-        <DeckValidationPanel />
+        <DeckValidationPanel unsupportedNames={unsupportedNames} />
         <TokenSection
           tokens={mergedTokens}
           cardSize={cardSize}

--- a/src/components/editor/DeckBuilder.tsx
+++ b/src/components/editor/DeckBuilder.tsx
@@ -182,6 +182,7 @@ function QuickCardSearch({
         <div className="absolute z-50 top-full left-0 right-0 mt-1 bg-popover border rounded-md shadow-lg max-h-80 overflow-y-auto min-w-[280px]">
           {results.map((sc) => {
             const count = getCount(sc.name);
+            const thumb = sc.image_uris?.small ?? sc.card_faces?.[0]?.image_uris?.small;
             return (
               <div
                 key={sc.id}
@@ -189,9 +190,9 @@ function QuickCardSearch({
                 onClick={() => onAdd(sc)}
                 title={`Add ${sc.name}`}
               >
-                {sc.image_uris?.small && (
+                {thumb && (
                   <ScryfallImg
-                    src={sc.image_uris.small}
+                    src={thumb}
                     alt=""
                     className="w-8 h-11 rounded object-cover object-top shrink-0"
                   />

--- a/src/components/editor/DeckListView.tsx
+++ b/src/components/editor/DeckListView.tsx
@@ -30,6 +30,7 @@ import {
   Trash2,
   Bookmark,
   Check,
+  AlertTriangle,
 } from "lucide-react";
 import { GameIcon } from "@/components/game/GameIcon";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
@@ -48,6 +49,7 @@ import {
   EmptyDropZone,
 } from "./deckEditor.primitives";
 import { buildCardActions, handleCardClick } from "./deckEditor.utils";
+import { useIsUnsupported } from "@/stores/useCardSupportStore";
 
 type CardLocation = "main" | "side" | "maybe";
 
@@ -360,6 +362,7 @@ function DraggableStackCard({
     id: dragId,
     data: { type: "deck-card", card: group.card, name: group.card.name },
   });
+  const unsupported = useIsUnsupported(group.card.name);
 
   return (
     <div
@@ -370,15 +373,25 @@ function DraggableStackCard({
         "absolute left-0 group cursor-grab active:cursor-grabbing transition-[top] duration-200 ease-out",
         isDragging && "opacity-30",
         isSelected && cn(CARD_RING.selected, "z-50"),
+        unsupported && "ring-2 ring-warning/70 rounded-[4%]",
       )}
       style={{ top: topOffset, width: cardWidth, zIndex: index + 1 }}
       data-card-name={group.card.name}
+      data-card-supported={unsupported ? "false" : undefined}
       onMouseEnter={() => onCardHover(index)}
       onMouseLeave={onCardLeave}
       onClick={(e) => handleCardClick(e, group.card.name, onSelect, onShowInfo)}
     >
       <CardThumbnail card={group.card} />
       <CardCountBadge count={group.count} className="border-white/30 shadow" />
+      {unsupported && (
+        <div
+          className="absolute top-1 right-1 z-30 rounded-full bg-warning/90 text-white p-0.5 shadow"
+          title="Not implemented by the engine — deck can only be saved as draft"
+        >
+          <AlertTriangle className="h-3 w-3" />
+        </div>
+      )}
       <CardHoverOverlay
         actions={buildCardActions(
           onAddOne,
@@ -536,6 +549,7 @@ function CardVisual({
     id: dragId,
     data: { type: "deck-card", card: group.card, name: group.card.name },
   });
+  const unsupported = useIsUnsupported(group.card.name);
 
   const visualContent = (
     <div
@@ -546,12 +560,22 @@ function CardVisual({
         "relative group cursor-grab active:cursor-grabbing select-none transition-[box-shadow]",
         isDragging && "opacity-30",
         isSelected && cn(CARD_RING.selected, "rounded-lg"),
+        unsupported && "ring-2 ring-warning/70 rounded-lg",
       )}
       data-card-name={group.card.name}
+      data-card-supported={unsupported ? "false" : undefined}
       onClick={(e) => handleCardClick(e, group.card.name, onSelect, onShowInfo)}
     >
       <CardThumbnail card={group.card} />
       <CardCountBadge count={group.count} />
+      {unsupported && (
+        <div
+          className="absolute top-1 right-1 z-30 rounded-full bg-warning/90 text-white p-0.5 shadow"
+          title="Not implemented by the engine — deck can only be saved as draft"
+        >
+          <AlertTriangle className="h-3 w-3" />
+        </div>
+      )}
       <div className="absolute top-1 left-1 z-20 flex gap-0.5">
         {showCommander && (
           <button
@@ -716,6 +740,7 @@ function CardRow({
     id: dragId,
     data: { type: "deck-card", card: group.card, name: group.card.name },
   });
+  const unsupported = useIsUnsupported(group.card.name);
 
   const rowContent = (
     <div
@@ -726,8 +751,10 @@ function CardRow({
         "flex items-center gap-1 group hover:bg-muted/40 rounded px-1 py-0.5 cursor-grab active:cursor-grabbing select-none transition-colors",
         isDragging && "opacity-30",
         isSelected && "bg-selection/20",
+        unsupported && "bg-warning/10 ring-1 ring-warning/40",
       )}
       data-card-name={group.card.name}
+      data-card-supported={unsupported ? "false" : undefined}
       onClick={(e) => {
         e.stopPropagation();
         if (e.shiftKey && onSelect) {
@@ -752,7 +779,20 @@ function CardRow({
       <span className="text-xs font-mono w-4 text-right text-muted-foreground shrink-0">
         {group.count}
       </span>
-      <span className="text-sm flex-1 truncate" title={group.card.name}>
+      {unsupported && (
+        <AlertTriangle
+          className="h-3 w-3 text-warning shrink-0"
+          aria-label="Card not supported by the engine"
+        />
+      )}
+      <span
+        className={cn("text-sm flex-1 truncate", unsupported && "text-warning")}
+        title={
+          unsupported
+            ? `${group.card.name} — not implemented by the engine; deck can only be saved as draft`
+            : group.card.name
+        }
+      >
         {group.card.name}
       </span>
       {group.card.manaCost && (

--- a/src/components/editor/DeckValidationPanel.tsx
+++ b/src/components/editor/DeckValidationPanel.tsx
@@ -3,7 +3,7 @@ import { AlertTriangle, ChevronDown, ChevronRight } from "lucide-react";
 import { useDeckStore } from "@/stores/useDeckStore";
 import { getFormat, validateDeckSections } from "@/lib/formats";
 
-export function DeckValidationPanel() {
+export function DeckValidationPanel({ unsupportedNames }: { unsupportedNames?: Set<string> }) {
   const [collapsed, setCollapsed] = useState(false);
   const { currentDeck } = useDeckStore();
 
@@ -18,9 +18,18 @@ export function DeckValidationPanel() {
     format,
   );
 
-  if (validation.legal) return null;
+  const unsupportedList = unsupportedNames ? [...unsupportedNames].sort() : [];
+  const hasUnsupported = unsupportedList.length > 0;
 
-  const count = validation.errors.length;
+  if (validation.legal && !hasUnsupported) return null;
+
+  const unsupportedErrors = hasUnsupported
+    ? [
+        `${unsupportedList.length} card${unsupportedList.length === 1 ? "" : "s"} not implemented by the engine — playable build blocked, save as draft only: ${unsupportedList.join(", ")}`,
+      ]
+    : [];
+  const errors = [...unsupportedErrors, ...validation.errors];
+  const count = errors.length;
 
   return (
     <div className="border-t border-destructive/30 bg-destructive/5 shrink-0">
@@ -49,7 +58,7 @@ export function DeckValidationPanel() {
       </div>
       {!collapsed && (
         <ul className="px-3 pb-2 space-y-0.5 ml-5">
-          {validation.errors.map((err, i) => (
+          {errors.map((err, i) => (
             <li key={i} className="text-xs text-destructive/80 flex items-start gap-1.5">
               <span className="shrink-0 mt-0.5">&#x2022;</span>
               <span>{err}</span>

--- a/src/components/game/CardPreview.tsx
+++ b/src/components/game/CardPreview.tsx
@@ -227,19 +227,31 @@ export function CardPreview({
     collectorNumber: deckCard.cardNumber,
   });
   const faces = scryfallCard?.card_faces;
-  const hasFlippableFaces =
+  const facesHaveImages =
     !!faces &&
     faces.length >= 2 &&
     !!faces[0].image_uris?.[imageSize] &&
     !!faces[1].image_uris?.[imageSize];
-  const doubleFacedData = hasFlippableFaces
+  const derivedBackImageUrl =
+    !facesHaveImages && deckCard.isDoubleFaced && imageUrl?.includes("/front/")
+      ? imageUrl.replace("/front/", "/back/")
+      : null;
+  const doubleFacedData = facesHaveImages
     ? {
         frontImageUrl: faces![0].image_uris![imageSize],
         backImageUrl: faces![1].image_uris![imageSize],
         frontName: faces![0].name,
         backName: faces![1].name,
       }
-    : null;
+    : derivedBackImageUrl
+      ? {
+          frontImageUrl: imageUrl,
+          backImageUrl: derivedBackImageUrl,
+          frontName: card.name,
+          backName: card.name,
+        }
+      : null;
+  const hasFlippableFaces = !!doubleFacedData;
 
   useEffect(() => {
     if (!onFlip || !hasFlippableFaces) return;

--- a/src/components/game/CardPreview.tsx
+++ b/src/components/game/CardPreview.tsx
@@ -1,5 +1,5 @@
 import { createPortal } from "react-dom";
-import { Loader2 } from "lucide-react";
+import { Loader2, RotateCw } from "lucide-react";
 import type { DeckCard, GameCard } from "@/types/manabrew";
 import { CounterDisplay } from "@/components/game/CounterBadge";
 import { GameIcon } from "@/components/game/GameIcon";
@@ -18,6 +18,7 @@ import type { CSSProperties } from "react";
 import { useGameStore } from "@/stores/useGameStore";
 import { asDeckCard } from "@/lib/decks";
 import { ScryfallImg } from "@/components/ScryfallImg";
+import { useCard } from "@/stores/useScryfallStore";
 
 interface CardPreviewProps {
   card: GameCard;
@@ -32,6 +33,8 @@ interface CardPreviewProps {
   onSelectAction?: (action: HandActionOption) => void;
   /** Called to dismiss the preview. */
   onDismiss?: () => void;
+  /** Toggle the back face of a double-faced card. */
+  onFlip?: () => void;
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
   isSticky?: boolean;
@@ -200,6 +203,7 @@ export function CardPreview({
   actions,
   onSelectAction,
   onDismiss,
+  onFlip,
   onMouseEnter,
   onMouseLeave,
   isSticky = false,
@@ -217,12 +221,39 @@ export function CardPreview({
   const deckCard: DeckCard = deck ? asDeckCard(deck, card) : (card as unknown as DeckCard);
   const isLoading = false;
   const imageUrl = deckCard.uris[imageSize];
-  const doubleFacedData = {
-    frontImageUrl: deckCard.uris[imageSize],
-    backImageUrl: null,
-    frontName: deckCard.name,
-    backName: undefined,
-  };
+  const scryfallCard = useCard({
+    name: card.name,
+    setCode: deckCard.setCode,
+    collectorNumber: deckCard.cardNumber,
+  });
+  const faces = scryfallCard?.card_faces;
+  const hasFlippableFaces =
+    !!faces &&
+    faces.length >= 2 &&
+    !!faces[0].image_uris?.[imageSize] &&
+    !!faces[1].image_uris?.[imageSize];
+  const doubleFacedData = hasFlippableFaces
+    ? {
+        frontImageUrl: faces![0].image_uris![imageSize],
+        backImageUrl: faces![1].image_uris![imageSize],
+        frontName: faces![0].name,
+        backName: faces![1].name,
+      }
+    : null;
+
+  useEffect(() => {
+    if (!onFlip || !hasFlippableFaces) return;
+    function handleFlipKey(e: KeyboardEvent) {
+      if (e.key.toLowerCase() === "f" && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        const target = e.target as HTMLElement | null;
+        if (target?.matches?.("input, textarea, [contenteditable='true']")) return;
+        e.preventDefault();
+        onFlip!();
+      }
+    }
+    window.addEventListener("keydown", handleFlipKey);
+    return () => window.removeEventListener("keydown", handleFlipKey);
+  }, [onFlip, hasFlippableFaces]);
 
   // Dismiss on Escape, outside click, or number key shortcut
   useEffect(() => {
@@ -299,14 +330,9 @@ export function CardPreview({
     top = Math.min(Math.max(anchorY - cardHeight / 2, 8), window.innerHeight - cardHeight - 8);
   }
 
-  const hasDoubleFace = !!doubleFacedData?.backImageUrl;
+  const hasDoubleFace = !!doubleFacedData;
   const currentImageUrl = hasDoubleFace && showBackFace ? doubleFacedData.backImageUrl : imageUrl;
-  const currentCardName =
-    hasDoubleFace && showBackFace
-      ? doubleFacedData.backName
-      : hasDoubleFace && !showBackFace
-        ? doubleFacedData.frontName
-        : card.name;
+  const currentCardName = hasDoubleFace && showBackFace ? doubleFacedData.backName : card.name;
 
   return createPortal(
     <>
@@ -372,6 +398,20 @@ export function CardPreview({
                   />
                 )}
                 <CardDetailOverlay card={card} />
+                {hasDoubleFace && onFlip && (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onFlip();
+                    }}
+                    className="absolute top-2 right-2 z-20 inline-flex items-center gap-1 rounded-full bg-black/65 hover:bg-black/85 text-white text-[10px] font-semibold uppercase tracking-wide px-2 py-1 shadow pointer-events-auto"
+                    title={`Flip card (F) — ${showBackFace ? doubleFacedData.frontName : doubleFacedData.backName}`}
+                  >
+                    <RotateCw className="h-3 w-3" />
+                    {showBackFace ? "Front" : "Back"}
+                  </button>
+                )}
               </>
             ) : (
               <div className="w-full h-full p-4 flex flex-col gap-2 bg-card">

--- a/src/components/game/CardPreview.tsx
+++ b/src/components/game/CardPreview.tsx
@@ -221,12 +221,12 @@ export function CardPreview({
   const deckCard: DeckCard = deck ? asDeckCard(deck, card) : (card as unknown as DeckCard);
   const isLoading = false;
   const imageUrl = deckCard.uris[imageSize];
-  const scryfallCard = useCard({
+  const scryfallEntry = useCard({
     name: card.name,
     setCode: deckCard.setCode,
     collectorNumber: deckCard.cardNumber,
   });
-  const faces = scryfallCard?.card_faces;
+  const faces = scryfallEntry?.info?.card_faces;
   const facesHaveImages =
     !!faces &&
     faces.length >= 2 &&

--- a/src/components/game/HoverCardPreview.tsx
+++ b/src/components/game/HoverCardPreview.tsx
@@ -40,6 +40,7 @@ export function HoverCardPreview({
       actions={actions}
       onSelectAction={onSelectAction}
       onDismiss={preview.dismiss}
+      onFlip={preview.flipCard}
       onMouseEnter={preview.onMouseEnterPreview}
       onMouseLeave={preview.onMouseLeavePreview}
       slot={slot}

--- a/src/hooks/useUnsupportedCards.ts
+++ b/src/hooks/useUnsupportedCards.ts
@@ -1,0 +1,35 @@
+import { useEffect, useMemo } from "react";
+import { useCardSupportStore, selectUnsupportedNames } from "@/stores/useCardSupportStore";
+import type { Deck } from "@/types/manabrew";
+
+function collectDeckNames(deck: Deck): string[] {
+  const names = new Set<string>();
+  const push = (name: string | undefined) => {
+    if (name) names.add(name);
+  };
+  for (const c of deck.cards) push(c.name);
+  for (const c of deck.sideboard) push(c.name);
+  for (const c of deck.commanders ?? []) push(c.name);
+  for (const c of deck.maybeboard ?? []) push(c.name);
+  for (const c of deck.attractions ?? []) push(c.name);
+  for (const c of deck.contraptions ?? []) push(c.name);
+  for (const c of deck.schemes ?? []) push(c.name);
+  for (const c of deck.planes ?? []) push(c.name);
+  if (deck.companion) push(deck.companion.name);
+  return [...names];
+}
+
+export function useUnsupportedCards(deck: Deck): Set<string> {
+  const names = useMemo(() => collectDeckNames(deck), [deck]);
+  const ensureChecked = useCardSupportStore((s) => s.ensureChecked);
+  const status = useCardSupportStore((s) => s.status);
+
+  useEffect(() => {
+    if (names.length > 0) void ensureChecked(names);
+  }, [names, ensureChecked]);
+
+  return useMemo(
+    () => selectUnsupportedNames({ status, ensureChecked }, names),
+    [status, names, ensureChecked],
+  );
+}

--- a/src/stores/useCardSupportStore.ts
+++ b/src/stores/useCardSupportStore.ts
@@ -1,0 +1,69 @@
+import { create } from "zustand";
+import { getPlatform } from "@/platform";
+
+type Status = "supported" | "unsupported" | "pending";
+
+interface CardSupportState {
+  status: Record<string, Status>;
+  ensureChecked: (names: string[]) => Promise<void>;
+}
+
+function normalize(name: string): string {
+  return name.toLowerCase();
+}
+
+export const useCardSupportStore = create<CardSupportState>((set, get) => ({
+  status: {},
+  ensureChecked: async (names) => {
+    const current = get().status;
+    const toCheck: string[] = [];
+    const seen = new Set<string>();
+    for (const raw of names) {
+      const key = normalize(raw);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      if (current[key] === undefined) toCheck.push(raw);
+    }
+    if (toCheck.length === 0) return;
+
+    set((s) => {
+      const next = { ...s.status };
+      for (const raw of toCheck) next[normalize(raw)] = "pending";
+      return { status: next };
+    });
+
+    const platform = getPlatform();
+    const results = await Promise.all(
+      toCheck.map(async (raw) => {
+        try {
+          const ok = await platform.invoke<boolean>("is_card_supported", { name: raw });
+          return [normalize(raw), ok ? "supported" : "unsupported"] as const;
+        } catch (err) {
+          console.warn("[card-support] check failed for", raw, err);
+          return [normalize(raw), "supported"] as const;
+        }
+      }),
+    );
+
+    set((s) => {
+      const next = { ...s.status };
+      for (const [key, value] of results) next[key] = value;
+      return { status: next };
+    });
+  },
+}));
+
+export function selectUnsupportedNames(
+  state: CardSupportState,
+  names: Iterable<string>,
+): Set<string> {
+  const out = new Set<string>();
+  for (const raw of names) {
+    if (state.status[normalize(raw)] === "unsupported") out.add(raw);
+  }
+  return out;
+}
+
+export function useIsUnsupported(name: string): boolean {
+  return useCardSupportStore((s) => s.status[normalize(name)] === "unsupported");
+}

--- a/src/workers/game-engine.worker.ts
+++ b/src/workers/game-engine.worker.ts
@@ -12,6 +12,7 @@ import init, {
   test_rng,
   test_foundation,
   load_card_archive,
+  has_card,
   run_interactive_game,
   run_multiplayer_game,
   limited_list_sealed_templates,
@@ -525,6 +526,15 @@ async function handleCommand(command: string, args?: Record<string, unknown>): P
         ...deck,
         coverCardName: deck.coverCardName ?? choosePresetCoverCardName(deck.cards),
       }));
+    }
+
+    case "is_card_supported": {
+      const name = (args?.name as string) ?? "";
+      if (!name) return false;
+      if (has_card(name)) return true;
+      const idx = name.indexOf(" // ");
+      if (idx > 0) return has_card(name.slice(0, idx));
+      return false;
     }
 
     case "limited_list_sealed_templates":


### PR DESCRIPTION
## Summary
- **Unsupported-card safeguard** — adds `is_card_supported` (Tauri command + worker command) so the UI can ask the engine whether a card is in the Forge cardset. Deck editor batches lookups for the current deck, highlights any unimplemented card, surfaces them in the validation panel, and forces **Save Draft** so the deck can't be picked for a game. (Drafts are already filtered out of `CreateGameDialog` / `DeckVsSelector` / `myDecks.utils`, so blocking the playable save is enough.)
- **DFC preview flip button** — `CardPreview` now detects double-faced cards (via Scryfall `card_faces` when cached, or via the `/front/` → `/back/` URL pattern off `deckCard.isDoubleFaced` when not). A ⟳ Front/Back chip appears top-right of the preview; **F** toggles it. Works from every zone, including the command zone.
- **Quick-add thumbnail fix** — DFC results in the deck editor's quick-add popup were rendering blank because Scryfall puts art on `card_faces[*].image_uris` for transform/MDFC instead of the top-level `image_uris`. Fall back to `card_faces[0].image_uris.small`.

## Why
Scryfall search lets a player add any printed card, but the engine only knows the cards in `forge/forge-gui/res/cardsfolder`. Those decks silently broke at game start. While in there: the in-game preview never had a way to see the back of a DFC, and DFC rows in quick-add were rendering iconless. Both QoL gaps that hit the same flow.

## Test plan
- Built a Pauper deck with `Turbulent Fen` (no Forge script). The row gains a warning ring + ⚠ icon, the validation panel lists the card, and Save flips to **Save Draft** in the header.
- DFC probe via `\"Fable of the Mirror-Breaker // Reflection of Kiki-Jiki\"` resolves through the front-face fallback on both Tauri (`is_card_supported`) and Web (worker → `has_card`).
- Hover `Venom, Lethal Protector // Eddie Brock` from the command zone → ⟳ Back chip appears top-right of the preview, click or press F to swap to the back face.
- Quick-add searches for transform/MDFC names now show the front-face art in the result rows.

<!-- screenshot: drag the deck-editor warning screenshot from local cache here -->

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main