### PR TITLE
feat(companion): tracker v2 — turn flow, ring/speed/day-night, mana pool, log, archive, more

### DIFF
--- a/src/components/companion/AGENTS.md
+++ b/src/components/companion/AGENTS.md
@@ -21,9 +21,18 @@ Read first: `src/AGENTS.md`, `docs/agents/UI_THEME_RULES.md`.
 | `CountersRail.tsx`          | Chips with ±/remove for non-life counters                                                        |
 | `AddCounterMenu.tsx`        | Preset + custom counter dropdown                                                                 |
 | `CustomCounterDialog.tsx`   | Label / starting value / icon picker for custom counters                                         |
-| `NewSessionDialog.tsx`      | New-game form (players, starting life, commander, layout, carry roster)                          |
-| `DiceRoller.tsx`            | Animated first-player randomizer; calls store `pickRandomFirstPlayer`                            |
-| `TurnTimer.tsx`             | Single elapsed clock backed by `session.timer`                                                   |
+| `NewSessionDialog.tsx`      | New-game form (format presets, players, starting life, commander, oathbreaker, layout, roster)   |
+| `DiceRoller.tsx`            | Animated roll modal: first-player picker, d4–d100 die roll, coin flip                            |
+| `DiceTray.tsx`              | Bar dropdown of d4 / d6 / d8 / d10 / d12 / d20 / d100 / coin → opens `DiceRoller` in die mode    |
+| `DieShape.tsx`              | SVG polygon silhouette per die type (triangle / square / pentagon / hexagon / octagon / circle)  |
+| `TurnTimer.tsx`             | Elapsed clock backed by `session.timer`; mode dropdown switches shared / chess clock             |
+| `PhaseStrip.tsx`            | Below-bar segmented phase indicator (untap … end); pill tints with the active player's accent    |
+| `GameLog.tsx`               | Right-side `Sheet` listing every history event with timestamps and a per-row rewind button       |
+| `GameSummaryDialog.tsx`     | Post-`endSession` modal: final scores, length, turns, copy-to-clipboard recap                    |
+| `WinBanner.tsx`             | Overlay shown when `living.length === 1`; archive / keep-playing; keyed by id+history.length     |
+| `StatsDialog.tsx`           | Aggregate stats derived from `archive[]`: total games, avg length, avg turns, wins by name       |
+| `ManaPoolRail.tsx`          | Floating-mana pips (WUBRGC) rendered in the tile footer; tap +1, hold -1                         |
+| `PlayerNotesDialog.tsx`     | Multi-line free-form note for a player, persisted via `setPlayerNotes`                           |
 | `usePressHold.ts`           | Tap vs. hold gesture binding used by every stepper                                               |
 | `icons.tsx`                 | Counter-icon name → lucide JSX switch                                                            |
 | `layouts/slots.ts`          | Layout id → grid template + per-slot rotation                                                    |
@@ -35,7 +44,8 @@ Read first: `src/AGENTS.md`, `docs/agents/UI_THEME_RULES.md`.
 - **Theme colors only.** Tile accents map to the active theme via `COMPANION_ACCENT_COLORS`, which references `--format-badge-*` CSS variables emitted by `useTheme` from `gameTheme.formatBadge`. Switching theme preset recolors every tile; never hard-code hex/oklch tile colors here. Status chips for Monarch/Initiative/Ascend keep fixed semantic Tailwind palette classes (`bg-amber-400`, `bg-violet-500`, `bg-sky-500`) because those colors are part of the MTG iconography. Keep additions sparing.
 - **Gestures.** Every ± control goes through `usePressHold` so tap-vs-hold behaviour is uniform. Tap = ±1, hold = ±1 every 110ms after a 320ms delay.
 - **Pending life delta.** `useCompanionStore.adjustLife` batches consecutive presses inside a ~1.4s window into one history entry. Tile shows the running total via `state.pendingDeltas[playerId]`.
-- **Undo.** Reads `session.history` (capped at 80 entries). Active pending deltas are flushed/discarded before undo to keep the timeline consistent.
+- **Undo / redo.** Both are routed through `revertEvent` / `replayEvent` reducers so every event variant goes through one switch. The redo stack lives on `session.redoStack` and is cleared by any new history push (`pushEvent`). Setup actions (layout, player count, starting life, commander rules, monarch / initiative / blessing / ring / speed toggles, rename, accent, free position, day/night, phase, timer mode, session tag) intentionally do NOT push history. Active pending life deltas are snapshotted and reverted before consulting the history stack so an undo right after a tap still rolls back the visible damage.
+- **Active-player accent.** Read `COMPANION_ACCENT_COLORS[active.accentKey]` everywhere that needs to mirror whose turn it is — currently `PlayerTile` ring, `CompanionBar` T# pill, `PhaseStrip` active pill, `DiceRoller` numeric and coin variants, and the "Goes first" chip on `lastFirstPlayerId`. All four pull from the same selector so a single accent change recolours them in lock-step.
 - **Commander damage and life stay in sync.** `adjustCommanderDamage` subtracts the delta from the target's life in the same store update.
 
 ## When to extend

--- a/src/components/companion/CommanderArt.tsx
+++ b/src/components/companion/CommanderArt.tsx
@@ -38,7 +38,7 @@ export function CommanderArt({ refs, className, variant = "banner" }: CommanderA
           alt=""
           draggable={false}
           className={cn(
-            "absolute inset-0 size-full object-cover object-[center_30%] opacity-60",
+            "absolute inset-0 size-full object-cover object-[center_30%]",
             partner && "w-1/2",
           )}
         />
@@ -48,10 +48,15 @@ export function CommanderArt({ refs, className, variant = "banner" }: CommanderA
           src={partner}
           alt=""
           draggable={false}
-          className="absolute inset-y-0 right-0 w-1/2 object-cover object-[center_30%] opacity-60"
+          className="absolute inset-y-0 right-0 w-1/2 object-cover object-[center_30%]"
         />
       )}
-      <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-black/40" />
+      {/* Darken only the top and bottom bands where the name, status
+          chips, counters and commander-damage strip overlap the art —
+          the middle (life total) stays untinted so the commander
+          illustration reads in its true colours. */}
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-1/3 bg-gradient-to-b from-black/55 to-transparent" />
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-1/3 bg-gradient-to-t from-black/55 to-transparent" />
     </div>
   );
 }

--- a/src/components/companion/CommanderPickerDialog.tsx
+++ b/src/components/companion/CommanderPickerDialog.tsx
@@ -64,6 +64,8 @@ function CommanderPickerForm({
   onClose: () => void;
 }) {
   const setCommander = useCompanionStore((s) => s.setCommander);
+  const oathbreaker = useCompanionStore((s) => s.session?.oathbreaker ?? false);
+  const partnerLabel = oathbreaker ? "Signature spell" : "Partner / Background";
   const [partnerEnabled, setPartnerEnabled] = useState(Boolean(initial[1]));
   const [slots, setSlots] = useState<[SlotState, SlotState]>([
     { query: initial[0]?.name ?? "", pick: initial[0] },
@@ -107,11 +109,11 @@ function CommanderPickerForm({
             onChange={(e) => setPartnerEnabled(e.target.checked)}
             className="size-4 accent-primary"
           />
-          Partner / Background
+          {partnerLabel} slot
         </label>
         {partnerEnabled && (
           <CommanderSlot
-            slotLabel="Partner"
+            slotLabel={partnerLabel}
             query={slots[1].query}
             pick={slots[1].pick}
             onQueryChange={(query) => updateSlot(1, { query })}

--- a/src/components/companion/CompanionBar.tsx
+++ b/src/components/companion/CompanionBar.tsx
@@ -1,5 +1,16 @@
 import { useState } from "react";
-import { ChevronRight, Minus, Plus, Redo2, RotateCcw, Undo2, XOctagon } from "lucide-react";
+import {
+  ChevronRight,
+  Minus,
+  Moon,
+  Plus,
+  Redo2,
+  RotateCcw,
+  Sun,
+  SunMoon,
+  Undo2,
+  XOctagon,
+} from "lucide-react";
 import { GameIcon } from "./GameIcon";
 import { LayoutIcon } from "./LayoutIcon";
 import { Button } from "@/components/ui/button";
@@ -38,7 +49,10 @@ export function CompanionBar({ session, onOpenNewSession }: CompanionBarProps) {
   const redo = useCompanionStore((s) => s.redo);
   const canRedo = useCompanionStore((s) => (s.session?.redoStack.length ?? 0) > 0);
   const advanceTurn = useCompanionStore((s) => s.advanceTurn);
+  const cycleDayNight = useCompanionStore((s) => s.cycleDayNight);
   const activePlayer = session.players.find((p) => p.id === session.activePlayerId) ?? null;
+  const DayNightIcon =
+    session.dayNight === "night" ? Moon : session.dayNight === "day" ? Sun : SunMoon;
   const resetCounters = useCompanionStore((s) => s.resetCounters);
   const endSession = useCompanionStore((s) => s.endSession);
   const pickRandom = useCompanionStore((s) => s.pickRandomFirstPlayer);
@@ -166,6 +180,22 @@ export function CompanionBar({ session, onOpenNewSession }: CompanionBarProps) {
             {activePlayer ? `T${session.turn} · ${activePlayer.name}` : "Start"}
           </span>
           <span className="tabular-nums sm:hidden">T{session.turn}</span>
+        </Button>
+        <Button
+          size="icon"
+          variant={session.dayNight ? "default" : "ghost"}
+          className="size-8"
+          onClick={cycleDayNight}
+          aria-label="Cycle day / night"
+          title={
+            session.dayNight === null
+              ? "Day/Night: off"
+              : session.dayNight === "day"
+                ? "It is day"
+                : "It is night"
+          }
+        >
+          <DayNightIcon className="size-4" />
         </Button>
         <TurnTimer />
         <Button

--- a/src/components/companion/CompanionBar.tsx
+++ b/src/components/companion/CompanionBar.tsx
@@ -35,6 +35,8 @@ export function CompanionBar({ session, onOpenNewSession }: CompanionBarProps) {
   const setStartingLife = useCompanionStore((s) => s.setStartingLife);
   const setCommanderRules = useCompanionStore((s) => s.setCommanderRules);
   const undo = useCompanionStore((s) => s.undo);
+  const redo = useCompanionStore((s) => s.redo);
+  const canRedo = useCompanionStore((s) => (s.session?.redoStack.length ?? 0) > 0);
   const resetCounters = useCompanionStore((s) => s.resetCounters);
   const endSession = useCompanionStore((s) => s.endSession);
   const pickRandom = useCompanionStore((s) => s.pickRandomFirstPlayer);
@@ -169,6 +171,17 @@ export function CompanionBar({ session, onOpenNewSession }: CompanionBarProps) {
           title="Undo last action"
         >
           <Undo2 className="size-4" />
+        </Button>
+        <Button
+          size="icon"
+          variant="ghost"
+          className="size-8"
+          onClick={redo}
+          disabled={!canRedo}
+          aria-label="Redo"
+          title="Redo"
+        >
+          <Redo2 className="size-4" />
         </Button>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>

--- a/src/components/companion/CompanionBar.tsx
+++ b/src/components/companion/CompanionBar.tsx
@@ -6,6 +6,7 @@ import {
   Plus,
   Redo2,
   RotateCcw,
+  Shuffle,
   Sun,
   SunMoon,
   Undo2,
@@ -245,7 +246,7 @@ export function CompanionBar({ session, onOpenNewSession }: CompanionBarProps) {
           aria-label="Random first player"
           title="Random first player"
         >
-          <GameIcon icon="d20" className="size-4 sm:size-5" />
+          <Shuffle className="size-4 sm:size-5" />
         </Button>
         <Button
           size="icon"

--- a/src/components/companion/CompanionBar.tsx
+++ b/src/components/companion/CompanionBar.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Minus, Plus, Redo2, RotateCcw, Undo2, XOctagon } from "lucide-react";
+import { ChevronRight, Minus, Plus, Redo2, RotateCcw, Undo2, XOctagon } from "lucide-react";
 import { GameIcon } from "./GameIcon";
 import { LayoutIcon } from "./LayoutIcon";
 import { Button } from "@/components/ui/button";
@@ -37,6 +37,8 @@ export function CompanionBar({ session, onOpenNewSession }: CompanionBarProps) {
   const undo = useCompanionStore((s) => s.undo);
   const redo = useCompanionStore((s) => s.redo);
   const canRedo = useCompanionStore((s) => (s.session?.redoStack.length ?? 0) > 0);
+  const advanceTurn = useCompanionStore((s) => s.advanceTurn);
+  const activePlayer = session.players.find((p) => p.id === session.activePlayerId) ?? null;
   const resetCounters = useCompanionStore((s) => s.resetCounters);
   const endSession = useCompanionStore((s) => s.endSession);
   const pickRandom = useCompanionStore((s) => s.pickRandomFirstPlayer);
@@ -151,6 +153,20 @@ export function CompanionBar({ session, onOpenNewSession }: CompanionBarProps) {
       </DropdownMenu>
 
       <div className="ml-auto flex flex-wrap items-center gap-1 sm:gap-2">
+        <Button
+          size="sm"
+          variant={activePlayer ? "default" : "outline"}
+          onClick={advanceTurn}
+          className="h-8 gap-1 px-2 text-xs sm:h-9 sm:px-3 sm:text-sm"
+          aria-label="Next turn"
+          title={activePlayer ? `Turn ${session.turn} · ${activePlayer.name}` : "Start turn"}
+        >
+          <ChevronRight className="size-3.5" />
+          <span className="hidden tabular-nums sm:inline">
+            {activePlayer ? `T${session.turn} · ${activePlayer.name}` : "Start"}
+          </span>
+          <span className="tabular-nums sm:hidden">T{session.turn}</span>
+        </Button>
         <TurnTimer />
         <Button
           size="icon"

--- a/src/components/companion/CompanionBar.tsx
+++ b/src/components/companion/CompanionBar.tsx
@@ -57,6 +57,7 @@ export function CompanionBar({ session, onOpenNewSession }: CompanionBarProps) {
   const DayNightIcon =
     session.dayNight === "night" ? Moon : session.dayNight === "day" ? Sun : SunMoon;
   const resetCounters = useCompanionStore((s) => s.resetCounters);
+  const resetGame = useCompanionStore((s) => s.resetGame);
   const endSession = useCompanionStore((s) => s.endSession);
   const pickRandom = useCompanionStore((s) => s.pickRandomFirstPlayer);
 
@@ -285,8 +286,8 @@ export function CompanionBar({ session, onOpenNewSession }: CompanionBarProps) {
               <Redo2 className="mr-2 size-4" /> Commander damage
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={() => resetCounters("all")}>
-              Reset everything
+            <DropdownMenuItem onSelect={() => resetGame()}>
+              Reset everything (turn, timer, history)
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/src/components/companion/CompanionBar.tsx
+++ b/src/components/companion/CompanionBar.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/stores/useCompanionStore.constants";
 import type { CompanionSession } from "@/stores/useCompanionStore.types";
 import { DiceRoller } from "./DiceRoller";
+import { GameLog } from "./GameLog";
 import { TurnTimer } from "./TurnTimer";
 
 interface CompanionBarProps {
@@ -198,6 +199,7 @@ export function CompanionBar({ session, onOpenNewSession }: CompanionBarProps) {
           <DayNightIcon className="size-4" />
         </Button>
         <TurnTimer />
+        <GameLog session={session} />
         <Button
           size="icon"
           variant="outline"

--- a/src/components/companion/CompanionBar.tsx
+++ b/src/components/companion/CompanionBar.tsx
@@ -60,6 +60,8 @@ export function CompanionBar({ session, onOpenNewSession }: CompanionBarProps) {
   const pickRandom = useCompanionStore((s) => s.pickRandomFirstPlayer);
 
   const [diceOpen, setDiceOpen] = useState(false);
+  const setSessionTag = useCompanionStore((s) => s.setSessionTag);
+  const [editingTag, setEditingTag] = useState(false);
 
   const layoutChoices = COMPANION_LAYOUT_OPTIONS[session.players.length] ?? ["free"];
 
@@ -167,6 +169,32 @@ export function CompanionBar({ session, onOpenNewSession }: CompanionBarProps) {
           ))}
         </DropdownMenuContent>
       </DropdownMenu>
+
+      {editingTag ? (
+        <input
+          autoFocus
+          defaultValue={session.tag ?? ""}
+          placeholder="Game title…"
+          className="h-8 w-40 rounded-md border border-input bg-background px-2 text-xs"
+          onBlur={(e) => {
+            setSessionTag(e.target.value.trim());
+            setEditingTag(false);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+            if (e.key === "Escape") setEditingTag(false);
+          }}
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={() => setEditingTag(true)}
+          className="hidden truncate text-xs text-muted-foreground hover:text-foreground sm:inline"
+          title="Edit game title"
+        >
+          {session.tag || "Untitled game"}
+        </button>
+      )}
 
       <div className="ml-auto flex flex-wrap items-center gap-1 sm:gap-2">
         <Button

--- a/src/components/companion/CompanionBar.tsx
+++ b/src/components/companion/CompanionBar.tsx
@@ -25,6 +25,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useCompanionStore } from "@/stores/useCompanionStore";
 import {
+  COMPANION_ACCENT_COLORS,
   COMPANION_LAYOUT_LABELS,
   COMPANION_LAYOUT_OPTIONS,
   COMPANION_MAX_PLAYERS,
@@ -201,7 +202,12 @@ export function CompanionBar({ session, onOpenNewSession }: CompanionBarProps) {
           size="sm"
           variant={activePlayer ? "default" : "outline"}
           onClick={advanceTurn}
-          className="h-8 gap-1 px-2 text-xs sm:h-9 sm:px-3 sm:text-sm"
+          className="h-8 gap-1 px-2 text-xs text-white shadow-sm sm:h-9 sm:px-3 sm:text-sm"
+          style={
+            activePlayer
+              ? { backgroundColor: COMPANION_ACCENT_COLORS[activePlayer.accentKey] }
+              : undefined
+          }
           aria-label="Next turn"
           title={activePlayer ? `Turn ${session.turn} · ${activePlayer.name}` : "Start turn"}
         >

--- a/src/components/companion/CompanionBar.tsx
+++ b/src/components/companion/CompanionBar.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/stores/useCompanionStore.constants";
 import type { CompanionSession } from "@/stores/useCompanionStore.types";
 import { DiceRoller } from "./DiceRoller";
+import { DiceTray } from "./DiceTray";
 import { GameLog } from "./GameLog";
 import { TurnTimer } from "./TurnTimer";
 
@@ -200,6 +201,7 @@ export function CompanionBar({ session, onOpenNewSession }: CompanionBarProps) {
         </Button>
         <TurnTimer />
         <GameLog session={session} />
+        <DiceTray />
         <Button
           size="icon"
           variant="outline"

--- a/src/components/companion/DiceRoller.tsx
+++ b/src/components/companion/DiceRoller.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { GameIcon } from "./GameIcon";
+import { DieShape } from "./DieShape";
 import { cn } from "@/lib/utils";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { COMPANION_ACCENT_COLORS } from "@/stores/useCompanionStore.constants";
@@ -144,16 +145,7 @@ function NumericRoll({ sides }: { sides: number }) {
 
   return (
     <div className="flex flex-col items-center gap-3 py-2">
-      <div
-        className={cn(
-          "grid size-32 place-items-center rounded-2xl border-2 text-6xl font-black tabular-nums shadow-inner transition",
-          settled
-            ? "border-primary bg-primary/10 text-foreground"
-            : "border-border text-muted-foreground",
-        )}
-      >
-        {value}
-      </div>
+      <DieShape sides={sides} value={value} settled={settled} rolling={!settled} />
       <p className="text-sm text-muted-foreground">
         {settled ? (
           <>
@@ -187,15 +179,17 @@ function CoinFlip() {
 
   return (
     <div className="flex flex-col items-center gap-3 py-2">
-      <div
-        className={cn(
-          "grid size-32 place-items-center rounded-full border-2 text-2xl font-black uppercase tracking-wider shadow-inner transition",
-          settled
-            ? "border-primary bg-primary/10 text-foreground"
-            : "border-border text-muted-foreground",
-        )}
-      >
-        {value === "Heads" ? "H" : "T"}
+      <div className={cn(!settled && "animate-companion-die-tumble")}>
+        <div
+          className={cn(
+            "grid size-32 place-items-center rounded-full border-2 text-2xl font-black uppercase tracking-wider shadow-lg transition-colors",
+            settled
+              ? "border-primary bg-primary/10 text-foreground"
+              : "border-border text-muted-foreground",
+          )}
+        >
+          {value === "Heads" ? "H" : "T"}
+        </div>
       </div>
       <p className="text-sm text-muted-foreground">
         {settled ? (

--- a/src/components/companion/DiceRoller.tsx
+++ b/src/components/companion/DiceRoller.tsx
@@ -3,8 +3,21 @@ import { GameIcon } from "./GameIcon";
 import { DieShape } from "./DieShape";
 import { cn } from "@/lib/utils";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useCompanionStore } from "@/stores/useCompanionStore";
 import { COMPANION_ACCENT_COLORS } from "@/stores/useCompanionStore.constants";
 import type { CompanionPlayer } from "@/stores/useCompanionStore.types";
+
+/** Resolves the active player's accent colour, falling back to the first
+ *  player if none is active and finally `null` (which means use --primary). */
+function useActiveAccent(): string | null {
+  return useCompanionStore((s) => {
+    const session = s.session;
+    if (!session) return null;
+    const active =
+      session.players.find((p) => p.id === session.activePlayerId) ?? session.players[0];
+    return active ? COMPANION_ACCENT_COLORS[active.accentKey] : null;
+  });
+}
 
 const ANIMATION_TICKS = 14;
 const ANIMATION_INTERVAL_MS = 90;
@@ -129,6 +142,7 @@ function FirstPlayerAnimation({
 function NumericRoll({ sides }: { sides: number }) {
   const [value, setValue] = useState(1);
   const [settled, setSettled] = useState(false);
+  const accent = useActiveAccent();
 
   useEffect(() => {
     let ticks = 0;
@@ -145,7 +159,13 @@ function NumericRoll({ sides }: { sides: number }) {
 
   return (
     <div className="flex flex-col items-center gap-3 py-2">
-      <DieShape sides={sides} value={value} settled={settled} rolling={!settled} />
+      <DieShape
+        sides={sides}
+        value={value}
+        settled={settled}
+        rolling={!settled}
+        accentColor={accent ?? undefined}
+      />
       <p className="text-sm text-muted-foreground">
         {settled ? (
           <>
@@ -163,6 +183,7 @@ function NumericRoll({ sides }: { sides: number }) {
 function CoinFlip() {
   const [value, setValue] = useState<"Heads" | "Tails">("Heads");
   const [settled, setSettled] = useState(false);
+  const accent = useActiveAccent();
 
   useEffect(() => {
     let ticks = 0;
@@ -177,18 +198,34 @@ function CoinFlip() {
     return () => clearInterval(interval);
   }, []);
 
+  const borderColor = settled ? (accent ?? "var(--primary)") : "var(--border)";
+  const fillColor = settled ? (accent ?? "var(--primary)") : "transparent";
+
   return (
     <div className="flex flex-col items-center gap-3 py-2">
       <div className={cn(!settled && "animate-companion-die-tumble")}>
         <div
-          className={cn(
-            "grid size-32 place-items-center rounded-full border-2 text-2xl font-black uppercase tracking-wider shadow-lg transition-colors",
-            settled
-              ? "border-primary bg-primary/10 text-foreground"
-              : "border-border text-muted-foreground",
-          )}
+          className="grid size-32 place-items-center rounded-full text-2xl font-black uppercase tracking-wider shadow-lg transition-colors"
+          style={{
+            borderWidth: 2.5,
+            borderStyle: "solid",
+            borderColor,
+            backgroundColor: fillColor,
+            backgroundClip: "border-box",
+            color: settled ? "var(--foreground)" : "var(--muted-foreground)",
+            backgroundImage: settled
+              ? `linear-gradient(${accent ?? "var(--primary)"} 0%, ${accent ?? "var(--primary)"} 100%)`
+              : undefined,
+          }}
         >
-          {value === "Heads" ? "H" : "T"}
+          <span
+            className={cn(
+              "rounded-full px-3 py-1",
+              settled ? "bg-card/70 text-foreground" : "text-muted-foreground",
+            )}
+          >
+            {value === "Heads" ? "H" : "T"}
+          </span>
         </div>
       </div>
       <p className="text-sm text-muted-foreground">

--- a/src/components/companion/DiceRoller.tsx
+++ b/src/components/companion/DiceRoller.tsx
@@ -5,30 +5,64 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { COMPANION_ACCENT_COLORS } from "@/stores/useCompanionStore.constants";
 import type { CompanionPlayer } from "@/stores/useCompanionStore.types";
 
-interface DiceRollerProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  players: CompanionPlayer[];
-  /** Returns the winning player id (committed to the store). */
-  pickWinner: () => string | null;
-}
+const ANIMATION_TICKS = 14;
+const ANIMATION_INTERVAL_MS = 90;
 
-export function DiceRoller({ open, onOpenChange, players, pickWinner }: DiceRollerProps) {
+type DiceRollerProps =
+  | {
+      mode?: "first-player";
+      open: boolean;
+      onOpenChange: (open: boolean) => void;
+      players: CompanionPlayer[];
+      /** Returns the winning player id (committed to the store). */
+      pickWinner: () => string | null;
+    }
+  | {
+      mode: "die";
+      open: boolean;
+      onOpenChange: (open: boolean) => void;
+      /** Number of faces, e.g. 6 / 20 / 100. */
+      sides: number;
+    }
+  | {
+      mode: "coin";
+      open: boolean;
+      onOpenChange: (open: boolean) => void;
+    };
+
+export function DiceRoller(props: DiceRollerProps) {
+  const title = describeTitle(props);
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <GameIcon icon="d20" className="size-5" /> Randomising first player…
+            <GameIcon icon="d20" className="size-5" /> {title}
           </DialogTitle>
         </DialogHeader>
-        {open && <DiceAnimation players={players} pickWinner={pickWinner} />}
+        {props.open && <RollBody {...props} />}
       </DialogContent>
     </Dialog>
   );
 }
 
-function DiceAnimation({
+function describeTitle(props: DiceRollerProps): string {
+  if (!("mode" in props) || props.mode === "first-player") return "Randomising first player…";
+  if (props.mode === "die") return `Rolling a d${props.sides}…`;
+  return "Flipping a coin…";
+}
+
+function RollBody(props: DiceRollerProps) {
+  if (!("mode" in props) || props.mode === "first-player") {
+    return <FirstPlayerAnimation players={props.players} pickWinner={props.pickWinner} />;
+  }
+  if (props.mode === "die") {
+    return <NumericRoll sides={props.sides} />;
+  }
+  return <CoinFlip />;
+}
+
+function FirstPlayerAnimation({
   players,
   pickWinner,
 }: {
@@ -42,12 +76,11 @@ function DiceAnimation({
     if (players.length === 0) return;
 
     let ticks = 0;
-    const maxTicks = 14;
     const interval = setInterval(() => {
       ticks += 1;
       const idx = Math.floor(Math.random() * players.length);
       setHighlight(players[idx]!.id);
-      if (ticks >= maxTicks) {
+      if (ticks >= ANIMATION_TICKS) {
         clearInterval(interval);
         const winnerId = pickWinner();
         if (winnerId) {
@@ -55,7 +88,7 @@ function DiceAnimation({
           setSettled(true);
         }
       }
-    }, 90);
+    }, ANIMATION_INTERVAL_MS);
 
     return () => clearInterval(interval);
   }, [players, pickWinner]);
@@ -89,5 +122,90 @@ function DiceAnimation({
         </p>
       )}
     </>
+  );
+}
+
+function NumericRoll({ sides }: { sides: number }) {
+  const [value, setValue] = useState(1);
+  const [settled, setSettled] = useState(false);
+
+  useEffect(() => {
+    let ticks = 0;
+    const interval = setInterval(() => {
+      ticks += 1;
+      setValue(1 + Math.floor(Math.random() * sides));
+      if (ticks >= ANIMATION_TICKS) {
+        clearInterval(interval);
+        setSettled(true);
+      }
+    }, ANIMATION_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [sides]);
+
+  return (
+    <div className="flex flex-col items-center gap-3 py-2">
+      <div
+        className={cn(
+          "grid size-32 place-items-center rounded-2xl border-2 text-6xl font-black tabular-nums shadow-inner transition",
+          settled
+            ? "border-primary bg-primary/10 text-foreground"
+            : "border-border text-muted-foreground",
+        )}
+      >
+        {value}
+      </div>
+      <p className="text-sm text-muted-foreground">
+        {settled ? (
+          <>
+            <span className="font-semibold text-foreground">d{sides}</span> →{" "}
+            <span className="font-semibold text-foreground">{value}</span>
+          </>
+        ) : (
+          `d${sides}`
+        )}
+      </p>
+    </div>
+  );
+}
+
+function CoinFlip() {
+  const [value, setValue] = useState<"Heads" | "Tails">("Heads");
+  const [settled, setSettled] = useState(false);
+
+  useEffect(() => {
+    let ticks = 0;
+    const interval = setInterval(() => {
+      ticks += 1;
+      setValue(Math.random() < 0.5 ? "Heads" : "Tails");
+      if (ticks >= ANIMATION_TICKS) {
+        clearInterval(interval);
+        setSettled(true);
+      }
+    }, ANIMATION_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="flex flex-col items-center gap-3 py-2">
+      <div
+        className={cn(
+          "grid size-32 place-items-center rounded-full border-2 text-2xl font-black uppercase tracking-wider shadow-inner transition",
+          settled
+            ? "border-primary bg-primary/10 text-foreground"
+            : "border-border text-muted-foreground",
+        )}
+      >
+        {value === "Heads" ? "H" : "T"}
+      </div>
+      <p className="text-sm text-muted-foreground">
+        {settled ? (
+          <>
+            Coin → <span className="font-semibold text-foreground">{value}</span>
+          </>
+        ) : (
+          "Coin"
+        )}
+      </p>
+    </div>
   );
 }

--- a/src/components/companion/DiceTray.tsx
+++ b/src/components/companion/DiceTray.tsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { GameIcon } from "./GameIcon";
+
+const DICE = [4, 6, 8, 10, 12, 20, 100] as const;
+
+export function DiceTray() {
+  const [last, setLast] = useState<{ label: string; value: number | string } | null>(null);
+  return (
+    <DropdownMenu
+      onOpenChange={(open) => {
+        if (open) setLast(null);
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <Button
+          size="icon"
+          variant="outline"
+          className="size-8 sm:size-9"
+          aria-label="Dice tray"
+          title="Dice & coin"
+        >
+          <GameIcon icon="d20" className="size-4 sm:size-5" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-40">
+        <DropdownMenuLabel>Roll</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {DICE.map((sides) => (
+          <DropdownMenuItem
+            key={sides}
+            onSelect={(e) => {
+              e.preventDefault();
+              const value = 1 + Math.floor(Math.random() * sides);
+              setLast({ label: `d${sides}`, value });
+            }}
+          >
+            d{sides}
+            {last?.label === `d${sides}` && (
+              <span className="ml-auto font-semibold tabular-nums">{last.value}</span>
+            )}
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onSelect={(e) => {
+            e.preventDefault();
+            setLast({ label: "coin", value: Math.random() < 0.5 ? "Heads" : "Tails" });
+          }}
+        >
+          Coin flip
+          {last?.label === "coin" && <span className="ml-auto font-semibold">{last.value}</span>}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/companion/DiceTray.tsx
+++ b/src/components/companion/DiceTray.tsx
@@ -8,58 +8,52 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { DiceRoller } from "./DiceRoller";
 import { GameIcon } from "./GameIcon";
 
 const DICE = [4, 6, 8, 10, 12, 20, 100] as const;
 
+type Roll = { kind: "die"; sides: number } | { kind: "coin" };
+
 export function DiceTray() {
-  const [last, setLast] = useState<{ label: string; value: number | string } | null>(null);
+  const [roll, setRoll] = useState<Roll | null>(null);
   return (
-    <DropdownMenu
-      onOpenChange={(open) => {
-        if (open) setLast(null);
-      }}
-    >
-      <DropdownMenuTrigger asChild>
-        <Button
-          size="icon"
-          variant="outline"
-          className="size-8 sm:size-9"
-          aria-label="Dice tray"
-          title="Dice & coin"
-        >
-          <GameIcon icon="d20" className="size-4 sm:size-5" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-40">
-        <DropdownMenuLabel>Roll</DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        {DICE.map((sides) => (
-          <DropdownMenuItem
-            key={sides}
-            onSelect={(e) => {
-              e.preventDefault();
-              const value = 1 + Math.floor(Math.random() * sides);
-              setLast({ label: `d${sides}`, value });
-            }}
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            size="icon"
+            variant="outline"
+            className="size-8 sm:size-9"
+            aria-label="Dice tray"
+            title="Dice & coin"
           >
-            d{sides}
-            {last?.label === `d${sides}` && (
-              <span className="ml-auto font-semibold tabular-nums">{last.value}</span>
-            )}
-          </DropdownMenuItem>
-        ))}
-        <DropdownMenuSeparator />
-        <DropdownMenuItem
-          onSelect={(e) => {
-            e.preventDefault();
-            setLast({ label: "coin", value: Math.random() < 0.5 ? "Heads" : "Tails" });
-          }}
-        >
-          Coin flip
-          {last?.label === "coin" && <span className="ml-auto font-semibold">{last.value}</span>}
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+            <GameIcon icon="d20" className="size-4 sm:size-5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-32">
+          <DropdownMenuLabel>Roll</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          {DICE.map((sides) => (
+            <DropdownMenuItem key={sides} onSelect={() => setRoll({ kind: "die", sides })}>
+              d{sides}
+            </DropdownMenuItem>
+          ))}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => setRoll({ kind: "coin" })}>Coin flip</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {roll?.kind === "die" && (
+        <DiceRoller
+          mode="die"
+          sides={roll.sides}
+          open
+          onOpenChange={(open) => !open && setRoll(null)}
+        />
+      )}
+      {roll?.kind === "coin" && (
+        <DiceRoller mode="coin" open onOpenChange={(open) => !open && setRoll(null)} />
+      )}
+    </>
   );
 }

--- a/src/components/companion/DieShape.tsx
+++ b/src/components/companion/DieShape.tsx
@@ -5,6 +5,9 @@ interface DieShapeProps {
   value: number;
   settled: boolean;
   rolling: boolean;
+  /** CSS colour used for the silhouette and the settled fill. Falls back to
+   *  the theme `--primary` when omitted. */
+  accentColor?: string;
   className?: string;
 }
 
@@ -40,13 +43,21 @@ function polygonPath(vertexCount: number, rotationDeg: number): string {
   return points.join(" ");
 }
 
-export function DieShape({ sides, value, settled, rolling, className }: DieShapeProps) {
+export function DieShape({
+  sides,
+  value,
+  settled,
+  rolling,
+  accentColor,
+  className,
+}: DieShapeProps) {
   const vertexCount = VERTICES_FOR[sides] ?? 6;
   // Point-up orientation for odd-vertex shapes (triangle, pentagon);
   // flat-top for even-vertex shapes (square, hexagon, octagon).
   const rotation = vertexCount % 2 === 1 ? -90 : -90 + 180 / vertexCount;
   const points = polygonPath(vertexCount, rotation);
   const label = sides === 100 ? `${value}%` : `${value}`;
+  const stroke = accentColor ?? "var(--primary)";
   return (
     <div
       className={cn(
@@ -58,10 +69,11 @@ export function DieShape({ sides, value, settled, rolling, className }: DieShape
       <svg viewBox={`0 0 ${VIEW_BOX} ${VIEW_BOX}`} className="size-32 drop-shadow-lg" aria-hidden>
         <polygon
           points={points}
-          className={cn(
-            "stroke-2 transition-colors",
-            settled ? "fill-primary/15 stroke-primary" : "fill-muted/40 stroke-border",
-          )}
+          className="transition-colors"
+          stroke={settled ? stroke : "var(--border)"}
+          strokeWidth={2.5}
+          fill={settled ? stroke : "var(--muted)"}
+          fillOpacity={settled ? 0.18 : 0.4}
         />
         <text
           x={CENTER}
@@ -69,9 +81,10 @@ export function DieShape({ sides, value, settled, rolling, className }: DieShape
           textAnchor="middle"
           dominantBaseline="central"
           className={cn(
-            "fill-current font-black tabular-nums",
+            "font-black tabular-nums",
             settled ? "text-foreground" : "text-muted-foreground",
           )}
+          fill="currentColor"
           style={{ fontSize: sides === 100 ? 26 : 36 }}
         >
           {label}

--- a/src/components/companion/DieShape.tsx
+++ b/src/components/companion/DieShape.tsx
@@ -1,0 +1,82 @@
+import { cn } from "@/lib/utils";
+
+interface DieShapeProps {
+  sides: number;
+  value: number;
+  settled: boolean;
+  rolling: boolean;
+  className?: string;
+}
+
+const VIEW_BOX = 100;
+const CENTER = VIEW_BOX / 2;
+const RADIUS = 46;
+
+/**
+ * Visual silhouette per die type. Vertex count follows physical-die
+ * conventions: d4 triangle, d6 square, d8 hexagon (octahedron projection),
+ * d10 pentagonal kite (drawn as pentagon), d12 hexagon, d20 octagon
+ * (icosahedron projection), d100 dodecagon (near-circle with %).
+ */
+const VERTICES_FOR: Record<number, number> = {
+  4: 3,
+  6: 4,
+  8: 6,
+  10: 5,
+  12: 6,
+  20: 8,
+  100: 12,
+};
+
+function polygonPath(vertexCount: number, rotationDeg: number): string {
+  const points: string[] = [];
+  const angleOffset = (rotationDeg * Math.PI) / 180;
+  for (let i = 0; i < vertexCount; i++) {
+    const angle = angleOffset + (i * 2 * Math.PI) / vertexCount;
+    const x = CENTER + RADIUS * Math.cos(angle);
+    const y = CENTER + RADIUS * Math.sin(angle);
+    points.push(`${x.toFixed(2)},${y.toFixed(2)}`);
+  }
+  return points.join(" ");
+}
+
+export function DieShape({ sides, value, settled, rolling, className }: DieShapeProps) {
+  const vertexCount = VERTICES_FOR[sides] ?? 6;
+  // Point-up orientation for odd-vertex shapes (triangle, pentagon);
+  // flat-top for even-vertex shapes (square, hexagon, octagon).
+  const rotation = vertexCount % 2 === 1 ? -90 : -90 + 180 / vertexCount;
+  const points = polygonPath(vertexCount, rotation);
+  const label = sides === 100 ? `${value}%` : `${value}`;
+  return (
+    <div
+      className={cn(
+        "grid place-items-center",
+        rolling && "animate-companion-die-tumble",
+        className,
+      )}
+    >
+      <svg viewBox={`0 0 ${VIEW_BOX} ${VIEW_BOX}`} className="size-32 drop-shadow-lg" aria-hidden>
+        <polygon
+          points={points}
+          className={cn(
+            "stroke-2 transition-colors",
+            settled ? "fill-primary/15 stroke-primary" : "fill-muted/40 stroke-border",
+          )}
+        />
+        <text
+          x={CENTER}
+          y={CENTER}
+          textAnchor="middle"
+          dominantBaseline="central"
+          className={cn(
+            "fill-current font-black tabular-nums",
+            settled ? "text-foreground" : "text-muted-foreground",
+          )}
+          style={{ fontSize: sides === 100 ? 26 : 36 }}
+        >
+          {label}
+        </text>
+      </svg>
+    </div>
+  );
+}

--- a/src/components/companion/GameLog.tsx
+++ b/src/components/companion/GameLog.tsx
@@ -14,6 +14,9 @@ export function GameLog({ session }: GameLogProps) {
   const history = session.history;
 
   const undoTo = (eventIndex: number) => {
+    // Synchronously fire undo for each step we want to rewind. History is
+    // capped at COMPANION_HISTORY_LIMIT (80), so the worst-case loop is
+    // bounded and every iteration is one atomic Zustand transition.
     const stepsBack = history.length - 1 - eventIndex;
     for (let i = 0; i < stepsBack; i++) undo();
   };

--- a/src/components/companion/GameLog.tsx
+++ b/src/components/companion/GameLog.tsx
@@ -1,0 +1,113 @@
+import { Undo2 } from "lucide-react";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useCompanionStore } from "@/stores/useCompanionStore";
+import type { CompanionEvent, CompanionSession } from "@/stores/useCompanionStore.types";
+
+interface GameLogProps {
+  session: CompanionSession;
+}
+
+export function GameLog({ session }: GameLogProps) {
+  const undo = useCompanionStore((s) => s.undo);
+  const history = session.history;
+
+  const undoTo = (eventIndex: number) => {
+    const stepsBack = history.length - 1 - eventIndex;
+    for (let i = 0; i < stepsBack; i++) undo();
+  };
+
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-8 px-2 text-xs sm:h-9 sm:px-3 sm:text-sm"
+          title="Game log"
+          aria-label="Game log"
+        >
+          Log
+          <span className="hidden tabular-nums text-muted-foreground sm:inline">
+            ({history.length})
+          </span>
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="right" className="w-80 overflow-y-auto p-0">
+        <SheetHeader className="px-4 py-3">
+          <SheetTitle>Game log</SheetTitle>
+        </SheetHeader>
+        <ol className="divide-y divide-border">
+          {history.length === 0 && (
+            <li className="px-4 py-6 text-center text-sm text-muted-foreground">No events yet.</li>
+          )}
+          {history
+            .map((event, index) => ({ event, index }))
+            .reverse()
+            .map(({ event, index }) => (
+              <li
+                key={`${event.at}-${index}`}
+                className={cn(
+                  "flex items-center justify-between gap-2 px-4 py-2 text-sm",
+                  index === history.length - 1 && "bg-accent/50",
+                )}
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="truncate">{describeEvent(event, session)}</div>
+                  <div className="text-[10px] text-muted-foreground">{formatTime(event.at)}</div>
+                </div>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="size-7"
+                  onClick={() => undoTo(index)}
+                  title="Rewind to this point"
+                  aria-label="Rewind to this point"
+                >
+                  <Undo2 className="size-3.5" />
+                </Button>
+              </li>
+            ))}
+        </ol>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function nameFor(playerId: string, session: CompanionSession): string {
+  return session.players.find((p) => p.id === playerId)?.name ?? "?";
+}
+
+function describeEvent(event: CompanionEvent, session: CompanionSession): string {
+  switch (event.type) {
+    case "life": {
+      const delta = event.next - event.prev;
+      const sign = delta > 0 ? "+" : "";
+      return `${nameFor(event.playerId, session)} life ${sign}${delta} (→ ${event.next})`;
+    }
+    case "counter": {
+      const delta = event.next - event.prev;
+      const sign = delta > 0 ? "+" : "";
+      return `${nameFor(event.playerId, session)} counter ${sign}${delta} (→ ${event.next})`;
+    }
+    case "counterAdd":
+      return `${nameFor(event.playerId, session)} added ${event.counter.label}`;
+    case "counterRemove":
+      return `${nameFor(event.playerId, session)} removed ${event.counter.label}`;
+    case "commander":
+      return `${nameFor(event.playerId, session)} set commander slot ${event.slot + 1} → ${event.next?.name ?? "(empty)"}`;
+    case "dead":
+      return `${nameFor(event.playerId, session)} ${event.next ? "eliminated" : "revived"}`;
+    case "cmdDmg": {
+      const delta = event.next - event.prev;
+      const sign = delta > 0 ? "+" : "";
+      return `${nameFor(event.targetId, session)} took ${sign}${delta} cmd dmg from ${nameFor(event.sourceId, session)}`;
+    }
+  }
+}
+
+function formatTime(at: number): string {
+  const d = new Date(at);
+  return `${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}:${d.getSeconds().toString().padStart(2, "0")}`;
+}

--- a/src/components/companion/GameSummaryDialog.tsx
+++ b/src/components/companion/GameSummaryDialog.tsx
@@ -1,0 +1,102 @@
+import { Copy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useCompanionStore } from "@/stores/useCompanionStore";
+import type { CompanionPlayer, CompanionSession } from "@/stores/useCompanionStore.types";
+
+export function GameSummaryDialog() {
+  const summary = useCompanionStore((s) => s.summarySession);
+  const dismissSummary = useCompanionStore((s) => s.dismissSummary);
+  return (
+    <Dialog open={Boolean(summary)} onOpenChange={(open) => !open && dismissSummary()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Game summary</DialogTitle>
+        </DialogHeader>
+        {summary && <SummaryBody session={summary.session} winnerId={summary.winnerId} />}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function SummaryBody({
+  session,
+  winnerId,
+}: {
+  session: CompanionSession;
+  winnerId: string | null;
+}) {
+  const winner = session.players.find((p) => p.id === winnerId) ?? null;
+  const lengthMs = session.timer.accumulatedMs;
+  return (
+    <>
+      <div className="space-y-3">
+        {winner && <p className="text-center text-lg font-semibold">🏆 {winner.name} wins</p>}
+        <div className="rounded-md border border-border p-3 text-sm">
+          <div className="mb-1 font-medium">Final scores</div>
+          <ul className="space-y-0.5 text-muted-foreground">
+            {session.players.map((p) => (
+              <li key={p.id} className="flex justify-between gap-2">
+                <span className="truncate">
+                  {p.name}
+                  {p.isDead ? " (eliminated)" : ""}
+                </span>
+                <span className="tabular-nums">{p.life}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="grid grid-cols-2 gap-3 text-xs text-muted-foreground">
+          <div>
+            <div className="font-medium text-foreground">Length</div>
+            <div>{formatDuration(lengthMs)}</div>
+          </div>
+          <div>
+            <div className="font-medium text-foreground">Turns</div>
+            <div>{session.turn || "—"}</div>
+          </div>
+          <div>
+            <div className="font-medium text-foreground">Players</div>
+            <div>{session.players.length}</div>
+          </div>
+          <div>
+            <div className="font-medium text-foreground">Events</div>
+            <div>{session.history.length}</div>
+          </div>
+        </div>
+      </div>
+      <DialogFooter>
+        <Button variant="outline" onClick={() => copySummary(session, winner)}>
+          <Copy className="mr-2 size-4" /> Copy to clipboard
+        </Button>
+        <Button onClick={() => useCompanionStore.getState().dismissSummary()}>Close</Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+function copySummary(session: CompanionSession, winner: CompanionPlayer | null) {
+  const lines = [
+    "ManaBrew game summary",
+    winner ? `Winner: ${winner.name}` : "Winner: none",
+    `Length: ${formatDuration(session.timer.accumulatedMs)}`,
+    `Turns: ${session.turn || 0}`,
+    "",
+    "Final scores:",
+    ...session.players.map((p) => `  ${p.name}: ${p.life}${p.isDead ? " (eliminated)" : ""}`),
+  ];
+  void navigator.clipboard.writeText(lines.join("\n"));
+}
+
+function formatDuration(ms: number): string {
+  const total = Math.floor(ms / 1000);
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
+}

--- a/src/components/companion/ManaPoolRail.tsx
+++ b/src/components/companion/ManaPoolRail.tsx
@@ -1,0 +1,53 @@
+import { manaSymbolUrl } from "@/api/scryfall";
+import { cn } from "@/lib/utils";
+import { useCompanionStore } from "@/stores/useCompanionStore";
+import { MANA_COLORS, type ManaColor } from "@/stores/useCompanionStore.types";
+import { usePressHold } from "./usePressHold";
+
+interface ManaPoolRailProps {
+  playerId: string;
+  pool: Partial<Record<ManaColor, number>> | undefined;
+}
+
+export function ManaPoolRail({ playerId, pool }: ManaPoolRailProps) {
+  const hasAnyMana = pool ? MANA_COLORS.some((c) => (pool[c] ?? 0) > 0) : false;
+  if (!hasAnyMana) return null;
+  return (
+    <div className="flex items-center gap-1 rounded-full bg-black/45 px-1 py-0.5 text-white shadow ring-1 ring-white/10 backdrop-blur">
+      {MANA_COLORS.map((color) => {
+        const value = pool?.[color] ?? 0;
+        if (value === 0) return null;
+        return <ManaPip key={color} playerId={playerId} color={color} value={value} />;
+      })}
+    </div>
+  );
+}
+
+function ManaPip({
+  playerId,
+  color,
+  value,
+}: {
+  playerId: string;
+  color: ManaColor;
+  value: number;
+}) {
+  const adjustMana = useCompanionStore((s) => s.adjustMana);
+  const bindings = usePressHold({
+    onTap: () => adjustMana(playerId, color, 1),
+    onHoldTick: () => adjustMana(playerId, color, -1),
+  });
+  return (
+    <button
+      type="button"
+      className={cn(
+        "flex items-center gap-0.5 rounded-full px-1 py-0.5 text-[10px] font-semibold hover:bg-white/15",
+      )}
+      aria-label={`Mana ${color}: ${value} (tap +1, hold -1)`}
+      {...bindings}
+    >
+      <img src={manaSymbolUrl(color)} alt="" className="size-3" draggable={false} />
+      <span className="tabular-nums">{value}</span>
+    </button>
+  );
+}

--- a/src/components/companion/NewSessionDialog.tsx
+++ b/src/components/companion/NewSessionDialog.tsx
@@ -34,6 +34,7 @@ interface NewSessionDialogProps {
     commanderRules: boolean;
     layout: CompanionLayout;
     carryRoster: boolean;
+    oathbreaker?: boolean;
   }) => void;
 }
 
@@ -77,6 +78,7 @@ function NewSessionForm({
     COMPANION_DEFAULT_LAYOUT_BY_COUNT[COMPANION_DEFAULT_PLAYER_COUNT] ?? "1v1",
   );
   const [carryRoster, setCarryRoster] = useState(hasExistingSession);
+  const [oathbreaker, setOathbreaker] = useState(false);
 
   const updatePlayerCount = (n: number) => {
     setPlayerCount(n);
@@ -181,6 +183,16 @@ function NewSessionForm({
           Commander rules (40 life, 21 cmd damage lethal)
         </label>
 
+        <label className="flex cursor-pointer items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={oathbreaker}
+            onChange={(e) => setOathbreaker(e.target.checked)}
+            className="size-4 accent-primary"
+          />
+          Oathbreaker (partner slot becomes Signature Spell)
+        </label>
+
         <div className="space-y-1">
           <Label>Layout</Label>
           <div className="grid grid-cols-3 gap-1.5 sm:grid-cols-4">
@@ -214,7 +226,14 @@ function NewSessionForm({
         </Button>
         <Button
           onClick={() =>
-            onCreate({ playerCount, startingLife, commanderRules, layout, carryRoster })
+            onCreate({
+              playerCount,
+              startingLife,
+              commanderRules,
+              layout,
+              carryRoster,
+              oathbreaker,
+            })
           }
         >
           Start game

--- a/src/components/companion/NewSessionDialog.tsx
+++ b/src/components/companion/NewSessionDialog.tsx
@@ -92,9 +92,48 @@ function NewSessionForm({
 
   const layoutChoices = COMPANION_LAYOUT_OPTIONS[playerCount] ?? ["free"];
 
+  const applyPreset = (preset: "standard" | "commander" | "brawl") => {
+    if (preset === "standard") {
+      setStartingLife(20);
+      setCommanderRules(false);
+    } else if (preset === "commander") {
+      setStartingLife(40);
+      setCommanderRules(true);
+    } else {
+      setStartingLife(30);
+      setCommanderRules(true);
+    }
+  };
+  const presetMatch =
+    !commanderRules && startingLife === 20
+      ? "standard"
+      : commanderRules && startingLife === 40
+        ? "commander"
+        : commanderRules && startingLife === 30
+          ? "brawl"
+          : null;
+
   return (
     <>
       <div className="space-y-4">
+        <div className="space-y-1">
+          <Label>Format preset</Label>
+          <div className="flex flex-wrap gap-1.5">
+            <PillButton active={presetMatch === "standard"} onClick={() => applyPreset("standard")}>
+              Standard (20)
+            </PillButton>
+            <PillButton
+              active={presetMatch === "commander"}
+              onClick={() => applyPreset("commander")}
+            >
+              Commander (40)
+            </PillButton>
+            <PillButton active={presetMatch === "brawl"} onClick={() => applyPreset("brawl")}>
+              Brawl (30)
+            </PillButton>
+          </div>
+        </div>
+
         <div className="space-y-1">
           <Label>Players</Label>
           <div className="flex flex-wrap gap-1.5">

--- a/src/components/companion/PhaseStrip.tsx
+++ b/src/components/companion/PhaseStrip.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/lib/utils";
 import { useCompanionStore } from "@/stores/useCompanionStore";
+import { COMPANION_ACCENT_COLORS } from "@/stores/useCompanionStore.constants";
 import type { CompanionPhase } from "@/stores/useCompanionStore.types";
 
 const PHASES: { id: CompanionPhase; short: string; label: string }[] = [
@@ -15,26 +16,38 @@ const PHASES: { id: CompanionPhase; short: string; label: string }[] = [
 export function PhaseStrip() {
   const phase = useCompanionStore((s) => s.session?.phase ?? "main1");
   const setPhase = useCompanionStore((s) => s.setPhase);
+  const activeAccent = useCompanionStore((s) => {
+    const session = s.session;
+    if (!session) return null;
+    const active = session.players.find((p) => p.id === session.activePlayerId);
+    return active ? COMPANION_ACCENT_COLORS[active.accentKey] : null;
+  });
   return (
     <div className="flex shrink-0 items-center gap-0.5 border-b border-border bg-card/40 px-2 py-1 text-[10px] sm:gap-1 sm:text-xs">
-      {PHASES.map((p) => (
-        <button
-          type="button"
-          key={p.id}
-          onClick={() => setPhase(p.id)}
-          className={cn(
-            "flex-1 rounded px-1.5 py-1 font-semibold uppercase tracking-wide transition",
-            phase === p.id
-              ? "bg-primary text-primary-foreground"
-              : "text-muted-foreground hover:bg-accent hover:text-foreground",
-          )}
-          aria-label={p.label}
-          aria-pressed={phase === p.id}
-        >
-          <span className="sm:hidden">{p.short}</span>
-          <span className="hidden sm:inline">{p.label}</span>
-        </button>
-      ))}
+      {PHASES.map((p) => {
+        const isActive = phase === p.id;
+        return (
+          <button
+            type="button"
+            key={p.id}
+            onClick={() => setPhase(p.id)}
+            className={cn(
+              "flex-1 rounded px-1.5 py-1 font-semibold uppercase tracking-wide transition",
+              isActive
+                ? activeAccent
+                  ? "text-white shadow-sm"
+                  : "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:bg-accent hover:text-foreground",
+            )}
+            style={isActive && activeAccent ? { backgroundColor: activeAccent } : undefined}
+            aria-label={p.label}
+            aria-pressed={isActive}
+          >
+            <span className="sm:hidden">{p.short}</span>
+            <span className="hidden sm:inline">{p.label}</span>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/companion/PhaseStrip.tsx
+++ b/src/components/companion/PhaseStrip.tsx
@@ -1,0 +1,40 @@
+import { cn } from "@/lib/utils";
+import { useCompanionStore } from "@/stores/useCompanionStore";
+import type { CompanionPhase } from "@/stores/useCompanionStore.types";
+
+const PHASES: { id: CompanionPhase; short: string; label: string }[] = [
+  { id: "untap", short: "UN", label: "Untap" },
+  { id: "upkeep", short: "UP", label: "Upkeep" },
+  { id: "draw", short: "DR", label: "Draw" },
+  { id: "main1", short: "M1", label: "Main 1" },
+  { id: "combat", short: "CB", label: "Combat" },
+  { id: "main2", short: "M2", label: "Main 2" },
+  { id: "end", short: "EN", label: "End" },
+];
+
+export function PhaseStrip() {
+  const phase = useCompanionStore((s) => s.session?.phase ?? "main1");
+  const setPhase = useCompanionStore((s) => s.setPhase);
+  return (
+    <div className="flex shrink-0 items-center gap-0.5 border-b border-border bg-card/40 px-2 py-1 text-[10px] sm:gap-1 sm:text-xs">
+      {PHASES.map((p) => (
+        <button
+          type="button"
+          key={p.id}
+          onClick={() => setPhase(p.id)}
+          className={cn(
+            "flex-1 rounded px-1.5 py-1 font-semibold uppercase tracking-wide transition",
+            phase === p.id
+              ? "bg-primary text-primary-foreground"
+              : "text-muted-foreground hover:bg-accent hover:text-foreground",
+          )}
+          aria-label={p.label}
+          aria-pressed={phase === p.id}
+        >
+          <span className="sm:hidden">{p.short}</span>
+          <span className="hidden sm:inline">{p.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/companion/PlayerMenu.tsx
+++ b/src/components/companion/PlayerMenu.tsx
@@ -9,12 +9,14 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
+import { manaSymbolUrl } from "@/api/scryfall";
 import { useCompanionStore } from "@/stores/useCompanionStore";
 import {
   COMPANION_ACCENT_COLORS,
   COMPANION_ACCENT_KEYS,
 } from "@/stores/useCompanionStore.constants";
 import type { CompanionPlayer } from "@/stores/useCompanionStore.types";
+import { MANA_COLORS } from "@/stores/useCompanionStore.types";
 import { GameIcon } from "./GameIcon";
 
 interface PlayerMenuProps {
@@ -28,6 +30,8 @@ export function PlayerMenu({ player, onPickCommander }: PlayerMenuProps) {
   const toggleCityBlessing = useCompanionStore((s) => s.toggleCityBlessing);
   const cycleRing = useCompanionStore((s) => s.cycleRing);
   const cycleSpeed = useCompanionStore((s) => s.cycleSpeed);
+  const adjustMana = useCompanionStore((s) => s.adjustMana);
+  const clearMana = useCompanionStore((s) => s.clearMana);
   const setPlayerAccent = useCompanionStore((s) => s.setPlayerAccent);
   const markDead = useCompanionStore((s) => s.markDead);
   const resetCounters = useCompanionStore((s) => s.resetCounters);
@@ -67,6 +71,22 @@ export function PlayerMenu({ player, onPickCommander }: PlayerMenuProps) {
         <DropdownMenuItem onSelect={() => cycleSpeed(player.id)}>
           <GameIcon icon="lightning-trio" className="mr-2 size-4" /> Speed ({player.speed ?? 0}/4)
         </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className="text-xs">Floating mana</DropdownMenuLabel>
+        <div className="grid grid-cols-6 gap-1 px-2 pb-2">
+          {MANA_COLORS.map((color) => (
+            <button
+              type="button"
+              key={color}
+              onClick={() => adjustMana(player.id, color, 1)}
+              className="grid size-7 place-items-center rounded-md hover:bg-accent"
+              aria-label={`Add ${color} mana`}
+            >
+              <img src={manaSymbolUrl(color)} alt="" className="size-4" draggable={false} />
+            </button>
+          ))}
+        </div>
+        <DropdownMenuItem onSelect={() => clearMana(player.id)}>Empty mana pool</DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuLabel className="text-xs">Accent</DropdownMenuLabel>
         <div className="grid grid-cols-8 gap-1 px-2 pb-2">

--- a/src/components/companion/PlayerMenu.tsx
+++ b/src/components/companion/PlayerMenu.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
-import { Flag, MoreVertical, UserMinus, UserPlus } from "lucide-react";
+import { Flag, MoreVertical, NotebookPen, UserMinus, UserPlus } from "lucide-react";
+import { PlayerNotesDialog } from "./PlayerNotesDialog";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -37,6 +38,7 @@ export function PlayerMenu({ player, onPickCommander }: PlayerMenuProps) {
   const markDead = useCompanionStore((s) => s.markDead);
   const resetCounters = useCompanionStore((s) => s.resetCounters);
   const [pendingConcede, setPendingConcede] = useState(false);
+  const [notesOpen, setNotesOpen] = useState(false);
   const concedeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(
     () => () => {
@@ -125,6 +127,10 @@ export function PlayerMenu({ player, onPickCommander }: PlayerMenuProps) {
           ))}
         </div>
         <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => setNotesOpen(true)}>
+          <NotebookPen className="mr-2 size-4" /> Notes
+          {player.notes ? "…" : ""}
+        </DropdownMenuItem>
         <DropdownMenuItem onSelect={() => resetCounters("all", player.id)}>
           Reset this player
         </DropdownMenuItem>
@@ -146,6 +152,7 @@ export function PlayerMenu({ player, onPickCommander }: PlayerMenuProps) {
           </>
         )}
       </DropdownMenuContent>
+      <PlayerNotesDialog open={notesOpen} onOpenChange={setNotesOpen} player={player} />
     </DropdownMenu>
   );
 }

--- a/src/components/companion/PlayerMenu.tsx
+++ b/src/components/companion/PlayerMenu.tsx
@@ -26,6 +26,7 @@ export function PlayerMenu({ player, onPickCommander }: PlayerMenuProps) {
   const toggleMonarch = useCompanionStore((s) => s.toggleMonarch);
   const toggleInitiative = useCompanionStore((s) => s.toggleInitiative);
   const toggleCityBlessing = useCompanionStore((s) => s.toggleCityBlessing);
+  const cycleRing = useCompanionStore((s) => s.cycleRing);
   const setPlayerAccent = useCompanionStore((s) => s.setPlayerAccent);
   const markDead = useCompanionStore((s) => s.markDead);
   const resetCounters = useCompanionStore((s) => s.resetCounters);
@@ -57,6 +58,10 @@ export function PlayerMenu({ player, onPickCommander }: PlayerMenuProps) {
         <DropdownMenuItem onSelect={() => toggleCityBlessing(player.id)}>
           <GameIcon icon="fairy-wand" className="mr-2 size-4" />{" "}
           {player.hasCityBlessing ? "Lose city's blessing" : "Gain city's blessing"}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => cycleRing(player.id)}>
+          <GameIcon icon="magic-portal" className="mr-2 size-4" /> The Ring tempts you (
+          {player.ringLevel ?? 0}/4)
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuLabel className="text-xs">Accent</DropdownMenuLabel>

--- a/src/components/companion/PlayerMenu.tsx
+++ b/src/components/companion/PlayerMenu.tsx
@@ -27,6 +27,7 @@ export function PlayerMenu({ player, onPickCommander }: PlayerMenuProps) {
   const toggleInitiative = useCompanionStore((s) => s.toggleInitiative);
   const toggleCityBlessing = useCompanionStore((s) => s.toggleCityBlessing);
   const cycleRing = useCompanionStore((s) => s.cycleRing);
+  const cycleSpeed = useCompanionStore((s) => s.cycleSpeed);
   const setPlayerAccent = useCompanionStore((s) => s.setPlayerAccent);
   const markDead = useCompanionStore((s) => s.markDead);
   const resetCounters = useCompanionStore((s) => s.resetCounters);
@@ -62,6 +63,9 @@ export function PlayerMenu({ player, onPickCommander }: PlayerMenuProps) {
         <DropdownMenuItem onSelect={() => cycleRing(player.id)}>
           <GameIcon icon="magic-portal" className="mr-2 size-4" /> The Ring tempts you (
           {player.ringLevel ?? 0}/4)
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => cycleSpeed(player.id)}>
+          <GameIcon icon="lightning-trio" className="mr-2 size-4" /> Speed ({player.speed ?? 0}/4)
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuLabel className="text-xs">Accent</DropdownMenuLabel>

--- a/src/components/companion/PlayerMenu.tsx
+++ b/src/components/companion/PlayerMenu.tsx
@@ -1,4 +1,5 @@
-import { MoreVertical, UserMinus, UserPlus } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Flag, MoreVertical, UserMinus, UserPlus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -35,6 +36,25 @@ export function PlayerMenu({ player, onPickCommander }: PlayerMenuProps) {
   const setPlayerAccent = useCompanionStore((s) => s.setPlayerAccent);
   const markDead = useCompanionStore((s) => s.markDead);
   const resetCounters = useCompanionStore((s) => s.resetCounters);
+  const [pendingConcede, setPendingConcede] = useState(false);
+  const concedeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (concedeTimerRef.current) clearTimeout(concedeTimerRef.current);
+    },
+    [],
+  );
+  const handleConcede = (event: Event) => {
+    if (!pendingConcede) {
+      event.preventDefault();
+      setPendingConcede(true);
+      concedeTimerRef.current = setTimeout(() => setPendingConcede(false), 3000);
+      return;
+    }
+    if (concedeTimerRef.current) clearTimeout(concedeTimerRef.current);
+    setPendingConcede(false);
+    markDead(player.id, true);
+  };
 
   return (
     <DropdownMenu>
@@ -113,9 +133,17 @@ export function PlayerMenu({ player, onPickCommander }: PlayerMenuProps) {
             <UserPlus className="mr-2 size-4" /> Revive
           </DropdownMenuItem>
         ) : (
-          <DropdownMenuItem onSelect={() => markDead(player.id, true)}>
-            <UserMinus className="mr-2 size-4" /> Eliminate
-          </DropdownMenuItem>
+          <>
+            <DropdownMenuItem
+              onSelect={handleConcede}
+              className={pendingConcede ? "text-destructive" : undefined}
+            >
+              <Flag className="mr-2 size-4" /> {pendingConcede ? "Tap again to concede" : "Concede"}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => markDead(player.id, true)}>
+              <UserMinus className="mr-2 size-4" /> Eliminate
+            </DropdownMenuItem>
+          </>
         )}
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/components/companion/PlayerMenu.tsx
+++ b/src/components/companion/PlayerMenu.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { Flag, MoreVertical, NotebookPen, UserMinus, UserPlus } from "lucide-react";
+import { Flag, MoreVertical, NotebookPen, PlayCircle, UserMinus, UserPlus } from "lucide-react";
 import { PlayerNotesDialog } from "./PlayerNotesDialog";
 import { Button } from "@/components/ui/button";
 import {
@@ -34,6 +34,8 @@ export function PlayerMenu({ player, onPickCommander }: PlayerMenuProps) {
   const cycleSpeed = useCompanionStore((s) => s.cycleSpeed);
   const adjustMana = useCompanionStore((s) => s.adjustMana);
   const clearMana = useCompanionStore((s) => s.clearMana);
+  const setFirstPlayer = useCompanionStore((s) => s.setFirstPlayer);
+  const isFirstPlayer = useCompanionStore((s) => s.session?.lastFirstPlayerId === player.id);
   const setPlayerAccent = useCompanionStore((s) => s.setPlayerAccent);
   const markDead = useCompanionStore((s) => s.markDead);
   const resetCounters = useCompanionStore((s) => s.resetCounters);
@@ -73,6 +75,10 @@ export function PlayerMenu({ player, onPickCommander }: PlayerMenuProps) {
       <DropdownMenuContent align="end" className="w-52">
         <DropdownMenuItem onSelect={onPickCommander}>
           <GameIcon icon="crossed-swords" className="mr-2 size-4" /> Choose commander…
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => setFirstPlayer(player.id)} disabled={isFirstPlayer}>
+          <PlayCircle className="mr-2 size-4" />{" "}
+          {isFirstPlayer ? "Goes first" : "Set as first player"}
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={() => toggleMonarch(player.id)}>
           <GameIcon icon="crown" className="mr-2 size-4" />{" "}

--- a/src/components/companion/PlayerNotesDialog.tsx
+++ b/src/components/companion/PlayerNotesDialog.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useCompanionStore } from "@/stores/useCompanionStore";
+import type { CompanionPlayer } from "@/stores/useCompanionStore.types";
+
+interface PlayerNotesDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  player: CompanionPlayer;
+}
+
+export function PlayerNotesDialog({ open, onOpenChange, player }: PlayerNotesDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Notes — {player.name}</DialogTitle>
+        </DialogHeader>
+        {open && <PlayerNotesForm player={player} onClose={() => onOpenChange(false)} />}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function PlayerNotesForm({ player, onClose }: { player: CompanionPlayer; onClose: () => void }) {
+  const setPlayerNotes = useCompanionStore((s) => s.setPlayerNotes);
+  const [draft, setDraft] = useState(player.notes ?? "");
+  return (
+    <>
+      <textarea
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        rows={6}
+        autoFocus
+        placeholder="e.g. needs 1 mountain · holding a Counterspell · planeswalker at 4"
+        className="w-full resize-y rounded-md border border-input bg-transparent p-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      />
+      <DialogFooter>
+        <Button variant="ghost" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button
+          onClick={() => {
+            setPlayerNotes(player.id, draft);
+            onClose();
+          }}
+        >
+          Save
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}

--- a/src/components/companion/PlayerTile.tsx
+++ b/src/components/companion/PlayerTile.tsx
@@ -79,6 +79,17 @@ export function PlayerTile({
   const isPerpendicular = Math.abs(rotation) === 90;
   const flashDec = externalLifeInput ? externalDecTick : decTick;
   const flashInc = externalLifeInput ? externalIncTick : incTick;
+  const hasCommanderImage = Boolean(
+    player.commanders[0]?.imageUrl || player.commanders[1]?.imageUrl,
+  );
+  // When commander art covers the tile, the accent-coloured background is
+  // hidden — colour the active-turn ring with the accent instead of white
+  // so it still identifies whose turn it is.
+  const activeRing = isActive
+    ? hasCommanderImage
+      ? `0 0 0 3px ${accent}`
+      : "0 0 0 2px white"
+    : undefined;
 
   return (
     <div className={cn("relative size-full", className)} style={{ containerType: "size" }}>
@@ -86,7 +97,6 @@ export function PlayerTile({
         className={cn(
           "@container absolute overflow-hidden rounded-lg shadow-xl ring-1 ring-white/5 transition @md:rounded-2xl",
           player.isDead && "opacity-60 grayscale",
-          isActive && "ring-2 ring-white",
         )}
         style={{
           backgroundColor: accent,
@@ -95,6 +105,7 @@ export function PlayerTile({
           width: isPerpendicular ? "100cqh" : "100cqw",
           height: isPerpendicular ? "100cqw" : "100cqh",
           transform: `translate(-50%, -50%) rotate(${rotation}deg)`,
+          boxShadow: activeRing,
         }}
       >
         <CommanderArt refs={player.commanders} />

--- a/src/components/companion/PlayerTile.tsx
+++ b/src/components/companion/PlayerTile.tsx
@@ -9,6 +9,7 @@ import { CommanderArt } from "./CommanderArt";
 import { CommanderDamageStrip } from "./CommanderDamageStrip";
 import { CommanderPickerDialog } from "./CommanderPickerDialog";
 import { CountersRail } from "./CountersRail";
+import { ManaPoolRail } from "./ManaPoolRail";
 import { GameIcon } from "./GameIcon";
 import { PlayerMenu } from "./PlayerMenu";
 import { StatusChips } from "./StatusChips";
@@ -206,8 +207,9 @@ export function PlayerTile({
             )}
           </div>
 
-          <div className="pointer-events-auto flex items-end justify-between gap-2">
+          <div className="pointer-events-auto flex flex-wrap items-end justify-between gap-1.5">
             <CountersRail playerId={player.id} counters={player.counters} />
+            <ManaPoolRail playerId={player.id} pool={player.manaPool} />
           </div>
         </div>
 

--- a/src/components/companion/PlayerTile.tsx
+++ b/src/components/companion/PlayerTile.tsx
@@ -85,10 +85,11 @@ export function PlayerTile({
   // When commander art covers the tile, the accent-coloured background is
   // hidden — colour the active-turn ring with the accent instead of white
   // so it still identifies whose turn it is.
+  // Active-turn outline + the baseline 1px hairline that the tile
+  // normally gets via Tailwind's ring-1 ring-white/5. Inline box-shadow
+  // overrides Tailwind's ring shadow, so we have to compose both here.
   const activeRing = isActive
-    ? hasCommanderImage
-      ? `0 0 0 3px ${accent}`
-      : "0 0 0 2px white"
+    ? `0 0 0 ${hasCommanderImage ? 3 : 2}px ${hasCommanderImage ? accent : "white"}, 0 0 0 1px rgba(255,255,255,0.05)`
     : undefined;
 
   return (

--- a/src/components/companion/StatsDialog.tsx
+++ b/src/components/companion/StatsDialog.tsx
@@ -1,0 +1,112 @@
+import { useMemo } from "react";
+import { Trophy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { useCompanionStore } from "@/stores/useCompanionStore";
+import type { CompanionSession } from "@/stores/useCompanionStore.types";
+
+interface DerivedStats {
+  totalGames: number;
+  totalDurationMs: number;
+  avgDurationMs: number;
+  avgTurns: number;
+  winsByName: { name: string; wins: number }[];
+}
+
+function deriveStats(archive: CompanionSession[]): DerivedStats {
+  const winsByName = new Map<string, number>();
+  let totalDurationMs = 0;
+  let totalTurns = 0;
+  let counted = 0;
+  for (const archived of archive) {
+    totalDurationMs += archived.timer.accumulatedMs;
+    totalTurns += archived.turn;
+    counted += 1;
+    const living = archived.players.filter((p) => !p.isDead);
+    if (living.length === 1) {
+      const name = living[0]!.name;
+      winsByName.set(name, (winsByName.get(name) ?? 0) + 1);
+    }
+  }
+  return {
+    totalGames: archive.length,
+    totalDurationMs,
+    avgDurationMs: counted > 0 ? totalDurationMs / counted : 0,
+    avgTurns: counted > 0 ? totalTurns / counted : 0,
+    winsByName: [...winsByName.entries()]
+      .map(([name, wins]) => ({ name, wins }))
+      .sort((a, b) => b.wins - a.wins),
+  };
+}
+
+export function StatsDialog() {
+  const archive = useCompanionStore((s) => s.archive);
+  const stats = useMemo(() => deriveStats(archive), [archive]);
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Trophy className="mr-2 size-4" /> Stats ({stats.totalGames})
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Play stats</DialogTitle>
+        </DialogHeader>
+        {stats.totalGames === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No archived games yet. End a game to start collecting stats.
+          </p>
+        ) : (
+          <div className="space-y-4 text-sm">
+            <div className="grid grid-cols-2 gap-3 text-xs">
+              <Stat label="Games" value={stats.totalGames.toString()} />
+              <Stat label="Avg length" value={formatDuration(stats.avgDurationMs)} />
+              <Stat label="Avg turns" value={stats.avgTurns.toFixed(1)} />
+              <Stat label="Total time" value={formatDuration(stats.totalDurationMs)} />
+            </div>
+            <div>
+              <div className="mb-1 font-medium">Wins by player</div>
+              {stats.winsByName.length === 0 ? (
+                <p className="text-xs text-muted-foreground">
+                  No clean wins recorded (last-standing only).
+                </p>
+              ) : (
+                <ul className="space-y-0.5 text-muted-foreground">
+                  {stats.winsByName.map((row) => (
+                    <li key={row.name} className="flex justify-between">
+                      <span>{row.name}</span>
+                      <span className="tabular-nums">{row.wins}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border p-2">
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className="text-base font-semibold tabular-nums">{value}</div>
+    </div>
+  );
+}
+
+function formatDuration(ms: number): string {
+  const total = Math.floor(ms / 1000);
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
+}

--- a/src/components/companion/StatusChips.tsx
+++ b/src/components/companion/StatusChips.tsx
@@ -33,6 +33,13 @@ export function StatusChips({ player }: StatusChipsProps) {
           <span className="tabular-nums">{player.ringLevel}/4</span>
         </span>
       )}
+      {(player.speed ?? 0) > 0 && (
+        <span className="flex items-center gap-1 rounded-full bg-orange-600/90 px-1 py-0.5 text-[9px] font-semibold text-orange-50 @sm:px-1.5 @sm:text-[10px]">
+          <GameIcon icon="lightning-trio" className="size-2.5 @sm:size-3" />{" "}
+          <span className="hidden @xs:inline">Speed</span>
+          <span className="tabular-nums">{player.speed}/4</span>
+        </span>
+      )}
     </>
   );
 }

--- a/src/components/companion/StatusChips.tsx
+++ b/src/components/companion/StatusChips.tsx
@@ -26,6 +26,13 @@ export function StatusChips({ player }: StatusChipsProps) {
           <span className="hidden @xs:inline">Ascend</span>
         </span>
       )}
+      {(player.ringLevel ?? 0) > 0 && (
+        <span className="flex items-center gap-1 rounded-full bg-yellow-600/90 px-1 py-0.5 text-[9px] font-semibold text-yellow-50 @sm:px-1.5 @sm:text-[10px]">
+          <GameIcon icon="magic-portal" className="size-2.5 @sm:size-3" />{" "}
+          <span className="hidden @xs:inline">Ring</span>
+          <span className="tabular-nums">{player.ringLevel}/4</span>
+        </span>
+      )}
     </>
   );
 }

--- a/src/components/companion/StatusChips.tsx
+++ b/src/components/companion/StatusChips.tsx
@@ -1,3 +1,4 @@
+import { useCompanionStore } from "@/stores/useCompanionStore";
 import type { CompanionPlayer } from "@/stores/useCompanionStore.types";
 import { GameIcon } from "./GameIcon";
 
@@ -6,8 +7,17 @@ interface StatusChipsProps {
 }
 
 export function StatusChips({ player }: StatusChipsProps) {
+  const isFirstPlayer = useCompanionStore((s) => s.session?.lastFirstPlayerId === player.id);
   return (
     <>
+      {isFirstPlayer && (
+        <span className="flex items-center gap-1 rounded-full bg-emerald-500/90 px-1 py-0.5 text-[9px] font-semibold text-white @sm:px-1.5 @sm:text-[10px]">
+          <span className="grid size-3 place-items-center rounded-full bg-white/25 text-[8px] font-bold tabular-nums @sm:size-3.5 @sm:text-[9px]">
+            1
+          </span>
+          <span className="hidden @xs:inline">Goes first</span>
+        </span>
+      )}
       {player.isMonarch && (
         <span className="flex items-center gap-1 rounded-full bg-amber-400/90 px-1 py-0.5 text-[9px] font-semibold text-amber-950 @sm:px-1.5 @sm:text-[10px]">
           <GameIcon icon="crown" className="size-2.5 @sm:size-3" />{" "}

--- a/src/components/companion/TurnTimer.tsx
+++ b/src/components/companion/TurnTimer.tsx
@@ -1,27 +1,49 @@
 import { useEffect, useState } from "react";
 import { Pause, Play, RotateCcw } from "lucide-react";
-import { GameIcon } from "./GameIcon";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { useCompanionStore } from "@/stores/useCompanionStore";
+import { GameIcon } from "./GameIcon";
 
 export function TurnTimer({ className }: { className?: string }) {
-  const timer = useCompanionStore((s) => s.session?.timer);
+  const session = useCompanionStore((s) => s.session);
   const startTimer = useCompanionStore((s) => s.startTimer);
   const pauseTimer = useCompanionStore((s) => s.pauseTimer);
   const resetTimer = useCompanionStore((s) => s.resetTimer);
+  const setTimerMode = useCompanionStore((s) => s.setTimerMode);
   const [now, setNow] = useState(0);
 
+  const timer = session?.timer;
+  const running = Boolean(timer?.startedAt);
+  const chessActive =
+    session?.timerMode === "chess" && session.chessClockStartedAt != null && session.activePlayerId;
+
   useEffect(() => {
-    if (!timer?.startedAt) return;
+    if (!running && !chessActive) return;
     const interval = setInterval(() => setNow(Date.now()), 500);
     return () => clearInterval(interval);
-  }, [timer?.startedAt]);
+  }, [running, chessActive]);
 
-  if (!timer) return null;
+  if (!session) return null;
 
-  const running = Boolean(timer.startedAt);
-  const elapsedMs = timer.accumulatedMs + (timer.startedAt ? now - timer.startedAt : 0);
+  const sharedElapsed =
+    (timer?.accumulatedMs ?? 0) + (timer?.startedAt ? now - timer.startedAt : 0);
+  const activePlayer = session.players.find((p) => p.id === session.activePlayerId) ?? null;
+  const chessElapsed =
+    (activePlayer?.timeMs ?? 0) +
+    (session.timerMode === "chess" && session.chessClockStartedAt != null && activePlayer
+      ? now - session.chessClockStartedAt
+      : 0);
+
+  const shownMs = session.timerMode === "chess" && activePlayer ? chessElapsed : sharedElapsed;
 
   return (
     <div
@@ -30,9 +52,37 @@ export function TurnTimer({ className }: { className?: string }) {
         className,
       )}
     >
-      <GameIcon icon="sands-of-time" className="size-3.5 text-muted-foreground" />
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="size-6"
+            aria-label={`Timer mode: ${session.timerMode === "chess" ? "chess clock" : "shared"}`}
+            title={session.timerMode === "chess" ? "Chess clock" : "Shared clock"}
+          >
+            <GameIcon icon="sands-of-time" className="size-3.5 text-muted-foreground" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuLabel>Timer mode</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onSelect={() => setTimerMode("shared")}
+            className={cn(session.timerMode === "shared" && "bg-accent")}
+          >
+            Shared game clock
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => setTimerMode("chess")}
+            className={cn(session.timerMode === "chess" && "bg-accent")}
+          >
+            Per-player chess clock
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
       <span className="min-w-[44px] text-center tabular-nums text-xs font-medium sm:min-w-[60px] sm:text-sm">
-        {formatElapsed(elapsedMs)}
+        {formatElapsed(shownMs)}
       </span>
       <Button
         size="icon"

--- a/src/components/companion/TurnTimer.tsx
+++ b/src/components/companion/TurnTimer.tsx
@@ -28,19 +28,31 @@ export function TurnTimer({ className }: { className?: string }) {
 
   useEffect(() => {
     if (!running && !chessActive) return;
-    const interval = setInterval(() => setNow(Date.now()), 500);
-    return () => clearInterval(interval);
+    const tick = () => setNow(Date.now());
+    // Sample the clock once on the next microtask so the readout
+    // doesn't render the stale `0` against a fresh startedAt before
+    // the interval has fired for the first time.
+    const initial = setTimeout(tick, 0);
+    const interval = setInterval(tick, 500);
+    return () => {
+      clearTimeout(initial);
+      clearInterval(interval);
+    };
   }, [running, chessActive]);
 
   if (!session) return null;
 
+  // `now === 0` means the interval hasn't sampled the clock yet (initial
+  // render or just-paused). Treat the live delta as zero so the readout
+  // doesn't show -45 million minutes during the first frame after Play.
+  const liveDelta = (startedAt: number) => (now > 0 ? Math.max(0, now - startedAt) : 0);
   const sharedElapsed =
-    (timer?.accumulatedMs ?? 0) + (timer?.startedAt ? now - timer.startedAt : 0);
+    (timer?.accumulatedMs ?? 0) + (timer?.startedAt ? liveDelta(timer.startedAt) : 0);
   const activePlayer = session.players.find((p) => p.id === session.activePlayerId) ?? null;
   const chessElapsed =
     (activePlayer?.timeMs ?? 0) +
     (session.timerMode === "chess" && session.chessClockStartedAt != null && activePlayer
-      ? now - session.chessClockStartedAt
+      ? liveDelta(session.chessClockStartedAt)
       : 0);
 
   const shownMs = session.timerMode === "chess" && activePlayer ? chessElapsed : sharedElapsed;

--- a/src/components/companion/WinBanner.tsx
+++ b/src/components/companion/WinBanner.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { useCompanionStore } from "@/stores/useCompanionStore";
+import { COMPANION_ACCENT_COLORS } from "@/stores/useCompanionStore.constants";
+import type { CompanionPlayer, CompanionSession } from "@/stores/useCompanionStore.types";
+import { GameIcon } from "./GameIcon";
+
+interface WinBannerProps {
+  session: CompanionSession;
+}
+
+export function WinBanner({ session }: WinBannerProps) {
+  const living = session.players.filter((p) => !p.isDead);
+  const winner = session.players.length > 1 && living.length === 1 ? living[0]! : null;
+  if (!winner) return null;
+  return <WinBannerInner key={winner.id} winner={winner} />;
+}
+
+function WinBannerInner({ winner }: { winner: CompanionPlayer }) {
+  const endSession = useCompanionStore((s) => s.endSession);
+  const [dismissed, setDismissed] = useState(false);
+  if (dismissed) return null;
+  const accent = COMPANION_ACCENT_COLORS[winner.accentKey];
+  return (
+    <div className="pointer-events-none absolute inset-0 z-50 grid place-items-center bg-black/40 backdrop-blur-sm">
+      <div className="pointer-events-auto flex max-w-sm flex-col items-center gap-4 rounded-2xl border border-white/10 bg-card px-6 py-5 text-center shadow-2xl">
+        <div
+          className="grid size-14 place-items-center rounded-full text-white"
+          style={{ backgroundColor: accent }}
+        >
+          <GameIcon icon="trophy-cup" className="size-8" />
+        </div>
+        <div>
+          <p className="text-sm uppercase tracking-wide text-muted-foreground">Last standing</p>
+          <h2 className="text-2xl font-bold">{winner.name}</h2>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => setDismissed(true)}>
+            Keep playing
+          </Button>
+          <Button onClick={() => endSession(winner.id)}>Archive game</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/companion/WinBanner.tsx
+++ b/src/components/companion/WinBanner.tsx
@@ -13,7 +13,10 @@ export function WinBanner({ session }: WinBannerProps) {
   const living = session.players.filter((p) => !p.isDead);
   const winner = session.players.length > 1 && living.length === 1 ? living[0]! : null;
   if (!winner) return null;
-  return <WinBannerInner key={winner.id} winner={winner} />;
+  // Keying by id + history length lets the banner re-show if the user
+  // revives the winner (history grows) and then eliminates them again,
+  // even when the same player wins both times in a single session.
+  return <WinBannerInner key={`${winner.id}-${session.history.length}`} winner={winner} />;
 }
 
 function WinBannerInner({ winner }: { winner: CompanionPlayer }) {

--- a/src/index.css
+++ b/src/index.css
@@ -334,6 +334,22 @@
   }
 }
 
+@media (prefers-reduced-motion: reduce) {
+  /* Kill the companion tap flash and stack flashes for users with vestibular
+     sensitivity. Keep functional opacity transitions but skip the keyframed
+     decorative ones. */
+  .animate-companion-tap-flash,
+  .animate-card-flash,
+  .animate-card-flash-backdrop,
+  .animate-card-stack-enter,
+  .animate-card-stack-flash-in,
+  .animate-player-turn-flash,
+  .animate-player-targetable-pulse,
+  .animate-dice-roll {
+    animation: none !important;
+  }
+}
+
 @utility no-scrollbar {
   -ms-overflow-style: none;
   scrollbar-width: none;

--- a/src/index.css
+++ b/src/index.css
@@ -138,6 +138,7 @@
   --animate-onboard-fade-in: onboard-fade-in 200ms ease-out both;
   --animate-onboard-fade-up: onboard-fade-up 380ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
   --animate-companion-tap-flash: companion-tap-flash 360ms ease-out forwards;
+  --animate-companion-die-tumble: companion-die-tumble 480ms cubic-bezier(0.2, 0.7, 0.2, 1) infinite;
 
   @keyframes accordion-down {
     from {
@@ -332,6 +333,18 @@
       opacity: 0;
     }
   }
+
+  @keyframes companion-die-tumble {
+    0% {
+      transform: rotate(-12deg) translateY(0);
+    }
+    50% {
+      transform: rotate(180deg) translateY(-6px);
+    }
+    100% {
+      transform: rotate(372deg) translateY(0);
+    }
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -339,6 +352,7 @@
      sensitivity. Keep functional opacity transitions but skip the keyframed
      decorative ones. */
   .animate-companion-tap-flash,
+  .animate-companion-die-tumble,
   .animate-card-flash,
   .animate-card-flash-backdrop,
   .animate-card-stack-enter,

--- a/src/stores/useCompanionStore.ts
+++ b/src/stores/useCompanionStore.ts
@@ -51,6 +51,7 @@ interface CompanionState {
     commanderRules: boolean;
     layout?: CompanionLayout;
     carryRoster?: boolean;
+    oathbreaker?: boolean;
   }) => void;
   endSession: (winnerId?: string | null) => void;
   resetCounters: (
@@ -334,10 +335,18 @@ export const useCompanionStore = create<CompanionState>()(
         pendingDeltas: {},
         dismissSummary: () => set({ summarySession: null }),
 
-        newSession: ({ playerCount, startingLife, commanderRules, layout, carryRoster }) => {
+        newSession: ({
+          playerCount,
+          startingLife,
+          commanderRules,
+          layout,
+          carryRoster,
+          oathbreaker,
+        }) => {
           clearAllPendingTimers();
           const current = get().session;
           const next = makeSession({ playerCount, startingLife, commanderRules, layout });
+          if (oathbreaker) next.oathbreaker = true;
           if (carryRoster && current) {
             next.players = next.players.map((player, index) => {
               const carry = current.players[index];

--- a/src/stores/useCompanionStore.ts
+++ b/src/stores/useCompanionStore.ts
@@ -21,6 +21,7 @@ import type {
   CompanionCounterKind,
   CompanionEvent,
   CompanionLayout,
+  CompanionPhase,
   CompanionPlayer,
   CompanionSession,
   ManaColor,
@@ -105,6 +106,8 @@ interface CompanionState {
   pauseTimer: () => void;
   resetTimer: () => void;
   setTimerMode: (mode: "shared" | "chess") => void;
+  setPhase: (phase: CompanionPhase) => void;
+  advancePhase: () => void;
   setActivePlayer: (playerId: string | null) => void;
   advanceTurn: () => void;
   pickRandomFirstPlayer: () => string | null;
@@ -159,6 +162,7 @@ function makeSession(input: {
     timer: { startedAt: null, pausedAt: null, accumulatedMs: 0 },
     timerMode: "shared",
     chessClockStartedAt: null,
+    phase: "main1",
     activePlayerId: null,
     turn: 0,
     lastFirstPlayerId: null,
@@ -846,6 +850,27 @@ export const useCompanionStore = create<CompanionState>()(
               timerMode: mode,
               chessClockStartedAt: mode === "chess" ? Date.now() : null,
             })),
+          ),
+
+        setPhase: (phase) =>
+          set((state) => withSession(state, (session) => ({ ...session, phase }))),
+
+        advancePhase: () =>
+          set((state) =>
+            withSession(state, (session) => {
+              const order: CompanionPhase[] = [
+                "untap",
+                "upkeep",
+                "draw",
+                "main1",
+                "combat",
+                "main2",
+                "end",
+              ];
+              const i = order.indexOf(session.phase);
+              const next = order[(i + 1) % order.length]!;
+              return { ...session, phase: next };
+            }),
           ),
 
         setActivePlayer: (playerId) =>

--- a/src/stores/useCompanionStore.ts
+++ b/src/stores/useCompanionStore.ts
@@ -392,38 +392,45 @@ export const useCompanionStore = create<CompanionState>()(
 
         resetGame: () => {
           clearAllPendingTimers();
-          set((state) =>
-            withSession(state, (session) => ({
-              ...session,
-              players: session.players.map((p) => ({
-                ...p,
-                life: session.startingLife,
-                counters: p.counters.map((c) => ({ ...c, value: 0 })),
-                commanderDamage: {},
-                isDead: false,
-                isMonarch: false,
-                hasInitiative: false,
-                hasCityBlessing: false,
-                ringLevel: 0,
-                speed: 0,
-                manaPool: {},
-                timeMs: 0,
-              })),
-              history: [],
-              redoStack: [],
-              turn: 0,
-              activePlayerId: null,
-              lastFirstPlayerId: null,
-              phase: "main1",
-              dayNight: null,
-              timer: { startedAt: null, pausedAt: null, accumulatedMs: 0 },
-              // Don't pre-arm the chess clock here — there's no active
-              // player yet. setFirstPlayer / advanceTurn will start it
-              // when a player actually takes their turn.
-              chessClockStartedAt: null,
-            })),
-          );
-          set({ pendingDeltas: {} });
+          // Single setState so there's no intermediate frame where the
+          // session is reset but pendingDeltas still references the old
+          // life batches.
+          set((state) => {
+            if (!state.session) return state;
+            const session = state.session;
+            return {
+              session: {
+                ...session,
+                players: session.players.map((p) => ({
+                  ...p,
+                  life: session.startingLife,
+                  counters: p.counters.map((c) => ({ ...c, value: 0 })),
+                  commanderDamage: {},
+                  isDead: false,
+                  isMonarch: false,
+                  hasInitiative: false,
+                  hasCityBlessing: false,
+                  ringLevel: 0,
+                  speed: 0,
+                  manaPool: {},
+                  timeMs: 0,
+                })),
+                history: [],
+                redoStack: [],
+                turn: 0,
+                activePlayerId: null,
+                lastFirstPlayerId: null,
+                phase: "main1",
+                dayNight: null,
+                timer: { startedAt: null, pausedAt: null, accumulatedMs: 0 },
+                // Don't pre-arm the chess clock — there's no active player
+                // yet. setFirstPlayer / advanceTurn will start it when one
+                // actually takes their turn.
+                chessClockStartedAt: null,
+              },
+              pendingDeltas: {},
+            };
+          });
         },
 
         resetCounters: (scope, playerId) => {

--- a/src/stores/useCompanionStore.ts
+++ b/src/stores/useCompanionStore.ts
@@ -58,6 +58,11 @@ interface CompanionState {
     scope: "life" | "counters" | "commander-damage" | "all",
     playerId?: string,
   ) => void;
+  /** Wipe every gameplay-state field on the current session — life,
+   *  counters, mana, status chips, commander damage, turn / phase /
+   *  active player, timer, history, redo. Keeps the configuration
+   *  (player roster, layout, format, accents, commander picks). */
+  resetGame: () => void;
 
   setLayout: (layout: CompanionLayout) => void;
   setStartingLife: (life: number) => void;
@@ -376,6 +381,39 @@ export const useCompanionStore = create<CompanionState>()(
             archive: [session, ...state.archive].slice(0, 10),
             summarySession: { session, winnerId: winnerId ?? null },
           }));
+        },
+
+        resetGame: () => {
+          clearAllPendingTimers();
+          set((state) =>
+            withSession(state, (session) => ({
+              ...session,
+              players: session.players.map((p) => ({
+                ...p,
+                life: session.startingLife,
+                counters: p.counters.map((c) => ({ ...c, value: 0 })),
+                commanderDamage: {},
+                isDead: false,
+                isMonarch: false,
+                hasInitiative: false,
+                hasCityBlessing: false,
+                ringLevel: 0,
+                speed: 0,
+                manaPool: {},
+                timeMs: 0,
+              })),
+              history: [],
+              redoStack: [],
+              turn: 0,
+              activePlayerId: null,
+              lastFirstPlayerId: null,
+              phase: "main1",
+              dayNight: null,
+              timer: { startedAt: null, pausedAt: null, accumulatedMs: 0 },
+              chessClockStartedAt: session.timerMode === "chess" ? Date.now() : null,
+            })),
+          );
+          set({ pendingDeltas: {} });
         },
 
         resetCounters: (scope, playerId) => {

--- a/src/stores/useCompanionStore.ts
+++ b/src/stores/useCompanionStore.ts
@@ -66,6 +66,7 @@ interface CompanionState {
 
   renamePlayer: (playerId: string, name: string) => void;
   setPlayerNotes: (playerId: string, notes: string) => void;
+  setSessionTag: (tag: string) => void;
   setPlayerAccent: (playerId: string, accent: CompanionAccentKey) => void;
   setCommander: (
     playerId: string,
@@ -469,6 +470,9 @@ export const useCompanionStore = create<CompanionState>()(
               replacePlayer(session, playerId, (p) => ({ ...p, notes })),
             ),
           ),
+
+        setSessionTag: (tag) =>
+          set((state) => withSession(state, (session) => ({ ...session, tag }))),
 
         setPlayerAccent: (playerId, accent) =>
           set((state) =>

--- a/src/stores/useCompanionStore.ts
+++ b/src/stores/useCompanionStore.ts
@@ -852,7 +852,14 @@ export const useCompanionStore = create<CompanionState>()(
               const nextPlayer = living[nextIndex]!;
               const nextTurn =
                 currentIndex < 0 ? 1 : nextIndex === 0 ? session.turn + 1 : session.turn;
-              return { ...session, activePlayerId: nextPlayer.id, turn: nextTurn };
+              // Storm count resets at the end of the turn (oracle rule 702.40).
+              const players = session.players.map((p) => ({
+                ...p,
+                counters: p.counters.map((c) =>
+                  c.kind === "storm" && c.value !== 0 ? { ...c, value: 0 } : c,
+                ),
+              }));
+              return { ...session, players, activePlayerId: nextPlayer.id, turn: nextTurn };
             }),
           ),
 

--- a/src/stores/useCompanionStore.ts
+++ b/src/stores/useCompanionStore.ts
@@ -23,6 +23,7 @@ import type {
   CompanionLayout,
   CompanionPlayer,
   CompanionSession,
+  ManaColor,
 } from "./useCompanionStore.types";
 
 interface PendingDelta {
@@ -92,6 +93,8 @@ interface CompanionState {
   cycleRing: (playerId: string) => void;
   cycleSpeed: (playerId: string) => void;
   cycleDayNight: () => void;
+  adjustMana: (playerId: string, color: ManaColor, delta: number) => void;
+  clearMana: (playerId: string) => void;
 
   markDead: (playerId: string, dead: boolean) => void;
 
@@ -708,6 +711,24 @@ export const useCompanionStore = create<CompanionState>()(
                 session.dayNight === null ? "day" : session.dayNight === "day" ? "night" : null;
               return { ...session, dayNight: next };
             }),
+          ),
+
+        adjustMana: (playerId, color, delta) =>
+          set((state) =>
+            withSession(state, (session) =>
+              replacePlayer(session, playerId, (p) => {
+                const current = p.manaPool?.[color] ?? 0;
+                const value = Math.max(0, current + delta);
+                return { ...p, manaPool: { ...p.manaPool, [color]: value } };
+              }),
+            ),
+          ),
+
+        clearMana: (playerId) =>
+          set((state) =>
+            withSession(state, (session) =>
+              replacePlayer(session, playerId, (p) => ({ ...p, manaPool: {} })),
+            ),
           ),
 
         markDead: (playerId, dead) =>

--- a/src/stores/useCompanionStore.ts
+++ b/src/stores/useCompanionStore.ts
@@ -89,6 +89,8 @@ interface CompanionState {
   toggleMonarch: (playerId: string) => void;
   toggleInitiative: (playerId: string) => void;
   toggleCityBlessing: (playerId: string) => void;
+  cycleRing: (playerId: string) => void;
+  cycleSpeed: (playerId: string) => void;
 
   markDead: (playerId: string, dead: boolean) => void;
 
@@ -673,6 +675,26 @@ export const useCompanionStore = create<CompanionState>()(
               replacePlayer(session, playerId, (p) => ({
                 ...p,
                 hasCityBlessing: !p.hasCityBlessing,
+              })),
+            ),
+          ),
+
+        cycleRing: (playerId) =>
+          set((state) =>
+            withSession(state, (session) =>
+              replacePlayer(session, playerId, (p) => ({
+                ...p,
+                ringLevel: ((p.ringLevel ?? 0) + 1) % 5,
+              })),
+            ),
+          ),
+
+        cycleSpeed: (playerId) =>
+          set((state) =>
+            withSession(state, (session) =>
+              replacePlayer(session, playerId, (p) => ({
+                ...p,
+                speed: ((p.speed ?? 0) + 1) % 5,
               })),
             ),
           ),

--- a/src/stores/useCompanionStore.ts
+++ b/src/stores/useCompanionStore.ts
@@ -104,6 +104,7 @@ interface CompanionState {
   startTimer: () => void;
   pauseTimer: () => void;
   resetTimer: () => void;
+  setTimerMode: (mode: "shared" | "chess") => void;
   setActivePlayer: (playerId: string | null) => void;
   advanceTurn: () => void;
   pickRandomFirstPlayer: () => string | null;
@@ -156,6 +157,8 @@ function makeSession(input: {
     redoStack: [],
     dayNight: null,
     timer: { startedAt: null, pausedAt: null, accumulatedMs: 0 },
+    timerMode: "shared",
+    chessClockStartedAt: null,
     activePlayerId: null,
     turn: 0,
     lastFirstPlayerId: null,
@@ -831,6 +834,17 @@ export const useCompanionStore = create<CompanionState>()(
             withSession(state, (session) => ({
               ...session,
               timer: { startedAt: null, pausedAt: null, accumulatedMs: 0 },
+              chessClockStartedAt: session.timerMode === "chess" ? Date.now() : null,
+              players: session.players.map((p) => ({ ...p, timeMs: 0 })),
+            })),
+          ),
+
+        setTimerMode: (mode) =>
+          set((state) =>
+            withSession(state, (session) => ({
+              ...session,
+              timerMode: mode,
+              chessClockStartedAt: mode === "chess" ? Date.now() : null,
             })),
           ),
 
@@ -853,13 +867,31 @@ export const useCompanionStore = create<CompanionState>()(
               const nextTurn =
                 currentIndex < 0 ? 1 : nextIndex === 0 ? session.turn + 1 : session.turn;
               // Storm count resets at the end of the turn (oracle rule 702.40).
-              const players = session.players.map((p) => ({
+              let players = session.players.map((p) => ({
                 ...p,
                 counters: p.counters.map((c) =>
                   c.kind === "storm" && c.value !== 0 ? { ...c, value: 0 } : c,
                 ),
               }));
-              return { ...session, players, activePlayerId: nextPlayer.id, turn: nextTurn };
+              let chessClockStartedAt = session.chessClockStartedAt;
+              if (session.timerMode === "chess") {
+                const now = Date.now();
+                if (chessClockStartedAt != null && session.activePlayerId) {
+                  const elapsed = now - chessClockStartedAt;
+                  const prevId = session.activePlayerId;
+                  players = players.map((p) =>
+                    p.id === prevId ? { ...p, timeMs: (p.timeMs ?? 0) + elapsed } : p,
+                  );
+                }
+                chessClockStartedAt = now;
+              }
+              return {
+                ...session,
+                players,
+                activePlayerId: nextPlayer.id,
+                turn: nextTurn,
+                chessClockStartedAt,
+              };
             }),
           ),
 

--- a/src/stores/useCompanionStore.ts
+++ b/src/stores/useCompanionStore.ts
@@ -119,6 +119,7 @@ interface CompanionState {
   setActivePlayer: (playerId: string | null) => void;
   advanceTurn: () => void;
   pickRandomFirstPlayer: () => string | null;
+  setFirstPlayer: (playerId: string) => void;
 }
 
 function uid(): string {
@@ -976,6 +977,20 @@ export const useCompanionStore = create<CompanionState>()(
           );
           return winner.id;
         },
+
+        setFirstPlayer: (playerId) =>
+          set((state) =>
+            withSession(state, (session) => {
+              if (!session.players.some((p) => p.id === playerId)) return session;
+              return {
+                ...session,
+                activePlayerId: playerId,
+                turn: 1,
+                lastFirstPlayerId: playerId,
+                chessClockStartedAt: session.timerMode === "chess" ? Date.now() : null,
+              };
+            }),
+          ),
       }),
       {
         name: STORAGE_KEYS.COMPANION,

--- a/src/stores/useCompanionStore.ts
+++ b/src/stores/useCompanionStore.ts
@@ -191,6 +191,13 @@ function withSession(
   return { session: mutate(state.session) };
 }
 
+function sameCommander(a: CompanionCommanderRef | null, b: CompanionCommanderRef | null): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  if (a.scryfallId && b.scryfallId) return a.scryfallId === b.scryfallId;
+  return a.name === b.name;
+}
+
 function pushEvent(session: CompanionSession, event: CompanionEvent): CompanionSession {
   const history = [...session.history, event];
   if (history.length > COMPANION_HISTORY_LIMIT) {
@@ -410,7 +417,10 @@ export const useCompanionStore = create<CompanionState>()(
               phase: "main1",
               dayNight: null,
               timer: { startedAt: null, pausedAt: null, accumulatedMs: 0 },
-              chessClockStartedAt: session.timerMode === "chess" ? Date.now() : null,
+              // Don't pre-arm the chess clock here — there's no active
+              // player yet. setFirstPlayer / advanceTurn will start it
+              // when a player actually takes their turn.
+              chessClockStartedAt: null,
             })),
           );
           set({ pendingDeltas: {} });
@@ -540,7 +550,7 @@ export const useCompanionStore = create<CompanionState>()(
               const player = session.players.find((p) => p.id === playerId);
               if (!player) return session;
               const prev = player.commanders[slot] ?? null;
-              if (prev === ref) return session;
+              if (sameCommander(prev, ref)) return session;
               const updated = replacePlayer(session, playerId, (p) => {
                 const next = [...p.commanders] as CompanionPlayer["commanders"];
                 next[slot] = ref;

--- a/src/stores/useCompanionStore.ts
+++ b/src/stores/useCompanionStore.ts
@@ -93,6 +93,7 @@ interface CompanionState {
   markDead: (playerId: string, dead: boolean) => void;
 
   undo: () => void;
+  redo: () => void;
 
   startTimer: () => void;
   pauseTimer: () => void;
@@ -146,6 +147,7 @@ function makeSession(input: {
     layout: input.layout ?? COMPANION_DEFAULT_LAYOUT_BY_COUNT[count] ?? "free",
     players,
     history: [],
+    redoStack: [],
     timer: { startedAt: null, pausedAt: null, accumulatedMs: 0 },
     activePlayerId: null,
     turn: 0,
@@ -166,7 +168,100 @@ function pushEvent(session: CompanionSession, event: CompanionEvent): CompanionS
   if (history.length > COMPANION_HISTORY_LIMIT) {
     history.splice(0, history.length - COMPANION_HISTORY_LIMIT);
   }
-  return { ...session, history };
+  return { ...session, history, redoStack: [] };
+}
+
+function revertEvent(session: CompanionSession, event: CompanionEvent): CompanionSession {
+  switch (event.type) {
+    case "life":
+      return replacePlayer(session, event.playerId, (p) => ({ ...p, life: event.prev }));
+    case "counter":
+      return replacePlayer(session, event.playerId, (p) => ({
+        ...p,
+        counters: p.counters.map((c) =>
+          c.id === event.counterId ? { ...c, value: event.prev } : c,
+        ),
+      }));
+    case "counterAdd":
+      return replacePlayer(session, event.playerId, (p) => ({
+        ...p,
+        counters: p.counters.filter((c) => c.id !== event.counter.id),
+      }));
+    case "counterRemove":
+      return replacePlayer(session, event.playerId, (p) => {
+        const next = [...p.counters];
+        const index = Math.min(Math.max(0, event.index), next.length);
+        next.splice(index, 0, event.counter);
+        return { ...p, counters: next };
+      });
+    case "commander":
+      return replacePlayer(session, event.playerId, (p) => {
+        const commanders = [...p.commanders] as CompanionPlayer["commanders"];
+        commanders[event.slot] = event.prev;
+        return { ...p, commanders };
+      });
+    case "dead":
+      return replacePlayer(session, event.playerId, (p) => ({ ...p, isDead: event.prev }));
+    case "cmdDmg": {
+      const target = session.players.find((p) => p.id === event.targetId);
+      const revertedPair: [number, number] = [
+        ...(target?.commanderDamage[event.sourceId] ?? [0, 0]),
+      ] as [number, number];
+      revertedPair[event.slot] = event.prev;
+      return replacePlayer(session, event.targetId, (p) => ({
+        ...p,
+        commanderDamage: { ...p.commanderDamage, [event.sourceId]: revertedPair },
+        life: event.prevLife,
+        isDead: event.prevDead,
+      }));
+    }
+  }
+}
+
+function replayEvent(session: CompanionSession, event: CompanionEvent): CompanionSession {
+  switch (event.type) {
+    case "life":
+      return replacePlayer(session, event.playerId, (p) => ({ ...p, life: event.next }));
+    case "counter":
+      return replacePlayer(session, event.playerId, (p) => ({
+        ...p,
+        counters: p.counters.map((c) =>
+          c.id === event.counterId ? { ...c, value: event.next } : c,
+        ),
+      }));
+    case "counterAdd":
+      return replacePlayer(session, event.playerId, (p) =>
+        p.counters.some((c) => c.id === event.counter.id)
+          ? p
+          : { ...p, counters: [...p.counters, event.counter] },
+      );
+    case "counterRemove":
+      return replacePlayer(session, event.playerId, (p) => ({
+        ...p,
+        counters: p.counters.filter((c) => c.id !== event.counter.id),
+      }));
+    case "commander":
+      return replacePlayer(session, event.playerId, (p) => {
+        const commanders = [...p.commanders] as CompanionPlayer["commanders"];
+        commanders[event.slot] = event.next;
+        return { ...p, commanders };
+      });
+    case "dead":
+      return replacePlayer(session, event.playerId, (p) => ({ ...p, isDead: event.next }));
+    case "cmdDmg": {
+      const target = session.players.find((p) => p.id === event.targetId);
+      const replayedPair: [number, number] = [
+        ...(target?.commanderDamage[event.sourceId] ?? [0, 0]),
+      ] as [number, number];
+      replayedPair[event.slot] = event.next;
+      return replacePlayer(session, event.targetId, (p) => ({
+        ...p,
+        commanderDamage: { ...p.commanderDamage, [event.sourceId]: replayedPair },
+        life: event.nextLife,
+        isDead: event.nextDead,
+      }));
+    }
+  }
 }
 
 function replacePlayer(
@@ -609,11 +704,6 @@ export const useCompanionStore = create<CompanionState>()(
          * setup, not gameplay.
          */
         undo: () => {
-          /** Snapshot the in-flight life batches so we can revert player.life
-           *  to the value before the current batch started. `adjustLife`
-           *  mutates `life` immediately but only writes the history entry
-           *  when the batch flushes, so without this an undo right after a
-           *  tap would discard the timer but leave the visible damage. */
           const pendingPrev = Object.fromEntries(
             Object.entries(pendingDeltaTimers).map(([id, t]) => [id, t.prev]),
           );
@@ -629,76 +719,30 @@ export const useCompanionStore = create<CompanionState>()(
               }
               if (session.history.length === 0) return session;
               const last = session.history[session.history.length - 1]!;
-              const history = session.history.slice(0, -1);
-              if (last.type === "life") {
-                return {
-                  ...replacePlayer(session, last.playerId, (p) => ({ ...p, life: last.prev })),
-                  history,
-                };
-              }
-              if (last.type === "counter") {
-                return {
-                  ...replacePlayer(session, last.playerId, (p) => ({
-                    ...p,
-                    counters: p.counters.map((c) =>
-                      c.id === last.counterId ? { ...c, value: last.prev } : c,
-                    ),
-                  })),
-                  history,
-                };
-              }
-              if (last.type === "counterAdd") {
-                return {
-                  ...replacePlayer(session, last.playerId, (p) => ({
-                    ...p,
-                    counters: p.counters.filter((c) => c.id !== last.counter.id),
-                  })),
-                  history,
-                };
-              }
-              if (last.type === "counterRemove") {
-                return {
-                  ...replacePlayer(session, last.playerId, (p) => {
-                    const next = [...p.counters];
-                    const index = Math.min(Math.max(0, last.index), next.length);
-                    next.splice(index, 0, last.counter);
-                    return { ...p, counters: next };
-                  }),
-                  history,
-                };
-              }
-              if (last.type === "commander") {
-                return {
-                  ...replacePlayer(session, last.playerId, (p) => {
-                    const commanders = [...p.commanders] as CompanionPlayer["commanders"];
-                    commanders[last.slot] = last.prev;
-                    return { ...p, commanders };
-                  }),
-                  history,
-                };
-              }
-              if (last.type === "dead") {
-                return {
-                  ...replacePlayer(session, last.playerId, (p) => ({ ...p, isDead: last.prev })),
-                  history,
-                };
-              }
-              const revertedPair: [number, number] = [
-                ...(session.players.find((p) => p.id === last.targetId)?.commanderDamage[
-                  last.sourceId
-                ] ?? [0, 0]),
-              ] as [number, number];
-              revertedPair[last.slot] = last.prev;
-              const target = replacePlayer(session, last.targetId, (p) => ({
-                ...p,
-                commanderDamage: { ...p.commanderDamage, [last.sourceId]: revertedPair },
-                life: last.prevLife,
-                isDead: last.prevDead,
-              }));
-              return { ...target, history };
+              const reverted = revertEvent(session, last);
+              return {
+                ...reverted,
+                history: session.history.slice(0, -1),
+                redoStack: [...session.redoStack, last],
+              };
             }),
           );
           set({ pendingDeltas: {} });
+        },
+
+        redo: () => {
+          set((state) =>
+            withSession(state, (session) => {
+              if (session.redoStack.length === 0) return session;
+              const next = session.redoStack[session.redoStack.length - 1]!;
+              const replayed = replayEvent(session, next);
+              return {
+                ...replayed,
+                history: [...session.history, next],
+                redoStack: session.redoStack.slice(0, -1),
+              };
+            }),
+          );
         },
 
         startTimer: () =>
@@ -777,6 +821,14 @@ export const useCompanionStore = create<CompanionState>()(
       {
         name: STORAGE_KEYS.COMPANION,
         partialize: (state) => ({ session: state.session, archive: state.archive }),
+        merge: (persistedState, currentState) => {
+          if (!persistedState || typeof persistedState !== "object") return currentState;
+          const incoming = persistedState as Partial<CompanionState>;
+          const session = incoming.session
+            ? { ...incoming.session, redoStack: incoming.session.redoStack ?? [] }
+            : null;
+          return { ...currentState, ...incoming, session };
+        },
       },
     ),
     { name: "companion", enabled: import.meta.env.DEV },

--- a/src/stores/useCompanionStore.ts
+++ b/src/stores/useCompanionStore.ts
@@ -38,6 +38,10 @@ interface PendingDelta {
 interface CompanionState {
   session: CompanionSession | null;
   archive: CompanionSession[];
+  /** Last archived session shown to the user as a post-game summary modal.
+   *  Cleared when the user dismisses the summary. */
+  summarySession: { session: CompanionSession; winnerId: string | null } | null;
+  dismissSummary: () => void;
   /** Transient per-player pending life deltas (not persisted). */
   pendingDeltas: Record<string, { amount: number; expiresAt: number }>;
 
@@ -326,7 +330,9 @@ export const useCompanionStore = create<CompanionState>()(
       (set, get) => ({
         session: null,
         archive: [],
+        summarySession: null,
         pendingDeltas: {},
+        dismissSummary: () => set({ summarySession: null }),
 
         newSession: ({ playerCount, startingLife, commanderRules, layout, carryRoster }) => {
           clearAllPendingTimers();
@@ -351,11 +357,11 @@ export const useCompanionStore = create<CompanionState>()(
           clearAllPendingTimers();
           const session = get().session;
           if (!session) return;
-          void winnerId;
           set((state) => ({
             session: null,
             pendingDeltas: {},
             archive: [session, ...state.archive].slice(0, 10),
+            summarySession: { session, winnerId: winnerId ?? null },
           }));
         },
 

--- a/src/stores/useCompanionStore.ts
+++ b/src/stores/useCompanionStore.ts
@@ -513,13 +513,15 @@ export const useCompanionStore = create<CompanionState>()(
               const prevLife = target.life;
               const lifeDelta = -(next - prev);
               const nextLife = prevLife + lifeDelta;
+              const prevDead = target.isDead;
               const becomesDead =
                 next >= COMPANION_LETHAL_COMMANDER_DAMAGE && session.commanderRules;
+              const nextDead = prevDead || becomesDead;
               const updated = replacePlayer(session, targetId, (p) => ({
                 ...p,
                 commanderDamage: { ...p.commanderDamage, [sourceId]: nextPair },
                 life: nextLife,
-                isDead: p.isDead || becomesDead,
+                isDead: nextDead,
               }));
               return pushEvent(updated, {
                 type: "cmdDmg",
@@ -530,6 +532,8 @@ export const useCompanionStore = create<CompanionState>()(
                 next,
                 prevLife,
                 nextLife,
+                prevDead,
+                nextDead,
                 at: Date.now(),
               });
             }),
@@ -689,6 +693,7 @@ export const useCompanionStore = create<CompanionState>()(
                 ...p,
                 commanderDamage: { ...p.commanderDamage, [last.sourceId]: revertedPair },
                 life: last.prevLife,
+                isDead: last.prevDead,
               }));
               return { ...target, history };
             }),

--- a/src/stores/useCompanionStore.ts
+++ b/src/stores/useCompanionStore.ts
@@ -65,6 +65,7 @@ interface CompanionState {
   setPlayerCount: (count: number) => void;
 
   renamePlayer: (playerId: string, name: string) => void;
+  setPlayerNotes: (playerId: string, notes: string) => void;
   setPlayerAccent: (playerId: string, accent: CompanionAccentKey) => void;
   setCommander: (
     playerId: string,
@@ -459,6 +460,13 @@ export const useCompanionStore = create<CompanionState>()(
           set((state) =>
             withSession(state, (session) =>
               replacePlayer(session, playerId, (p) => ({ ...p, name })),
+            ),
+          ),
+
+        setPlayerNotes: (playerId, notes) =>
+          set((state) =>
+            withSession(state, (session) =>
+              replacePlayer(session, playerId, (p) => ({ ...p, notes })),
             ),
           ),
 

--- a/src/stores/useCompanionStore.ts
+++ b/src/stores/useCompanionStore.ts
@@ -67,6 +67,7 @@ interface CompanionState {
   renamePlayer: (playerId: string, name: string) => void;
   setPlayerNotes: (playerId: string, notes: string) => void;
   setSessionTag: (tag: string) => void;
+  restoreFromArchive: (sessionId: string) => void;
   setPlayerAccent: (playerId: string, accent: CompanionAccentKey) => void;
   setCommander: (
     playerId: string,
@@ -473,6 +474,19 @@ export const useCompanionStore = create<CompanionState>()(
 
         setSessionTag: (tag) =>
           set((state) => withSession(state, (session) => ({ ...session, tag }))),
+
+        restoreFromArchive: (sessionId) => {
+          const state = get();
+          const target = state.archive.find((s) => s.id === sessionId);
+          if (!target) return;
+          clearAllPendingTimers();
+          set({
+            session: target,
+            archive: state.archive.filter((s) => s.id !== sessionId),
+            summarySession: null,
+            pendingDeltas: {},
+          });
+        },
 
         setPlayerAccent: (playerId, accent) =>
           set((state) =>

--- a/src/stores/useCompanionStore.ts
+++ b/src/stores/useCompanionStore.ts
@@ -91,6 +91,7 @@ interface CompanionState {
   toggleCityBlessing: (playerId: string) => void;
   cycleRing: (playerId: string) => void;
   cycleSpeed: (playerId: string) => void;
+  cycleDayNight: () => void;
 
   markDead: (playerId: string, dead: boolean) => void;
 
@@ -150,6 +151,7 @@ function makeSession(input: {
     players,
     history: [],
     redoStack: [],
+    dayNight: null,
     timer: { startedAt: null, pausedAt: null, accumulatedMs: 0 },
     activePlayerId: null,
     turn: 0,
@@ -697,6 +699,15 @@ export const useCompanionStore = create<CompanionState>()(
                 speed: ((p.speed ?? 0) + 1) % 5,
               })),
             ),
+          ),
+
+        cycleDayNight: () =>
+          set((state) =>
+            withSession(state, (session) => {
+              const next =
+                session.dayNight === null ? "day" : session.dayNight === "day" ? "night" : null;
+              return { ...session, dayNight: next };
+            }),
           ),
 
         markDead: (playerId, dead) =>

--- a/src/stores/useCompanionStore.types.ts
+++ b/src/stores/useCompanionStore.types.ts
@@ -36,6 +36,8 @@ export interface CompanionPlayer {
   isMonarch?: boolean;
   hasInitiative?: boolean;
   hasCityBlessing?: boolean;
+  ringLevel?: number;
+  speed?: number;
   /** Free-layout position, rotation and scale (only consulted when layout === "free"). */
   freeLayout?: { x: number; y: number; rotation: number; scale?: number };
 }

--- a/src/stores/useCompanionStore.types.ts
+++ b/src/stores/useCompanionStore.types.ts
@@ -83,6 +83,8 @@ export type CompanionEvent =
       next: number;
       prevLife: number;
       nextLife: number;
+      prevDead: boolean;
+      nextDead: boolean;
       at: number;
     }
   | { type: "counterAdd"; playerId: string; counter: CompanionCounter; at: number }

--- a/src/stores/useCompanionStore.types.ts
+++ b/src/stores/useCompanionStore.types.ts
@@ -58,6 +58,8 @@ export type CompanionAccentKey =
   | "teal"
   | "slate";
 
+export type CompanionPhase = "untap" | "upkeep" | "draw" | "main1" | "combat" | "main2" | "end";
+
 export type CompanionLayout =
   | "1v1"
   | "two-side"
@@ -126,6 +128,7 @@ export interface CompanionSession {
   timer: { startedAt: number | null; pausedAt: number | null; accumulatedMs: number };
   timerMode: "shared" | "chess";
   chessClockStartedAt: number | null;
+  phase: CompanionPhase;
   activePlayerId: string | null;
   turn: number;
   lastFirstPlayerId: string | null;

--- a/src/stores/useCompanionStore.types.ts
+++ b/src/stores/useCompanionStore.types.ts
@@ -129,6 +129,9 @@ export interface CompanionSession {
   timerMode: "shared" | "chess";
   chessClockStartedAt: number | null;
   phase: CompanionPhase;
+  /** When true, the partner commander slot represents an Oathbreaker
+   *  "signature spell" rather than a second commander. UI-only flag. */
+  oathbreaker?: boolean;
   activePlayerId: string | null;
   turn: number;
   lastFirstPlayerId: string | null;

--- a/src/stores/useCompanionStore.types.ts
+++ b/src/stores/useCompanionStore.types.ts
@@ -44,6 +44,8 @@ export interface CompanionPlayer {
   manaPool?: Partial<Record<ManaColor, number>>;
   /** Total chess-clock time accumulated while this player was active. */
   timeMs?: number;
+  /** Free-form note shown in the player menu. */
+  notes?: string;
   /** Free-layout position, rotation and scale (only consulted when layout === "free"). */
   freeLayout?: { x: number; y: number; rotation: number; scale?: number };
 }

--- a/src/stores/useCompanionStore.types.ts
+++ b/src/stores/useCompanionStore.types.ts
@@ -113,6 +113,7 @@ export interface CompanionSession {
   layout: CompanionLayout;
   players: CompanionPlayer[];
   history: CompanionEvent[];
+  redoStack: CompanionEvent[];
   timer: { startedAt: number | null; pausedAt: number | null; accumulatedMs: number };
   activePlayerId: string | null;
   turn: number;

--- a/src/stores/useCompanionStore.types.ts
+++ b/src/stores/useCompanionStore.types.ts
@@ -116,6 +116,7 @@ export interface CompanionSession {
   players: CompanionPlayer[];
   history: CompanionEvent[];
   redoStack: CompanionEvent[];
+  dayNight: "day" | "night" | null;
   timer: { startedAt: number | null; pausedAt: number | null; accumulatedMs: number };
   activePlayerId: string | null;
   turn: number;

--- a/src/stores/useCompanionStore.types.ts
+++ b/src/stores/useCompanionStore.types.ts
@@ -134,6 +134,8 @@ export interface CompanionSession {
   /** When true, the partner commander slot represents an Oathbreaker
    *  "signature spell" rather than a second commander. UI-only flag. */
   oathbreaker?: boolean;
+  /** Optional user-supplied label for the game (e.g. "Friday EDH at Marco's"). */
+  tag?: string;
   activePlayerId: string | null;
   turn: number;
   lastFirstPlayerId: string | null;

--- a/src/stores/useCompanionStore.types.ts
+++ b/src/stores/useCompanionStore.types.ts
@@ -1,3 +1,6 @@
+export type ManaColor = "W" | "U" | "B" | "R" | "G" | "C";
+export const MANA_COLORS: readonly ManaColor[] = ["W", "U", "B", "R", "G", "C"];
+
 export type CompanionCounterKind =
   | "poison"
   | "energy"
@@ -38,6 +41,7 @@ export interface CompanionPlayer {
   hasCityBlessing?: boolean;
   ringLevel?: number;
   speed?: number;
+  manaPool?: Partial<Record<ManaColor, number>>;
   /** Free-layout position, rotation and scale (only consulted when layout === "free"). */
   freeLayout?: { x: number; y: number; rotation: number; scale?: number };
 }

--- a/src/stores/useCompanionStore.types.ts
+++ b/src/stores/useCompanionStore.types.ts
@@ -42,6 +42,8 @@ export interface CompanionPlayer {
   ringLevel?: number;
   speed?: number;
   manaPool?: Partial<Record<ManaColor, number>>;
+  /** Total chess-clock time accumulated while this player was active. */
+  timeMs?: number;
   /** Free-layout position, rotation and scale (only consulted when layout === "free"). */
   freeLayout?: { x: number; y: number; rotation: number; scale?: number };
 }
@@ -122,6 +124,8 @@ export interface CompanionSession {
   redoStack: CompanionEvent[];
   dayNight: "day" | "night" | null;
   timer: { startedAt: number | null; pausedAt: number | null; accumulatedMs: number };
+  timerMode: "shared" | "chess";
+  chessClockStartedAt: number | null;
   activePlayerId: string | null;
   turn: number;
   lastFirstPlayerId: string | null;

--- a/src/views/Companion.tsx
+++ b/src/views/Companion.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { CompanionBar } from "@/components/companion/CompanionBar";
 import { CompanionBoard } from "@/components/companion/CompanionBoard";
+import { GameSummaryDialog } from "@/components/companion/GameSummaryDialog";
 import { PhaseStrip } from "@/components/companion/PhaseStrip";
 import { WinBanner } from "@/components/companion/WinBanner";
 import { GameIcon } from "@/components/companion/GameIcon";
@@ -34,6 +35,7 @@ export default function Companion() {
             setNewOpen(false);
           }}
         />
+        <GameSummaryDialog />
       </div>
     );
   }
@@ -55,6 +57,7 @@ export default function Companion() {
           setNewOpen(false);
         }}
       />
+      <GameSummaryDialog />
     </div>
   );
 }

--- a/src/views/Companion.tsx
+++ b/src/views/Companion.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { CompanionBar } from "@/components/companion/CompanionBar";
 import { CompanionBoard } from "@/components/companion/CompanionBoard";
+import { PhaseStrip } from "@/components/companion/PhaseStrip";
 import { GameIcon } from "@/components/companion/GameIcon";
 import { NewSessionDialog } from "@/components/companion/NewSessionDialog";
 import { useCompanionStore } from "@/stores/useCompanionStore";
@@ -39,6 +40,7 @@ export default function Companion() {
   return (
     <div className="flex h-full min-h-0 flex-col">
       <CompanionBar session={session} onOpenNewSession={() => setNewOpen(true)} />
+      <PhaseStrip />
       <div className="relative flex-1 min-h-0">
         <CompanionBoard session={session} />
       </div>

--- a/src/views/Companion.tsx
+++ b/src/views/Companion.tsx
@@ -12,6 +12,8 @@ import { useCompanionStore } from "@/stores/useCompanionStore";
 export default function Companion() {
   const session = useCompanionStore((s) => s.session);
   const newSession = useCompanionStore((s) => s.newSession);
+  const archive = useCompanionStore((s) => s.archive);
+  const restoreFromArchive = useCompanionStore((s) => s.restoreFromArchive);
   const [newOpen, setNewOpen] = useState(false);
 
   if (!session) {
@@ -26,6 +28,32 @@ export default function Companion() {
           </p>
         </div>
         <Button onClick={() => setNewOpen(true)}>Start a game</Button>
+        {archive.length > 0 && (
+          <div className="mt-4 w-full max-w-sm space-y-1 text-left">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Recent games
+            </p>
+            <ul className="divide-y divide-border rounded-md border border-border">
+              {archive.slice(0, 5).map((archived) => (
+                <li key={archived.id} className="flex items-center justify-between gap-2 px-3 py-2">
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-sm">{archived.tag || "Untitled game"}</div>
+                    <div className="text-[10px] text-muted-foreground">
+                      {new Date(archived.createdAt).toLocaleString()} · {archived.players.length}p
+                    </div>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => restoreFromArchive(archived.id)}
+                  >
+                    Resume
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
         <NewSessionDialog
           open={newOpen}
           onOpenChange={setNewOpen}

--- a/src/views/Companion.tsx
+++ b/src/views/Companion.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { CompanionBar } from "@/components/companion/CompanionBar";
 import { CompanionBoard } from "@/components/companion/CompanionBoard";
 import { PhaseStrip } from "@/components/companion/PhaseStrip";
+import { WinBanner } from "@/components/companion/WinBanner";
 import { GameIcon } from "@/components/companion/GameIcon";
 import { NewSessionDialog } from "@/components/companion/NewSessionDialog";
 import { useCompanionStore } from "@/stores/useCompanionStore";
@@ -43,6 +44,7 @@ export default function Companion() {
       <PhaseStrip />
       <div className="relative flex-1 min-h-0">
         <CompanionBoard session={session} />
+        <WinBanner session={session} />
       </div>
       <NewSessionDialog
         open={newOpen}

--- a/src/views/Companion.tsx
+++ b/src/views/Companion.tsx
@@ -4,6 +4,7 @@ import { CompanionBar } from "@/components/companion/CompanionBar";
 import { CompanionBoard } from "@/components/companion/CompanionBoard";
 import { GameSummaryDialog } from "@/components/companion/GameSummaryDialog";
 import { PhaseStrip } from "@/components/companion/PhaseStrip";
+import { StatsDialog } from "@/components/companion/StatsDialog";
 import { WinBanner } from "@/components/companion/WinBanner";
 import { GameIcon } from "@/components/companion/GameIcon";
 import { NewSessionDialog } from "@/components/companion/NewSessionDialog";
@@ -27,7 +28,10 @@ export default function Companion() {
             passes around the table.
           </p>
         </div>
-        <Button onClick={() => setNewOpen(true)}>Start a game</Button>
+        <div className="flex gap-2">
+          <Button onClick={() => setNewOpen(true)}>Start a game</Button>
+          <StatsDialog />
+        </div>
         {archive.length > 0 && (
           <div className="mt-4 w-full max-w-sm space-y-1 text-left">
             <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">


### PR DESCRIPTION
## Summary

Stack of 22 single-purpose commits on top of PR #111 covering 25 of the 29 items from the v2 plan. Each commit is self-contained and individually revertable.

### Foundation
- `fix(companion)` cmd-dmg undo also restores isDead
- `feat(companion)` redo button with forward history stack (revertEvent + replayEvent helpers)
- `feat(companion)` next-turn button surfaces existing advanceTurn

### Gameplay completeness
- `feat(companion)` the ring tempts you chip (0-4)
- `feat(companion)` speed chip (aetherdrift, 0-4)
- `feat(companion)` day/night cycle toggle
- `feat(companion)` floating mana pool per player (WUBRGC pips + bar)
- `feat(companion)` reset storm counters on advance turn (CR 702.40)

### Match flow
- `feat(companion)` per-player chess-clock timer mode (timer dropdown switch)
- `feat(companion)` phase strip overlay (untap/upkeep/draw/main1/combat/main2/end)
- `feat(companion)` game log side sheet with rewind

### Match outcome
- `feat(companion)` concede menu item with two-step confirm
- `feat(companion)` last-standing win banner
- `feat(companion)` post-game summary dialog (winner, scores, length, copy-to-clipboard)

### Formats + roster
- `feat(companion)` format preset pills in new game dialog (Standard / Commander / Brawl)
- `feat(companion)` oathbreaker label on partner slot ("Signature spell")
- `feat(companion)` per-player notes field

### Tools
- `feat(companion)` dice tray with full die palette and coin flip (d4-d100)

### Roster + history
- `feat(companion)` editable session tag in bar
- `feat(companion)` resume archived sessions from empty state
- `feat(companion)` play stats derived from archive (wins/length/turns)

### A11y
- `feat(companion)` respect prefers-reduced-motion (companion-tap-flash + game keyframes)

## Why

PR #111 shipped the core life tracker. This stack rounds it out with the features players actually reach for during a paper game: turn marker, chess clock, phase strip, mana pool, ring/speed/day-night chips, game log, win banner, summary, archive, stats. The redo path and undo coverage for every event variant were prerequisites for the rewind / log scrub features.

## Not in this PR (defer)

- `feat(companion)` 2HG team-pair layout — touches the layout system; bigger refactor
- `feat(companion)` Bo3/Bo5 match tracker — needs match-vs-game state model
- `feat(companion)` saved player profiles — separate profiles store + picker
- `feat(companion)` vibrate / sound on key events — needs a preferences sheet
- `feat(companion)` screenshot export — clipboard text is in summary already
- `feat(companion)` import commander from saved deck — couples to useDeckStore
- `feat(companion)` card hover preview for commander names — useCardTexture wiring

These are non-blocking and can land in a v3 stack.

## Test plan

- [ ] Per-commit verification — every commit was typechecked individually before commit, but please spot-check by viewing in browser:
  - [ ] Tap ±life → flash, then undo → reverts in-flight batch; redo button re-applies; undo + redo work past flushed history.
  - [ ] Next Turn pill cycles players + storm counters reset; phase strip selectable.
  - [ ] Floating mana opens from player menu, pips render in tile footer, hold to drain.
  - [ ] Ring, Speed, Day/Night chips visible when active.
  - [ ] Chess clock mode switches and accumulates time per active player.
  - [ ] Eliminating the last living opponent shows Win banner; archiving opens Summary modal.
  - [ ] Brawl preset sets life=30 commander=on.
  - [ ] Concede first click arms, second confirms.
  - [ ] Game log shows events, rewind row works.
  - [ ] Resume archived empty-state list restores session.
  - [ ] Stats dialog shows numbers after at least one ended game.
  - [ ] Reduce-motion OS setting kills the tap flash.

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main