### PR TITLE
fix(ci): send discord payload via file to preserve utf-8 on windows

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -229,6 +229,14 @@ jobs:
               }]
             }')
 
+          # Write PAYLOAD to a file and use --data-binary @file so curl reads
+          # the body bytes verbatim. Passing via -d "$PAYLOAD" goes through
+          # Windows argv encoding (Bash → CreateProcess UTF-16 → curl), which
+          # mangles raw-UTF-8 emoji in the JSON and trips Discord error 50109
+          # (invalid JSON). Mac argv preserves UTF-8 so it didn't surface there.
+          REQ=$(mktemp)
+          printf '%s' "$PAYLOAD" > "$REQ"
+
           post_discord() {
             local attempt=0
             local max_attempts=3
@@ -240,21 +248,21 @@ jobs:
               http=$(curl -sS -X POST \
                 -H "Authorization: Bot $BOT_TOKEN" \
                 -H "Content-Type: application/json" \
-                -d "$PAYLOAD" \
+                --data-binary "@$REQ" \
                 -o "$body" \
                 -w "%{http_code}" \
                 "https://discord.com/api/v10/channels/$CHANNEL_ID/messages" || echo "000")
 
               if [ "$http" -ge 200 ] && [ "$http" -lt 300 ]; then
                 echo "Discord notification posted (HTTP $http)."
-                rm -f "$body"
+                rm -f "$body" "$REQ"
                 return 0
               fi
 
               echo "::warning::Discord API returned HTTP $http on attempt $attempt: $(cat "$body" 2>/dev/null)"
               if [ "$attempt" -ge "$max_attempts" ]; then
                 echo "::warning::Giving up on Discord notification after $attempt attempts; artifact build itself succeeded."
-                rm -f "$body"
+                rm -f "$body" "$REQ"
                 return 0
               fi
               sleep "$delay"
@@ -414,6 +422,14 @@ jobs:
               }]
             }')
 
+          # Write PAYLOAD to a file and use --data-binary @file so curl reads
+          # the body bytes verbatim. Passing via -d "$PAYLOAD" goes through
+          # Windows argv encoding (Bash → CreateProcess UTF-16 → curl), which
+          # mangles raw-UTF-8 emoji in the JSON and trips Discord error 50109
+          # (invalid JSON). Mac argv preserves UTF-8 so it didn't surface there.
+          REQ=$(mktemp)
+          printf '%s' "$PAYLOAD" > "$REQ"
+
           post_discord() {
             local attempt=0
             local max_attempts=3
@@ -425,21 +441,21 @@ jobs:
               http=$(curl -sS -X POST \
                 -H "Authorization: Bot $BOT_TOKEN" \
                 -H "Content-Type: application/json" \
-                -d "$PAYLOAD" \
+                --data-binary "@$REQ" \
                 -o "$body" \
                 -w "%{http_code}" \
                 "https://discord.com/api/v10/channels/$CHANNEL_ID/messages" || echo "000")
 
               if [ "$http" -ge 200 ] && [ "$http" -lt 300 ]; then
                 echo "Discord notification posted (HTTP $http)."
-                rm -f "$body"
+                rm -f "$body" "$REQ"
                 return 0
               fi
 
               echo "::warning::Discord API returned HTTP $http on attempt $attempt: $(cat "$body" 2>/dev/null)"
               if [ "$attempt" -ge "$max_attempts" ]; then
                 echo "::warning::Giving up on Discord notification after $attempt attempts; artifact build itself succeeded."
-                rm -f "$body"
+                rm -f "$body" "$REQ"
                 return 0
               fi
               sleep "$delay"
@@ -571,6 +587,14 @@ jobs:
               }]
             }')
 
+          # Write PAYLOAD to a file and use --data-binary @file so curl reads
+          # the body bytes verbatim. Passing via -d "$PAYLOAD" goes through
+          # Windows argv encoding (Bash → CreateProcess UTF-16 → curl), which
+          # mangles raw-UTF-8 emoji in the JSON and trips Discord error 50109
+          # (invalid JSON). Mac argv preserves UTF-8 so it didn't surface there.
+          REQ=$(mktemp)
+          printf '%s' "$PAYLOAD" > "$REQ"
+
           post_discord() {
             local attempt=0
             local max_attempts=3
@@ -582,21 +606,21 @@ jobs:
               http=$(curl -sS -X POST \
                 -H "Authorization: Bot $BOT_TOKEN" \
                 -H "Content-Type: application/json" \
-                -d "$PAYLOAD" \
+                --data-binary "@$REQ" \
                 -o "$body" \
                 -w "%{http_code}" \
                 "https://discord.com/api/v10/channels/$CHANNEL_ID/messages" || echo "000")
 
               if [ "$http" -ge 200 ] && [ "$http" -lt 300 ]; then
                 echo "Discord notification posted (HTTP $http)."
-                rm -f "$body"
+                rm -f "$body" "$REQ"
                 return 0
               fi
 
               echo "::warning::Discord API returned HTTP $http on attempt $attempt: $(cat "$body" 2>/dev/null)"
               if [ "$attempt" -ge "$max_attempts" ]; then
                 echo "::warning::Giving up on Discord notification after $attempt attempts; artifact build itself succeeded."
-                rm -f "$body"
+                rm -f "$body" "$REQ"
                 return 0
               fi
               sleep "$delay"


### PR DESCRIPTION
## Summary
- Write the Discord embed JSON to a tempfile via `printf`, then pass it to curl with `--data-binary @file` instead of `-d "$PAYLOAD"`. Applied to all three Discord-notify steps (mac, windows, release).

## Why
Follow-up to #103. With that PR's diagnostic helper in place, run [`26772038930`](https://github.com/witchesofthehill/manabrew/actions/runs/26772038930) surfaced Discord's actual error from the Windows job:

```
HTTP 400: {"message": "The request body contains invalid JSON.", "code": 50109}
```

…three times, then degraded to a `::warning::` (the build stayed green, as intended). But the embed never posted.

Root cause: `curl -d "$PAYLOAD"` passes the JSON as a command-line argument. On `windows-latest` that's `Git Bash` bytes → `CreateProcess` UTF-16 → `curl.exe` re-decode. The round-trip mangles the raw-UTF-8 emoji jq emitted (`🪟`, `🧪`, `📦`, `📝`) into invalid UTF-8, which Discord rejects as not-valid JSON. macOS preserves UTF-8 in argv, so the same payload structure posted fine there.

Writing the body to a file and using `--data-binary @file` reads bytes verbatim from the filesystem — no argv encoding round-trip — and works identically on both runners.

## Test plan
- [x] `npx prettier --check .github/workflows/release-artifacts.yml` — clean.
- [ ] After merge, dispatch `workflow_dispatch` with both platforms enabled. Expected:
  - macOS embed still posts (no behaviour change).
  - Windows embed now actually delivers — the log line should be `Discord notification posted (HTTP 200).` and a real message lands in the channel.

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main