### PR TITLE
feat(companion): focus mode, bar restructure, mobile polish

### DIFF
--- a/src/components/companion/CompanionBar.tsx
+++ b/src/components/companion/CompanionBar.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
-import { ChevronRight, EyeOff, Moon, Redo2, Shuffle, Sun, SunMoon, Undo2 } from "lucide-react";
-import { GameIcon } from "./GameIcon";
+import { ChevronRight, EyeOff, Moon, Redo2, Sun, SunMoon, Undo2 } from "lucide-react";
 import { LayoutIcon } from "./LayoutIcon";
 import { Button } from "@/components/ui/button";
 import {
@@ -19,13 +18,11 @@ import {
   COMPANION_LAYOUT_OPTIONS,
 } from "@/stores/useCompanionStore.constants";
 import type { CompanionSession } from "@/stores/useCompanionStore.types";
-import { DiceRoller } from "./DiceRoller";
+import { DiceMenu } from "./DiceMenu";
 import { FocusModeButton } from "./FocusModeButton";
 import { GameLog } from "./GameLog";
 import { SetupMenu } from "./SetupMenu";
 import { TurnTimer } from "./TurnTimer";
-
-const DICE = [4, 6, 8, 10, 12, 20, 100] as const;
 
 interface CompanionBarProps {
   session: CompanionSession;
@@ -37,8 +34,6 @@ interface CompanionBarProps {
    *  the chrome back down without exiting focus mode. */
   onHidePeek?: () => void;
 }
-
-type Roll = { kind: "die"; sides: number } | { kind: "coin" } | { kind: "first" };
 
 export function CompanionBar({
   session,
@@ -53,10 +48,8 @@ export function CompanionBar({
   const canRedo = useCompanionStore((s) => (s.session?.redoStack.length ?? 0) > 0);
   const advanceTurn = useCompanionStore((s) => s.advanceTurn);
   const cycleDayNight = useCompanionStore((s) => s.cycleDayNight);
-  const pickRandom = useCompanionStore((s) => s.pickRandomFirstPlayer);
 
   const activePlayer = session.players.find((p) => p.id === session.activePlayerId) ?? null;
-  const [roll, setRoll] = useState<Roll | null>(null);
   const [logOpen, setLogOpen] = useState(false);
   const DayNightIcon =
     session.dayNight === "night" ? Moon : session.dayNight === "day" ? Sun : SunMoon;
@@ -147,35 +140,7 @@ export function CompanionBar({
 
         <TurnTimer />
 
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              size="icon"
-              variant="outline"
-              className="size-8 sm:size-9"
-              aria-label="Dice and randomizers"
-              title="Dice, coin, random first player"
-            >
-              <GameIcon icon="d20" className="size-4 sm:size-5" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-40">
-            <DropdownMenuLabel>Roll</DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            {DICE.map((sides) => (
-              <DropdownMenuItem key={sides} onSelect={() => setRoll({ kind: "die", sides })}>
-                d{sides}
-              </DropdownMenuItem>
-            ))}
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={() => setRoll({ kind: "coin" })}>
-              Coin flip
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => setRoll({ kind: "first" })}>
-              <Shuffle className="mr-2 size-4" /> Random first player
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <DiceMenu players={session.players} />
 
         <Button
           size="icon"
@@ -215,26 +180,6 @@ export function CompanionBar({
       </div>
 
       <GameLog session={session} open={logOpen} onOpenChange={setLogOpen} />
-
-      {roll?.kind === "die" && (
-        <DiceRoller
-          mode="die"
-          sides={roll.sides}
-          open
-          onOpenChange={(open) => !open && setRoll(null)}
-        />
-      )}
-      {roll?.kind === "coin" && (
-        <DiceRoller mode="coin" open onOpenChange={(open) => !open && setRoll(null)} />
-      )}
-      {roll?.kind === "first" && (
-        <DiceRoller
-          open
-          onOpenChange={(open) => !open && setRoll(null)}
-          players={session.players}
-          pickWinner={pickRandom}
-        />
-      )}
     </div>
   );
 }

--- a/src/components/companion/CompanionBar.tsx
+++ b/src/components/companion/CompanionBar.tsx
@@ -1,17 +1,5 @@
 import { useState } from "react";
-import {
-  ChevronRight,
-  Minus,
-  Moon,
-  Plus,
-  Redo2,
-  RotateCcw,
-  Shuffle,
-  Sun,
-  SunMoon,
-  Undo2,
-  XOctagon,
-} from "lucide-react";
+import { ChevronRight, EyeOff, Moon, Redo2, Shuffle, Sun, SunMoon, Undo2 } from "lucide-react";
 import { GameIcon } from "./GameIcon";
 import { LayoutIcon } from "./LayoutIcon";
 import { Button } from "@/components/ui/button";
@@ -29,120 +17,66 @@ import {
   COMPANION_ACCENT_COLORS,
   COMPANION_LAYOUT_LABELS,
   COMPANION_LAYOUT_OPTIONS,
-  COMPANION_MAX_PLAYERS,
-  COMPANION_MIN_PLAYERS,
-  COMPANION_STARTING_LIFE_PRESETS,
 } from "@/stores/useCompanionStore.constants";
 import type { CompanionSession } from "@/stores/useCompanionStore.types";
 import { DiceRoller } from "./DiceRoller";
-import { DiceTray } from "./DiceTray";
+import { FocusModeButton } from "./FocusModeButton";
 import { GameLog } from "./GameLog";
+import { SetupMenu } from "./SetupMenu";
 import { TurnTimer } from "./TurnTimer";
+
+const DICE = [4, 6, 8, 10, 12, 20, 100] as const;
 
 interface CompanionBarProps {
   session: CompanionSession;
   onOpenNewSession: () => void;
+  focus: boolean;
+  onToggleFocus: (next: boolean) => void;
+  /** When set, the bar is being rendered as the focus-mode peek overlay
+   *  — show a hide-peek control alongside Focus so the user can collapse
+   *  the chrome back down without exiting focus mode. */
+  onHidePeek?: () => void;
 }
 
-export function CompanionBar({ session, onOpenNewSession }: CompanionBarProps) {
+type Roll = { kind: "die"; sides: number } | { kind: "coin" } | { kind: "first" };
+
+export function CompanionBar({
+  session,
+  onOpenNewSession,
+  focus,
+  onToggleFocus,
+  onHidePeek,
+}: CompanionBarProps) {
   const setLayout = useCompanionStore((s) => s.setLayout);
-  const setPlayerCount = useCompanionStore((s) => s.setPlayerCount);
-  const setStartingLife = useCompanionStore((s) => s.setStartingLife);
-  const setCommanderRules = useCompanionStore((s) => s.setCommanderRules);
   const undo = useCompanionStore((s) => s.undo);
   const redo = useCompanionStore((s) => s.redo);
   const canRedo = useCompanionStore((s) => (s.session?.redoStack.length ?? 0) > 0);
   const advanceTurn = useCompanionStore((s) => s.advanceTurn);
   const cycleDayNight = useCompanionStore((s) => s.cycleDayNight);
-  const activePlayer = session.players.find((p) => p.id === session.activePlayerId) ?? null;
-  const DayNightIcon =
-    session.dayNight === "night" ? Moon : session.dayNight === "day" ? Sun : SunMoon;
-  const resetCounters = useCompanionStore((s) => s.resetCounters);
-  const resetGame = useCompanionStore((s) => s.resetGame);
-  const endSession = useCompanionStore((s) => s.endSession);
   const pickRandom = useCompanionStore((s) => s.pickRandomFirstPlayer);
 
-  const [diceOpen, setDiceOpen] = useState(false);
-  const setSessionTag = useCompanionStore((s) => s.setSessionTag);
-  const [editingTag, setEditingTag] = useState(false);
+  const activePlayer = session.players.find((p) => p.id === session.activePlayerId) ?? null;
+  const [roll, setRoll] = useState<Roll | null>(null);
+  const [logOpen, setLogOpen] = useState(false);
+  const DayNightIcon =
+    session.dayNight === "night" ? Moon : session.dayNight === "day" ? Sun : SunMoon;
 
   const layoutChoices = COMPANION_LAYOUT_OPTIONS[session.players.length] ?? ["free"];
 
   return (
-    <div className="flex flex-wrap items-center gap-1 border-b border-border bg-card/70 px-2 py-1.5 backdrop-blur sm:gap-2 sm:px-3 sm:py-2">
+    <div className="flex flex-wrap items-center gap-0.5 border-b border-border bg-card/70 px-1.5 py-1 backdrop-blur sm:gap-2 sm:px-3 sm:py-2">
       <Button
         size="sm"
         onClick={onOpenNewSession}
         className="h-8 px-2 text-xs sm:h-9 sm:px-4 sm:text-sm"
+        aria-label="New game"
+        title="New game"
       >
-        <span className="sm:hidden">New</span>
         <span className="hidden sm:inline">New game</span>
+        <span className="sm:hidden">+</span>
       </Button>
 
-      <div className="flex items-center gap-0.5 rounded-md bg-muted/60 px-1 py-0.5 sm:gap-1 sm:px-1.5 sm:py-1">
-        <span className="hidden text-xs text-muted-foreground sm:inline">Players</span>
-        <Button
-          size="icon"
-          variant="ghost"
-          className="size-6"
-          onClick={() => setPlayerCount(session.players.length - 1)}
-          disabled={session.players.length <= COMPANION_MIN_PLAYERS}
-          aria-label="Fewer players"
-        >
-          <Minus className="size-3.5" />
-        </Button>
-        <span className="min-w-4 text-center tabular-nums text-sm font-semibold">
-          {session.players.length}
-        </span>
-        <Button
-          size="icon"
-          variant="ghost"
-          className="size-6"
-          onClick={() => setPlayerCount(session.players.length + 1)}
-          disabled={session.players.length >= COMPANION_MAX_PLAYERS}
-          aria-label="More players"
-        >
-          <Plus className="size-3.5" />
-        </Button>
-      </div>
-
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            size="sm"
-            variant="outline"
-            className="h-8 gap-1 px-2 text-xs sm:h-9 sm:px-3 sm:text-sm"
-          >
-            <span className="hidden sm:inline">Life:</span>
-            <span className="tabular-nums font-semibold">{session.startingLife}</span>
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent>
-          <DropdownMenuLabel>Starting life</DropdownMenuLabel>
-          <DropdownMenuSeparator />
-          {COMPANION_STARTING_LIFE_PRESETS.map((value) => (
-            <DropdownMenuItem
-              key={value}
-              onSelect={() => setStartingLife(value)}
-              className={cn(value === session.startingLife && "bg-accent")}
-            >
-              {value}
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
-
-      <Button
-        size="sm"
-        variant={session.commanderRules ? "default" : "outline"}
-        onClick={() => setCommanderRules(!session.commanderRules)}
-        className="h-8 gap-1 px-2 sm:h-9 sm:px-3"
-        aria-label="Toggle commander rules"
-        title="Commander rules"
-      >
-        <GameIcon icon="crown" className="size-3.5" />
-        <span className="hidden sm:inline">Commander</span>
-      </Button>
+      <SetupMenu session={session} onOpenLog={() => setLogOpen(true)} />
 
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
@@ -173,52 +107,27 @@ export function CompanionBar({ session, onOpenNewSession }: CompanionBarProps) {
         </DropdownMenuContent>
       </DropdownMenu>
 
-      {editingTag ? (
-        <input
-          autoFocus
-          defaultValue={session.tag ?? ""}
-          placeholder="Game title…"
-          className="h-8 w-40 rounded-md border border-input bg-background px-2 text-xs"
-          onBlur={(e) => {
-            setSessionTag(e.target.value.trim());
-            setEditingTag(false);
-          }}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") (e.target as HTMLInputElement).blur();
-            if (e.key === "Escape") setEditingTag(false);
-          }}
-        />
-      ) : (
-        <button
-          type="button"
-          onClick={() => setEditingTag(true)}
-          className="hidden truncate text-xs text-muted-foreground hover:text-foreground sm:inline"
-          title="Edit game title"
-        >
-          {session.tag || "Untitled game"}
-        </button>
-      )}
-
-      <div className="ml-auto flex flex-wrap items-center gap-1 sm:gap-2">
+      <div className="ml-auto flex flex-wrap items-center gap-0.5 sm:gap-2">
         <Button
           size="sm"
           variant={activePlayer ? "default" : "outline"}
           onClick={advanceTurn}
-          className="h-8 gap-1 px-2 text-xs text-white shadow-sm sm:h-9 sm:px-3 sm:text-sm"
+          className="h-8 gap-1 px-1.5 text-xs text-white shadow-sm sm:h-9 sm:px-3 sm:text-sm"
           style={
             activePlayer
               ? { backgroundColor: COMPANION_ACCENT_COLORS[activePlayer.accentKey] }
               : undefined
           }
-          aria-label="Next turn"
+          aria-label={activePlayer ? `Turn ${session.turn} · ${activePlayer.name}` : "Start turn"}
           title={activePlayer ? `Turn ${session.turn} · ${activePlayer.name}` : "Start turn"}
         >
           <ChevronRight className="size-3.5" />
           <span className="hidden tabular-nums sm:inline">
             {activePlayer ? `T${session.turn} · ${activePlayer.name}` : "Start"}
           </span>
-          <span className="tabular-nums sm:hidden">T{session.turn}</span>
+          <span className="tabular-nums sm:hidden">T{session.turn || 1}</span>
         </Button>
+
         <Button
           size="icon"
           variant={session.dayNight ? "default" : "ghost"}
@@ -235,19 +144,39 @@ export function CompanionBar({ session, onOpenNewSession }: CompanionBarProps) {
         >
           <DayNightIcon className="size-4" />
         </Button>
+
         <TurnTimer />
-        <GameLog session={session} />
-        <DiceTray />
-        <Button
-          size="icon"
-          variant="outline"
-          onClick={() => setDiceOpen(true)}
-          className="size-8 sm:size-9"
-          aria-label="Random first player"
-          title="Random first player"
-        >
-          <Shuffle className="size-4 sm:size-5" />
-        </Button>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              size="icon"
+              variant="outline"
+              className="size-8 sm:size-9"
+              aria-label="Dice and randomizers"
+              title="Dice, coin, random first player"
+            >
+              <GameIcon icon="d20" className="size-4 sm:size-5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-40">
+            <DropdownMenuLabel>Roll</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {DICE.map((sides) => (
+              <DropdownMenuItem key={sides} onSelect={() => setRoll({ kind: "die", sides })}>
+                d{sides}
+              </DropdownMenuItem>
+            ))}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => setRoll({ kind: "coin" })}>
+              Coin flip
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setRoll({ kind: "first" })}>
+              <Shuffle className="mr-2 size-4" /> Random first player
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
         <Button
           size="icon"
           variant="ghost"
@@ -269,47 +198,43 @@ export function CompanionBar({ session, onOpenNewSession }: CompanionBarProps) {
         >
           <Redo2 className="size-4" />
         </Button>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button size="icon" variant="ghost" className="size-8" aria-label="More actions">
-              <RotateCcw className="size-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuLabel>Reset</DropdownMenuLabel>
-            <DropdownMenuItem onSelect={() => resetCounters("life")}>
-              <Redo2 className="mr-2 size-4" /> Life only
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => resetCounters("counters")}>
-              <Redo2 className="mr-2 size-4" /> Counters only
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => resetCounters("commander-damage")}>
-              <Redo2 className="mr-2 size-4" /> Commander damage
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={() => resetGame()}>
-              Reset everything (turn, timer, history)
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-        <Button
-          size="icon"
-          variant="ghost"
-          className="size-8 text-destructive hover:text-destructive"
-          onClick={() => endSession()}
-          aria-label="End game"
-          title="End game"
-        >
-          <XOctagon className="size-4" />
-        </Button>
+
+        {onHidePeek && (
+          <Button
+            size="icon"
+            variant="ghost"
+            className="size-8"
+            onClick={onHidePeek}
+            aria-label="Hide controls"
+            title="Hide bar and phase strip"
+          >
+            <EyeOff className="size-4" />
+          </Button>
+        )}
+        <FocusModeButton focus={focus} onToggle={onToggleFocus} />
       </div>
 
-      <DiceRoller
-        open={diceOpen}
-        onOpenChange={setDiceOpen}
-        players={session.players}
-        pickWinner={pickRandom}
-      />
+      <GameLog session={session} open={logOpen} onOpenChange={setLogOpen} />
+
+      {roll?.kind === "die" && (
+        <DiceRoller
+          mode="die"
+          sides={roll.sides}
+          open
+          onOpenChange={(open) => !open && setRoll(null)}
+        />
+      )}
+      {roll?.kind === "coin" && (
+        <DiceRoller mode="coin" open onOpenChange={(open) => !open && setRoll(null)} />
+      )}
+      {roll?.kind === "first" && (
+        <DiceRoller
+          open
+          onOpenChange={(open) => !open && setRoll(null)}
+          players={session.players}
+          pickWinner={pickRandom}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/companion/DiceMenu.tsx
+++ b/src/components/companion/DiceMenu.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+import { Shuffle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useCompanionStore } from "@/stores/useCompanionStore";
+import type { CompanionPlayer } from "@/stores/useCompanionStore.types";
+import { DiceRoller } from "./DiceRoller";
+import { GameIcon } from "./GameIcon";
+
+const DICE = [4, 6, 8, 10, 12, 20, 100] as const;
+
+type Roll = { kind: "die"; sides: number } | { kind: "coin" } | { kind: "first" };
+
+interface DiceMenuProps {
+  players: CompanionPlayer[];
+}
+
+/**
+ * Single-entry-point dice control: d4 / d6 / d8 / d10 / d12 / d20 / d100,
+ * coin flip, and random first player all live behind one d20 dropdown
+ * trigger. Each selection opens the shared DiceRoller modal in the
+ * matching mode.
+ */
+export function DiceMenu({ players }: DiceMenuProps) {
+  const pickRandom = useCompanionStore((s) => s.pickRandomFirstPlayer);
+  const [roll, setRoll] = useState<Roll | null>(null);
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            size="icon"
+            variant="outline"
+            className="size-8 sm:size-9"
+            aria-label="Dice and randomizers"
+            title="Dice, coin, random first player"
+          >
+            <GameIcon icon="d20" className="size-4 sm:size-5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-40">
+          <DropdownMenuLabel>Roll</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          {DICE.map((sides) => (
+            <DropdownMenuItem key={sides} onSelect={() => setRoll({ kind: "die", sides })}>
+              d{sides}
+            </DropdownMenuItem>
+          ))}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => setRoll({ kind: "coin" })}>Coin flip</DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setRoll({ kind: "first" })}>
+            <Shuffle className="mr-2 size-4" /> Random first player
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {roll?.kind === "die" && (
+        <DiceRoller
+          mode="die"
+          sides={roll.sides}
+          open
+          onOpenChange={(open) => !open && setRoll(null)}
+        />
+      )}
+      {roll?.kind === "coin" && (
+        <DiceRoller mode="coin" open onOpenChange={(open) => !open && setRoll(null)} />
+      )}
+      {roll?.kind === "first" && (
+        <DiceRoller
+          open
+          onOpenChange={(open) => !open && setRoll(null)}
+          players={players}
+          pickWinner={pickRandom}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/companion/FocusExitButton.tsx
+++ b/src/components/companion/FocusExitButton.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import { Eye, EyeOff, Minimize2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface FocusExitButtonProps {
+  onExit: () => void;
+  chromeVisible: boolean;
+  onToggleChrome: (next: boolean) => void;
+}
+
+const AUTO_DIM_AFTER_MS = 4000;
+
+/**
+ * Floating focus-mode control cluster for touch devices. Pinned to the
+ * top-right inside the safe-area-inset; full opacity for the first few
+ * seconds, then dims to a small always-tappable chip. Houses two
+ * actions: peek the bar + phase strip back in (without leaving focus
+ * mode) and exit focus entirely.
+ */
+export function FocusExitButton({ onExit, chromeVisible, onToggleChrome }: FocusExitButtonProps) {
+  const [bright, setBright] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setBright(false), AUTO_DIM_AFTER_MS);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const handleExit = () => {
+    onExit();
+    if (document.fullscreenElement && document.exitFullscreen) {
+      document.exitFullscreen().catch(() => {
+        /* already exited */
+      });
+    }
+  };
+
+  const wake = () => setBright(true);
+
+  return (
+    <div
+      onPointerEnter={wake}
+      onPointerDown={wake}
+      onTouchStart={wake}
+      className={cn(
+        "pointer-events-auto fixed right-[calc(env(safe-area-inset-right)+12px)] top-[calc(env(safe-area-inset-top)+12px)] z-[60] flex items-center gap-1 rounded-full border border-border bg-card/90 px-1 py-1 shadow-xl backdrop-blur transition-opacity",
+        bright ? "opacity-100" : "opacity-40",
+      )}
+    >
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={() => onToggleChrome(!chromeVisible)}
+        className="h-9 gap-1 rounded-full px-3 text-xs font-semibold"
+        aria-label={chromeVisible ? "Hide controls" : "Show controls"}
+        title={chromeVisible ? "Hide bar and phase strip" : "Peek bar and phase strip"}
+      >
+        {chromeVisible ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+      </Button>
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={handleExit}
+        className="h-9 gap-1 rounded-full px-3 text-xs font-semibold"
+        aria-label="Exit focus mode"
+        title="Exit focus mode"
+      >
+        <Minimize2 className="size-4" />
+        <span>Exit</span>
+      </Button>
+    </div>
+  );
+}

--- a/src/components/companion/FocusExitButton.tsx
+++ b/src/components/companion/FocusExitButton.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useState } from "react";
-import { Eye, EyeOff, Minimize2 } from "lucide-react";
+import { Eye, Minimize2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 interface FocusExitButtonProps {
   onExit: () => void;
-  chromeVisible: boolean;
-  onToggleChrome: (next: boolean) => void;
+  onShowChrome: () => void;
 }
 
 const AUTO_DIM_AFTER_MS = 4000;
@@ -16,9 +15,11 @@ const AUTO_DIM_AFTER_MS = 4000;
  * top-right inside the safe-area-inset; full opacity for the first few
  * seconds, then dims to a small always-tappable chip. Houses two
  * actions: peek the bar + phase strip back in (without leaving focus
- * mode) and exit focus entirely.
+ * mode) and exit focus entirely. Only mounted while focus is on AND
+ * the chrome is hidden — the hide-peek control lives in the bar
+ * itself once chrome is visible.
  */
-export function FocusExitButton({ onExit, chromeVisible, onToggleChrome }: FocusExitButtonProps) {
+export function FocusExitButton({ onExit, onShowChrome }: FocusExitButtonProps) {
   const [bright, setBright] = useState(true);
 
   useEffect(() => {
@@ -50,12 +51,12 @@ export function FocusExitButton({ onExit, chromeVisible, onToggleChrome }: Focus
       <Button
         size="sm"
         variant="ghost"
-        onClick={() => onToggleChrome(!chromeVisible)}
+        onClick={onShowChrome}
         className="h-9 gap-1 rounded-full px-3 text-xs font-semibold"
-        aria-label={chromeVisible ? "Hide controls" : "Show controls"}
-        title={chromeVisible ? "Hide bar and phase strip" : "Peek bar and phase strip"}
+        aria-label="Show controls"
+        title="Peek bar and phase strip"
       >
-        {chromeVisible ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+        <Eye className="size-4" />
       </Button>
       <Button
         size="sm"

--- a/src/components/companion/FocusModeButton.tsx
+++ b/src/components/companion/FocusModeButton.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { Maximize2, Minimize2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
@@ -12,18 +11,11 @@ interface FocusModeButtonProps {
  * focus mode that hands the whole viewport to the player tiles — meant for
  * the "phone in the centre of the table" use case. Also drives the browser
  * Fullscreen API so the address bar / status bar disappear too on mobile.
+ * Esc / system-gesture sync lives in `Companion.tsx`, not here — that
+ * keeps the listener registered exactly once, owned by the focus-state
+ * holder.
  */
 export function FocusModeButton({ focus, onToggle }: FocusModeButtonProps) {
-  // Sync focus state if the user exits browser fullscreen via Esc or the
-  // system gesture so the in-app UI doesn't lie about its mode.
-  useEffect(() => {
-    const onChange = () => {
-      if (!document.fullscreenElement && focus) onToggle(false);
-    };
-    document.addEventListener("fullscreenchange", onChange);
-    return () => document.removeEventListener("fullscreenchange", onChange);
-  }, [focus, onToggle]);
-
   const toggle = () => {
     const next = !focus;
     onToggle(next);

--- a/src/components/companion/FocusModeButton.tsx
+++ b/src/components/companion/FocusModeButton.tsx
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+import { Maximize2, Minimize2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface FocusModeButtonProps {
+  focus: boolean;
+  onToggle: (next: boolean) => void;
+}
+
+/**
+ * Toggle between the standard bar+strip companion layout and a chrome-free
+ * focus mode that hands the whole viewport to the player tiles — meant for
+ * the "phone in the centre of the table" use case. Also drives the browser
+ * Fullscreen API so the address bar / status bar disappear too on mobile.
+ */
+export function FocusModeButton({ focus, onToggle }: FocusModeButtonProps) {
+  // Sync focus state if the user exits browser fullscreen via Esc or the
+  // system gesture so the in-app UI doesn't lie about its mode.
+  useEffect(() => {
+    const onChange = () => {
+      if (!document.fullscreenElement && focus) onToggle(false);
+    };
+    document.addEventListener("fullscreenchange", onChange);
+    return () => document.removeEventListener("fullscreenchange", onChange);
+  }, [focus, onToggle]);
+
+  const toggle = () => {
+    const next = !focus;
+    onToggle(next);
+    if (next && document.documentElement.requestFullscreen) {
+      document.documentElement.requestFullscreen().catch(() => {
+        /* user denied or unsupported — focus mode still works without fullscreen */
+      });
+    } else if (!next && document.fullscreenElement && document.exitFullscreen) {
+      document.exitFullscreen().catch(() => {
+        /* already exited */
+      });
+    }
+  };
+
+  return (
+    <Button
+      size="icon"
+      variant="ghost"
+      className="size-8"
+      onClick={toggle}
+      aria-label={focus ? "Exit focus mode" : "Focus mode"}
+      title={focus ? "Exit focus mode (Esc)" : "Focus mode — hide controls"}
+    >
+      {focus ? <Minimize2 className="size-4" /> : <Maximize2 className="size-4" />}
+    </Button>
+  );
+}

--- a/src/components/companion/GameLog.tsx
+++ b/src/components/companion/GameLog.tsx
@@ -1,5 +1,5 @@
 import { Undo2 } from "lucide-react";
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useCompanionStore } from "@/stores/useCompanionStore";
@@ -7,9 +7,11 @@ import type { CompanionEvent, CompanionSession } from "@/stores/useCompanionStor
 
 interface GameLogProps {
   session: CompanionSession;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }
 
-export function GameLog({ session }: GameLogProps) {
+export function GameLog({ session, open, onOpenChange }: GameLogProps) {
   const undo = useCompanionStore((s) => s.undo);
   const history = session.history;
 
@@ -22,21 +24,7 @@ export function GameLog({ session }: GameLogProps) {
   };
 
   return (
-    <Sheet>
-      <SheetTrigger asChild>
-        <Button
-          size="sm"
-          variant="outline"
-          className="h-8 px-2 text-xs sm:h-9 sm:px-3 sm:text-sm"
-          title="Game log"
-          aria-label="Game log"
-        >
-          Log
-          <span className="hidden tabular-nums text-muted-foreground sm:inline">
-            ({history.length})
-          </span>
-        </Button>
-      </SheetTrigger>
+    <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent side="right" className="w-80 overflow-y-auto p-0">
         <SheetHeader className="px-4 py-3">
           <SheetTitle>Game log</SheetTitle>

--- a/src/components/companion/SetupMenu.tsx
+++ b/src/components/companion/SetupMenu.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { ListOrdered, Minus, Plus, RotateCcw, Settings, XOctagon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -40,7 +39,6 @@ export function SetupMenu({ session, onOpenLog }: SetupMenuProps) {
   const resetCounters = useCompanionStore((s) => s.resetCounters);
   const resetGame = useCompanionStore((s) => s.resetGame);
   const endSession = useCompanionStore((s) => s.endSession);
-  const [tagDraft, setTagDraft] = useState(session.tag ?? "");
 
   return (
     <DropdownMenu>
@@ -134,9 +132,9 @@ export function SetupMenu({ session, onOpenLog }: SetupMenuProps) {
         <DropdownMenuLabel>Game title</DropdownMenuLabel>
         <div className="px-2 pb-2">
           <Input
-            value={tagDraft}
-            onChange={(e) => setTagDraft(e.target.value)}
-            onBlur={() => setSessionTag(tagDraft.trim())}
+            key={session.id}
+            defaultValue={session.tag ?? ""}
+            onBlur={(e) => setSessionTag(e.target.value.trim())}
             onKeyDown={(e) => {
               if (e.key === "Enter") (e.target as HTMLInputElement).blur();
             }}

--- a/src/components/companion/SetupMenu.tsx
+++ b/src/components/companion/SetupMenu.tsx
@@ -1,0 +1,178 @@
+import { useState } from "react";
+import { ListOrdered, Minus, Plus, RotateCcw, Settings, XOctagon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { useCompanionStore } from "@/stores/useCompanionStore";
+import {
+  COMPANION_MAX_PLAYERS,
+  COMPANION_MIN_PLAYERS,
+  COMPANION_STARTING_LIFE_PRESETS,
+} from "@/stores/useCompanionStore.constants";
+import type { CompanionSession } from "@/stores/useCompanionStore.types";
+import { GameIcon } from "./GameIcon";
+
+interface SetupMenuProps {
+  session: CompanionSession;
+  onOpenLog: () => void;
+}
+
+/**
+ * Collapses every "rarely touched once the game starts" control into one
+ * dropdown: player count, starting life, commander rules, oathbreaker,
+ * day/night cycle, timer mode, session tag. Keeps the inline bar
+ * focused on actions you actually take every turn.
+ */
+export function SetupMenu({ session, onOpenLog }: SetupMenuProps) {
+  const setPlayerCount = useCompanionStore((s) => s.setPlayerCount);
+  const setStartingLife = useCompanionStore((s) => s.setStartingLife);
+  const setCommanderRules = useCompanionStore((s) => s.setCommanderRules);
+  const setTimerMode = useCompanionStore((s) => s.setTimerMode);
+  const setSessionTag = useCompanionStore((s) => s.setSessionTag);
+  const resetCounters = useCompanionStore((s) => s.resetCounters);
+  const resetGame = useCompanionStore((s) => s.resetGame);
+  const endSession = useCompanionStore((s) => s.endSession);
+  const [tagDraft, setTagDraft] = useState(session.tag ?? "");
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          size="icon"
+          variant="outline"
+          className="size-8 sm:size-9"
+          aria-label="Game setup"
+          title="Game setup"
+        >
+          <Settings className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-64">
+        <DropdownMenuLabel>Players</DropdownMenuLabel>
+        <div className="flex items-center justify-between gap-2 px-2 pb-2">
+          <Button
+            size="icon"
+            variant="outline"
+            className="size-7"
+            onClick={() => setPlayerCount(session.players.length - 1)}
+            disabled={session.players.length <= COMPANION_MIN_PLAYERS}
+            aria-label="Fewer players"
+          >
+            <Minus className="size-3.5" />
+          </Button>
+          <span className="text-sm font-semibold tabular-nums">{session.players.length}</span>
+          <Button
+            size="icon"
+            variant="outline"
+            className="size-7"
+            onClick={() => setPlayerCount(session.players.length + 1)}
+            disabled={session.players.length >= COMPANION_MAX_PLAYERS}
+            aria-label="More players"
+          >
+            <Plus className="size-3.5" />
+          </Button>
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel>Starting life</DropdownMenuLabel>
+        <div className="flex flex-wrap gap-1 px-2 pb-2">
+          {COMPANION_STARTING_LIFE_PRESETS.map((value) => (
+            <button
+              type="button"
+              key={value}
+              onClick={() => setStartingLife(value)}
+              className={cn(
+                "rounded-full border px-2.5 py-0.5 text-xs font-medium transition",
+                value === session.startingLife
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-border bg-background hover:bg-accent",
+              )}
+            >
+              {value}
+            </button>
+          ))}
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onSelect={(e) => {
+            e.preventDefault();
+            setCommanderRules(!session.commanderRules);
+          }}
+          className={cn(session.commanderRules && "bg-accent")}
+        >
+          <GameIcon icon="crown" className="mr-2 size-4" /> Commander rules
+          {session.commanderRules && <span className="ml-auto text-xs">on</span>}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel>Timer mode</DropdownMenuLabel>
+        <DropdownMenuItem
+          onSelect={(e) => {
+            e.preventDefault();
+            setTimerMode("shared");
+          }}
+          className={cn(session.timerMode === "shared" && "bg-accent")}
+        >
+          Shared game clock
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onSelect={(e) => {
+            e.preventDefault();
+            setTimerMode("chess");
+          }}
+          className={cn(session.timerMode === "chess" && "bg-accent")}
+        >
+          Per-player chess clock
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel>Game title</DropdownMenuLabel>
+        <div className="px-2 pb-2">
+          <Input
+            value={tagDraft}
+            onChange={(e) => setTagDraft(e.target.value)}
+            onBlur={() => setSessionTag(tagDraft.trim())}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+            }}
+            placeholder="Untitled game"
+            className="h-8 text-xs"
+          />
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={onOpenLog}>
+          <ListOrdered className="mr-2 size-4" /> Game log
+          <span className="ml-auto tabular-nums text-xs text-muted-foreground">
+            {session.history.length}
+          </span>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel>Reset</DropdownMenuLabel>
+        <DropdownMenuItem onSelect={() => resetCounters("life")}>
+          <RotateCcw className="mr-2 size-4" /> Life only
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => resetCounters("counters")}>
+          <RotateCcw className="mr-2 size-4" /> Counters only
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => resetCounters("commander-damage")}>
+          <RotateCcw className="mr-2 size-4" /> Commander damage
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => resetGame()}>
+          <RotateCcw className="mr-2 size-4" /> Reset everything
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onSelect={() => endSession()}
+          className="text-destructive focus:text-destructive"
+        >
+          <XOctagon className="mr-2 size-4" /> End game
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/companion/TurnTimer.tsx
+++ b/src/components/companion/TurnTimer.tsx
@@ -57,10 +57,29 @@ export function TurnTimer({ className }: { className?: string }) {
 
   const shownMs = session.timerMode === "chess" && activePlayer ? chessElapsed : sharedElapsed;
 
+  const isIdle = !running && shownMs === 0;
+  // When the timer hasn't started yet, collapse to a single Play button.
+  // Once it's running (or has accumulated time on pause), expand to show
+  // the readout + the pause / reset controls. Saves ~120px on phones.
+  if (isIdle) {
+    return (
+      <Button
+        size="icon"
+        variant="ghost"
+        className={cn("size-8 rounded-md bg-muted/60", className)}
+        onClick={() => startTimer()}
+        aria-label="Start timer"
+        title="Start timer"
+      >
+        <GameIcon icon="sands-of-time" className="size-3.5 text-muted-foreground" />
+      </Button>
+    );
+  }
+
   return (
     <div
       className={cn(
-        "flex items-center gap-0.5 rounded-md bg-muted/60 px-1.5 py-0.5 sm:gap-1 sm:px-2 sm:py-1",
+        "flex items-center gap-0.5 rounded-md bg-muted/60 px-1 py-0.5 sm:gap-1 sm:px-1.5 sm:py-1",
         className,
       )}
     >
@@ -93,7 +112,7 @@ export function TurnTimer({ className }: { className?: string }) {
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-      <span className="min-w-[44px] text-center tabular-nums text-xs font-medium sm:min-w-[60px] sm:text-sm">
+      <span className="min-w-[42px] text-center tabular-nums text-xs font-medium sm:min-w-[52px]">
         {formatElapsed(shownMs)}
       </span>
       <Button
@@ -101,7 +120,7 @@ export function TurnTimer({ className }: { className?: string }) {
         variant="ghost"
         className="size-6"
         onClick={() => (running ? pauseTimer() : startTimer())}
-        aria-label={running ? "Pause timer" : "Start timer"}
+        aria-label={running ? "Pause timer" : "Resume timer"}
       >
         {running ? <Pause className="size-3.5" /> : <Play className="size-3.5" />}
       </Button>

--- a/src/views/Companion.tsx
+++ b/src/views/Companion.tsx
@@ -1,13 +1,15 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { CompanionBar } from "@/components/companion/CompanionBar";
 import { CompanionBoard } from "@/components/companion/CompanionBoard";
+import { FocusExitButton } from "@/components/companion/FocusExitButton";
+import { GameIcon } from "@/components/companion/GameIcon";
 import { GameSummaryDialog } from "@/components/companion/GameSummaryDialog";
+import { NewSessionDialog } from "@/components/companion/NewSessionDialog";
 import { PhaseStrip } from "@/components/companion/PhaseStrip";
 import { StatsDialog } from "@/components/companion/StatsDialog";
 import { WinBanner } from "@/components/companion/WinBanner";
-import { GameIcon } from "@/components/companion/GameIcon";
-import { NewSessionDialog } from "@/components/companion/NewSessionDialog";
 import { useCompanionStore } from "@/stores/useCompanionStore";
 
 export default function Companion() {
@@ -16,6 +18,27 @@ export default function Companion() {
   const archive = useCompanionStore((s) => s.archive);
   const restoreFromArchive = useCompanionStore((s) => s.restoreFromArchive);
   const [newOpen, setNewOpen] = useState(false);
+  const [focus, setFocus] = useState(false);
+  const [chromeInFocus, setChromeInFocus] = useState(false);
+
+  // Wrap the focus setter so leaving focus mode also clears the peek flag,
+  // without needing an effect that calls setState (which the React-hooks
+  // lint rules don't allow).
+  const setFocusMode = (next: boolean) => {
+    setFocus(next);
+    if (!next) setChromeInFocus(false);
+  };
+
+  // Keep focus state in sync with the browser's fullscreen state so Esc /
+  // the system gesture drops us back into the chrome'd view automatically.
+  useEffect(() => {
+    if (!focus) return;
+    const onChange = () => {
+      if (!document.fullscreenElement) setFocusMode(false);
+    };
+    document.addEventListener("fullscreenchange", onChange);
+    return () => document.removeEventListener("fullscreenchange", onChange);
+  }, [focus]);
 
   if (!session) {
     return (
@@ -72,13 +95,42 @@ export default function Companion() {
     );
   }
 
+  const showChrome = !focus || chromeInFocus;
+
   return (
-    <div className="flex h-full min-h-0 flex-col">
-      <CompanionBar session={session} onOpenNewSession={() => setNewOpen(true)} />
-      <PhaseStrip />
+    <div
+      className={cn(
+        "flex h-full min-h-0 flex-col",
+        focus &&
+          "fixed inset-0 z-50 h-screen w-screen bg-background pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)] pr-[env(safe-area-inset-right)] pt-[env(safe-area-inset-top)]",
+      )}
+    >
+      {showChrome && (
+        <div
+          className={cn(
+            focus && "absolute inset-x-0 top-[env(safe-area-inset-top)] z-40 shadow-xl",
+          )}
+        >
+          <CompanionBar
+            session={session}
+            onOpenNewSession={() => setNewOpen(true)}
+            focus={focus}
+            onToggleFocus={setFocusMode}
+            onHidePeek={focus && chromeInFocus ? () => setChromeInFocus(false) : undefined}
+          />
+          <PhaseStrip />
+        </div>
+      )}
       <div className="relative flex-1 min-h-0">
         <CompanionBoard session={session} />
         <WinBanner session={session} />
+        {focus && !chromeInFocus && (
+          <FocusExitButton
+            onExit={() => setFocusMode(false)}
+            chromeVisible={chromeInFocus}
+            onToggleChrome={setChromeInFocus}
+          />
+        )}
       </div>
       <NewSessionDialog
         open={newOpen}

--- a/src/views/Companion.tsx
+++ b/src/views/Companion.tsx
@@ -127,8 +127,7 @@ export default function Companion() {
         {focus && !chromeInFocus && (
           <FocusExitButton
             onExit={() => setFocusMode(false)}
-            chromeVisible={chromeInFocus}
-            onToggleChrome={setChromeInFocus}
+            onShowChrome={() => setChromeInFocus(true)}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary

Follow-ups on top of the merged tracker v2 (PR #113):

- **Focus mode** toggle hides bar + phase strip and goes fullscreen via the browser Fullscreen API — designed for a phone placed in the centre of the table. Floating Exit / Eye chip pinned to the safe-area inset (notch / rounded corners), Esc + system-gesture exit synced via \`fullscreenchange\`. Eye toggles the bar back in as a peek overlay, EyeOff in the bar collapses it again — both inside focus mode, no need to exit.
- **Bar restructure** — collapse rarely-touched controls into a Settings (⚙) dropdown: players ±, life presets, commander rules, timer mode, game title, game log, reset variants, end game. Day/Night stays inline. Dice palette + random first player merge into one dropdown with distinct icons (d20 for palette, Shuffle for first player). Inline controls drop from ~15 to ~10.
- **Idle-collapse TurnTimer** — single hourglass button when no clock is running and no accumulated time; expands to readout + pause + reset once running. Saves ~140 px of bar width during setup phase.
- **Mobile polish** — "New game" → "+" on phones, tighter gap/padding below \`sm:\`, accent-coloured T# pill, bar fits one row at 390 px-wide viewports.

## Why

Building on the merged tracker v2, this PR is the in-play UX layer — the things you notice once you actually sit at a table with the app. The headline use case is a single phone laying flat in the centre of a 4-player EDH pod; focus mode plus the slimmed bar plus the accent-driven turn indicators all support that scenario.

## Test plan

- [ ] Toggle focus mode from the bar; Esc exits cleanly on desktop; system gesture exits on mobile.
- [ ] In focus mode, tap Eye → bar peeks at the top; tap EyeOff in the bar → collapses back. Focus button in the bar still exits focus entirely.
- [ ] Settings (⚙) menu: change players, life preset, commander rules, timer mode, set a game title, open the game log, run each reset variant, end game.
- [ ] TurnTimer collapses to one hourglass when reset; tap → expands and starts ticking.
- [ ] Dice dropdown: roll d4, d6, d20, d100, coin, random first player — each opens the DiceRoller modal in its mode with the active-player accent.
- [ ] Bar fits one row on a 390 px-wide viewport with 2-, 4-, and 6-player commander sessions.
- [ ] Day/Night cycle off → day → night → off via the inline icon.

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main