### PR TITLE
fix(ui): keep limited lobby styling after StartGame flips format

### DIFF
--- a/src/components/lobby/TablesList.tsx
+++ b/src/components/lobby/TablesList.tsx
@@ -78,7 +78,8 @@ export function TablesList({
   // bots, start) even when the host is a non-playing engine node. In a normal
   // self-created room the host is the first player, so the two coincide.
   const isController = currentRoom?.players[0]?.username === username;
-  const isOpenFormat = currentRoom?.format === "Any";
+  const isLimitedRoom = !!(currentRoom?.draft_config || currentRoom?.sealed_config);
+  const isOpenFormat = currentRoom?.format === "Any" || isLimitedRoom;
   const minReady = isOpenFormat ? 1 : 2;
   const allReady = currentRoom
     ? currentRoom.players.length >= minReady && currentRoom.players.every((p) => p.ready)


### PR DESCRIPTION
## Summary
- Detect limited (draft / sealed) rooms in `TablesList` by `draft_config` / `sealed_config` presence instead of `format === "Any"`.
- Keeps the draft/sealed lobby UI (Start Draft / Start Sealed buttons, no Add Bot / Select Deck / Start Game battle controls) visible from room creation through to the start hand-off.

## Why
Limited rooms are created with `format="Any"`, but the host clicking Start Draft / Start Sealed calls `startGame("Draft" | "Sealed")` and the server immediately flips `currentRoom.format` to `"Draft"` / `"Sealed"`. Every limited-vs-battle branch in `TablesList` was keyed off `isOpenFormat = format === "Any"`, so as soon as the format flipped:

- `Add Bot`, `Select Deck`, `Start Game` (battle controls) appeared.
- `Start Draft` / `Start Sealed` (limited controls) vanished.

If `startDraftAsHost` / `startMpSealed` then errored — which is currently happening on the wasm engine for a separate reason — the user was left looking at battle styling instead of the draft lobby they had just been in. Even on the happy path the UI flickered to battle styling for the duration of the hand-off.

The room's `draft_config` / `sealed_config` is set at creation and never mutated mid-flow, so it's the stable signal for "this is a limited room".

## Test plan
- [ ] Create a Draft room → confirm Start Draft button, no Add Bot / Select Deck / Start Game.
- [ ] Click Start Draft → lobby continues to show limited styling during the hand-off (or until navigation away).
- [ ] If Start Draft errors (toast appears), lobby stays in limited styling — no flicker to battle controls.
- [ ] Same checks for Sealed.
- [ ] Battle (Standard / Modern / …) rooms unchanged: still show Add Bot, Select Deck, Start Game.

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main