### PR TITLE
ci: swap jetli/wasm-pack-action for taiki-e/install-action

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -37,9 +37,9 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
+        uses: taiki-e/install-action@v2
         with:
-          version: "v0.13.1"
+          tool: wasm-pack@0.13.1
 
       - run: yarn
       - run: yarn build:wasm
@@ -144,9 +144,9 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
+        uses: taiki-e/install-action@v2
         with:
-          version: "v0.13.1"
+          tool: wasm-pack@0.13.1
 
       - run: yarn
 

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -122,12 +122,9 @@ jobs:
           shared-key: tauri-macos
 
       - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
+        uses: taiki-e/install-action@v2
         with:
-          # Pin to the same version Dockerfile.web uses. `version: latest`
-          # fetches v0.15.0+, which jetli/wasm-pack-action's platform-mapper
-          # doesn't recognise on Windows ("Unsupported platform: x64").
-          version: "v0.13.1"
+          tool: wasm-pack@0.13.1
 
       - run: yarn
 
@@ -274,12 +271,9 @@ jobs:
           shared-key: tauri-windows
 
       - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
+        uses: taiki-e/install-action@v2
         with:
-          # Pin to the same version Dockerfile.web uses. `version: latest`
-          # fetches v0.15.0+, which jetli/wasm-pack-action's platform-mapper
-          # doesn't recognise on Windows ("Unsupported platform: x64").
-          version: "v0.13.1"
+          tool: wasm-pack@0.13.1
 
       - run: yarn
 


### PR DESCRIPTION
## Summary
- Replace `jetli/wasm-pack-action@v0.4.0` with `taiki-e/install-action@v2` across all four CI call sites (`build-checks.yml` x2, `release-artifacts.yml` macOS + Windows).
- Drop the now-stale comments about the v0.13.1 pin / Dockerfile.web — `taiki-e/install-action` has its own up-to-date platform mapping.
- wasm-pack version stays pinned at `0.13.1`.

## Why
The Windows release job started failing during `Install wasm-pack` with `Error: Unsupported platform: x64`. The error comes from `jetli/wasm-pack-action`'s own platform-mapper, which the current Windows runner image no longer matches. The action has been unmaintained for years. `taiki-e/install-action` is actively maintained, supports wasm-pack, and works across Linux/macOS/Windows runners.

## Test plan
- [x] CI: `build-checks` workflow runs on this PR — both `wasm-pack` install steps must succeed on `ubuntu-latest`.
- [ ] CI: `release-artifacts` workflow — macOS + Windows `Install wasm-pack` steps must succeed (verified by tag push or by checking the `[ ] Build Windows .exe` box on a `main` merge).

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [x] Build Windows .exe / .msi on merge to main