### PR TITLE
refactor(ui): drop redundant TOP badge from stack display

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,7 +21,7 @@
   "packages": {
     ".": {
       "package-name": "manabrew",
-      "release-as": "0.1.0",
+      "release-as": "0.2.0",
       "extra-files": [
         {
           "type": "json",

--- a/src/components/game/panels/StackDisplay.tsx
+++ b/src/components/game/panels/StackDisplay.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState, type CSSProperties } from "react";
 import { Card } from "@/components/game/Card";
-import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { withAlpha } from "@/themes/gameTheme";
 import { useTheme } from "@/hooks/useTheme";
@@ -207,16 +206,6 @@ export function StackDisplay({
                 )}
                 style={cardStyle}
               />
-              {isTopOfStack && (
-                <div
-                  className="pointer-events-none absolute left-0 right-0 -top-6 flex justify-center"
-                  style={{ zIndex: 250 }}
-                >
-                  <Badge variant="secondary" className="text-[10px] h-5 px-1.5 shadow">
-                    TOP · resolves next
-                  </Badge>
-                </div>
-              )}
             </div>
           );
         })}


### PR DESCRIPTION
## Summary
- Remove the "TOP · resolves next" badge that floated above the topmost stack card in `StackDisplay`.
- Drop the now-unused `Badge` import.

## Why
The stack already telegraphs the resolve order in two other ways: the cards cascade in a fixed direction (newest pushed leftward) and the top card carries the `playable-card` glow when the player can respond to it. The badge sat on top of those signals and was visual noise more than help.

## Test plan
- [ ] Open a multi-card stack in-game, confirm no badge floats above the top card.
- [ ] Hover/click the top card — `playable-card` glow + click-to-respond still work.
- [ ] No leftover `Badge` references in the file (`grep Badge src/components/game/panels/StackDisplay.tsx`).

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main