### PR TITLE
fix(ui): deck editor save & exit flow bugs

### DIFF
--- a/src/components/editor/DeckBuilder.tsx
+++ b/src/components/editor/DeckBuilder.tsx
@@ -311,7 +311,6 @@ export function DeckBuilder({
     setLastSavedSnapshotRef(snap);
     return snap;
   });
-  const [pendingSwitchAction, setPendingSwitchAction] = useState<(() => void) | null>(null);
   const [confirmClear, setConfirmClear] = useState(false);
   const [pendingDeleteDeck, setPendingDeleteDeck] = useState<{ id: string; name: string } | null>(
     null,
@@ -835,15 +834,6 @@ export function DeckBuilder({
     }
   }
 
-  /** If unsaved changes exist, queue the action behind a confirm dialog. Otherwise run it immediately. */
-  function guardUnsaved(action: () => void) {
-    if (hasUnsavedChanges) {
-      setPendingSwitchAction(() => action);
-    } else {
-      action();
-    }
-  }
-
   function handleImportPresetToMyDecks() {
     const importedName = currentDeck.name;
     importPresetToMyDecks();
@@ -893,11 +883,11 @@ export function DeckBuilder({
               tabIndex={0}
               className="h-7 w-7 shrink-0 rounded-md inline-flex items-center justify-center cursor-pointer hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
               title="Back to My Decks"
-              onClick={() => guardUnsaved(onBack)}
+              onClick={onBack}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
-                  guardUnsaved(onBack);
+                  onBack();
                 }
               }}
             >
@@ -1457,44 +1447,6 @@ export function DeckBuilder({
                   }}
                 >
                   Delete
-                </Button>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Unsaved changes confirm dialog (for deck switching) */}
-        {pendingSwitchAction && (
-          <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-overlay/50 backdrop-blur-sm">
-            <div className="bg-card border rounded-xl shadow-xl p-6 max-w-sm space-y-4">
-              <h3 className="text-lg font-semibold">Unsaved Changes</h3>
-              <p className="text-sm text-muted-foreground">
-                You have unsaved changes. Do you want to discard them?
-              </p>
-              <div className="flex justify-end gap-2">
-                <Button variant="outline" size="sm" onClick={() => setPendingSwitchAction(null)}>
-                  Cancel
-                </Button>
-                <Button
-                  variant="default"
-                  size="sm"
-                  onClick={() => {
-                    handleSave();
-                    pendingSwitchAction();
-                    setPendingSwitchAction(null);
-                  }}
-                >
-                  Save & Switch
-                </Button>
-                <Button
-                  variant="destructive"
-                  size="sm"
-                  onClick={() => {
-                    pendingSwitchAction();
-                    setPendingSwitchAction(null);
-                  }}
-                >
-                  Discard
                 </Button>
               </div>
             </div>

--- a/src/components/editor/DeckBuilder.tsx
+++ b/src/components/editor/DeckBuilder.tsx
@@ -263,9 +263,9 @@ export function DeckBuilder({
   const [labelsOpen, setLabelsOpen] = useState(false);
   const isReadOnly = useDeckStore((s) => s.isReadOnly);
   const importPresetToMyDecks = useDeckStore((s) => s.importPresetToMyDecks);
+  const currentDeckId = useDeckStore((s) => s.currentDeckId);
   const {
     currentDeck,
-    savedDecks,
     removeFromMain,
     removeFromSide,
     addToMain,
@@ -363,11 +363,10 @@ export function DeckBuilder({
     setUnsavedState(lastSavedSnapshot, isReadOnly ? lastSavedSnapshot : currentSnapshot);
   }, [lastSavedSnapshot, currentSnapshot, isReadOnly]);
 
-  // Reset snapshot when a deck is loaded
-  const deckIdentity = `${currentDeck.name}:${savedDecks.length}`;
-  const [prevDeckIdentity, setPrevDeckIdentity] = useState(deckIdentity);
-  if (prevDeckIdentity !== deckIdentity) {
-    setPrevDeckIdentity(deckIdentity);
+  // Reset snapshot when a different deck is loaded (or cleared).
+  const [prevDeckId, setPrevDeckId] = useState(currentDeckId);
+  if (prevDeckId !== currentDeckId) {
+    setPrevDeckId(currentDeckId);
     const snapshot = buildDeckSnapshot(currentDeck);
     setLastSavedSnapshot(snapshot);
     setUnsavedState(snapshot, snapshot);

--- a/src/components/editor/deckBuilder.unsavedChanges.ts
+++ b/src/components/editor/deckBuilder.unsavedChanges.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useDeckStore } from "@/stores/useDeckStore";
-import type { DeckCard } from "@/types/manabrew";
+import type { Deck } from "@/types/manabrew";
 
 let _hasUnsavedChanges = false;
 const _listeners = new Set<() => void>();
@@ -18,20 +18,7 @@ export function setLastSavedSnapshotRef(snapshot: string | null) {
   _lastSavedSnapshotRef = snapshot;
 }
 
-export function buildDeckSnapshot(deck: {
-  format?: string;
-  draft?: boolean;
-  cards: DeckCard[];
-  commanders?: DeckCard[];
-  sideboard: DeckCard[];
-  maybeboard?: DeckCard[];
-  attractions?: DeckCard[];
-  contraptions?: DeckCard[];
-  schemes?: DeckCard[];
-  planes?: DeckCard[];
-  name: string;
-  stackPositions?: Record<string, { x: number; y: number }>;
-}): string {
+export function buildDeckSnapshot(deck: Deck): string {
   return JSON.stringify({
     format: deck.format,
     cards: deck.cards,
@@ -42,7 +29,14 @@ export function buildDeckSnapshot(deck: {
     contraptions: deck.contraptions ?? [],
     schemes: deck.schemes ?? [],
     planes: deck.planes ?? [],
+    companion: deck.companion,
+    tokens: deck.tokens ?? [],
     name: deck.name,
+    labels: deck.labels ?? [],
+    customTags: deck.customTags ?? [],
+    cardTags: deck.cardTags ?? {},
+    coverCardName: deck.coverCardName,
+    coverCardFace: deck.coverCardFace,
     stackPositions: deck.stackPositions,
   });
 }

--- a/src/views/DeckEditor.tsx
+++ b/src/views/DeckEditor.tsx
@@ -296,10 +296,15 @@ export default function DeckEditor() {
 
   function confirmRename() {
     if (!renamingId || !renameInput.trim()) return;
+    const newName = renameInput.trim();
     useDeckStore.setState((state) => ({
       savedDecks: state.savedDecks.map((s) =>
-        s.id === renamingId ? { ...s, deck: { ...s.deck, name: renameInput.trim() } } : s,
+        s.id === renamingId ? { ...s, deck: { ...s.deck, name: newName } } : s,
       ),
+      currentDeck:
+        state.currentDeckId === renamingId
+          ? { ...state.currentDeck, name: newName }
+          : state.currentDeck,
     }));
     setRenamingId(null);
     toast.success("Deck renamed");


### PR DESCRIPTION
## Summary
- Track labels / customTags / cardTags / cover / companion / tokens in the unsaved-changes snapshot so the Save button enables when those mutate.
- Key the snapshot reset on `currentDeckId`, not `name + savedDecks.length` — renaming the open deck no longer silently flips `hasUnsavedChanges` to false and loses the rename on exit.
- Drop DeckBuilder's `guardUnsaved` wrapper + `pendingSwitchAction` dialog; the back arrow now calls `onBack` directly and DeckEditor owns the single unsaved-changes prompt.
- `confirmRename` from the list view now also updates `currentDeck.name` when the renamed deck is the one currently loaded in the editor.

## Why
Audit of the deck editor save / exit flows surfaced four real bugs:

1. Adding a deck label, tagging a card, picking a cover card, customizing a token, etc. never enabled the Save button — `buildDeckSnapshot` omitted those fields, so the deck looked saved while the changes had not been persisted.
2. The dirty-tracking reset was keyed on `${currentDeck.name}:${savedDecks.length}`. Renaming the open deck via the inline editor changed `name` → reset fired → `hasUnsavedChanges` flipped false → Back exited without a prompt → rename lost because it was never written into `savedDecks`. The same false-clean fired on any `savedDecks.length` delta.
3. Clicking the back arrow with unsaved changes opened DeckBuilder's 3-button (Cancel / Save & Switch / Discard) dialog. Picking Discard or Save & Switch then fell through to DeckEditor's `handleBack`, which still saw `hasUnsavedChanges = true` (closure-stale) and opened a second nearly identical dialog. Save & Switch also bypassed the legality check and could persist an illegal deck as non-draft.
4. Renaming the currently-open deck from the list-view rename dialog updated `savedDecks` but not `currentDeck`, so the editor header kept showing the old name until the deck was reloaded.

## Test plan
- `npx tsc -p tsconfig.app.json --noEmit` clean for touched files (pre-existing errors in `gameStore.constants.test.ts` are unrelated).
- `npx eslint` clean on every touched file.
- Lint-staged ran `eslint --fix` + `prettier --write` clean for each commit.
- Manual UI verification recommended before merge:
  - [ ] Rename open deck via inline editor → Save enables → exit without saving prompts → rename survives reload.
  - [ ] Add a label / pick a cover / tag a card → Save enables.
  - [ ] Back arrow with unsaved changes shows exactly one dialog.
  - [ ] Rename a saved deck from the list while it is the loaded deck → editor header updates.

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main