### PR TITLE
fix(companion): lock page scroll and harden responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,12 +2,20 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+    />
     <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#121316" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="ManaBrew" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="128x128" href="/favicon-128x128.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <title>ManaBrew</title>
     <style>
       html {

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,23 @@
+{
+  "name": "ManaBrew",
+  "short_name": "ManaBrew",
+  "description": "Magic: The Gathering client and paper-play life tracker.",
+  "start_url": "/companion",
+  "display": "standalone",
+  "orientation": "any",
+  "background_color": "#121316",
+  "theme_color": "#121316",
+  "icons": [
+    {
+      "src": "/favicon-128x128.png",
+      "sizes": "128x128",
+      "type": "image/png"
+    },
+    {
+      "src": "/apple-touch-icon.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -36,6 +36,7 @@ Read first: `/AGENTS.md`, `docs/STYLE_GUIDELINES.md`, `docs/agents/UI_THEME_RULE
 - **Always `import type` for type-only imports.**
 - **Path aliases (`@/`) only.** Never `../../` that escapes the current directory.
 - **State lives close to where it's used.** Hoist to a Zustand store only when state needs to persist across unmounts or be read from non-React code.
+- **The page never scrolls.** `body` is `overflow:hidden; overscroll-behavior:none` and `html/body/#root` are `height:100%` (`index.css` base layer); `AppShell` is `h-[100dvh]` and owns scrolling via its inner `<main overflow-auto>`. Views must fit the viewport and scroll their own content — don't rely on body scroll. Immersive routes (`isImmersiveRoute` in `AppShell`: game + companion) get `!p-0 !overflow-hidden`. Use `100dvh`, not `100vh`/`h-screen`, for full-height on mobile, and `env(safe-area-inset-*)` for notch/home-indicator padding (the viewport meta sets `viewport-fit=cover`).
 - **One exported component per file.** Files past ~200 lines split.
 - **No new abstractions for one-off patterns.** Three similar lines beat a helper.
 - **Tests** run via `yarn test` (vitest); co-locate `*.test.ts` next to the code. The prompt-handling test (`stores/gameStore.constants.test.ts`) runs the rust `emit_prompt_fixtures` bin on demand and replays every `AgentPromptInner` variant through `applyPrompt` — no committed fixture, so it can't drift from the engine types.

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -32,6 +32,8 @@ export function AppShell() {
   const isGameActive = useGameStore((s) => s.isGameActive);
   const isTabletopRoute = location.pathname.startsWith("/tabletop");
   const isGameRoute = location.pathname.startsWith("/game") || isGameActive;
+  const isCompanionRoute = location.pathname.startsWith("/companion");
+  const isImmersiveRoute = isGameRoute || isCompanionRoute;
   const hideNavChrome = isGameRoute && !isTabletopRoute;
 
   // Register Tauri event listeners at app level so they're always active.
@@ -90,12 +92,12 @@ export function AppShell() {
   }, [shouldCollapseSidebar]);
 
   return (
-    <div className="h-screen overflow-hidden flex flex-col">
+    <div className="h-[100dvh] overflow-hidden flex flex-col">
       {!isDesktop && (
         <>
           <header
             className={cn(
-              "flex items-center gap-2 px-3 py-2 border-b bg-background",
+              "flex items-center gap-2 border-b bg-background px-3 py-2 pl-[calc(env(safe-area-inset-left)+0.75rem)] pr-[calc(env(safe-area-inset-right)+0.75rem)] pt-[calc(env(safe-area-inset-top)+0.5rem)]",
               hideNavChrome && "hidden",
             )}
           >
@@ -118,7 +120,7 @@ export function AppShell() {
             </SheetContent>
           </Sheet>
 
-          <main className={cn("flex-1 overflow-auto", isGameRoute && "!p-0 !overflow-hidden")}>
+          <main className={cn("flex-1 overflow-auto", isImmersiveRoute && "!p-0 !overflow-hidden")}>
             <Outlet />
           </main>
         </>
@@ -164,7 +166,9 @@ export function AppShell() {
                   )}
                 </Button>
               </div>
-              <main className={cn("h-full overflow-auto", isGameRoute && "!p-0 !overflow-hidden")}>
+              <main
+                className={cn("h-full overflow-auto", isImmersiveRoute && "!p-0 !overflow-hidden")}
+              >
                 <Outlet />
               </main>
             </ResizablePanel>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid max-h-[90dvh] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -466,8 +466,16 @@
   * {
     @apply border-border;
   }
+  html,
+  body,
+  #root {
+    height: 100%;
+  }
   body {
     @apply bg-background text-foreground;
+    overflow: hidden;
+    overscroll-behavior: none;
+    -webkit-text-size-adjust: 100%;
   }
 }
 

--- a/src/views/Companion.tsx
+++ b/src/views/Companion.tsx
@@ -101,8 +101,9 @@ export default function Companion() {
     <div
       className={cn(
         "flex h-full min-h-0 flex-col",
-        focus &&
-          "fixed inset-0 z-50 h-screen w-screen bg-background pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)] pr-[env(safe-area-inset-right)] pt-[env(safe-area-inset-top)]",
+        focus
+          ? "fixed inset-0 z-50 h-[100dvh] w-screen bg-background pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)] pr-[env(safe-area-inset-right)] pt-[env(safe-area-inset-top)]"
+          : "pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)] pr-[env(safe-area-inset-right)]",
       )}
     >
       {showChrome && (


### PR DESCRIPTION
## Summary

Make the companion (paper-play life tracker) fill exactly the visible viewport on every phone, tablet, and desktop, and launch chrome-free from an iPhone homescreen bookmark — instead of scrolling and rubber-banding.

The board itself never overflowed (CSS-grid `fr` units + container queries). The scroll/"move" came from the **shell + viewport** layer:

- `index.html` had no iOS standalone PWA meta, so a homescreen bookmark opened inside Safari chrome (address bar that scrolls away).
- No `viewport-fit=cover`, so the companion's existing `env(safe-area-inset-*)` padding silently resolved to `0`.
- `AppShell` / `Companion` used `h-screen` (`100vh`), which on iOS overshoots the visible area → overflow + bounce.
- No global overscroll lock on `html`/`body`/`#root`.
- AppShell's mobile `<main>` was `overflow-auto` for non-game routes, and companion isn't a game route — so the page was allowed to scroll.

### Changes
- **`index.html`** — standalone iOS PWA meta (`apple-mobile-web-app-capable`, status-bar style, title, `theme-color`), `viewport-fit=cover`, and `maximum-scale=1, user-scalable=no` to stop accidental zoom/pan on fast life taps; link the new manifest.
- **`public/manifest.webmanifest`** (new) — `display: standalone`, `start_url: /companion`, reusing existing icons (`favicon-128x128.png`, `apple-touch-icon.png` 512×512). Installable fullscreen on Android/desktop.
- **`src/index.css`** — global no-scroll lock: `html/body/#root { height:100% }`, `body { overflow:hidden; overscroll-behavior:none; -webkit-text-size-adjust:100% }`.
- **`src/components/layout/AppShell.tsx`** — root `h-screen` → `h-[100dvh]`; new `isImmersiveRoute = isGameRoute || isCompanionRoute` gives companion `!p-0 !overflow-hidden`; mobile nav header gains `env(safe-area-inset-*)` padding.
- **`src/views/Companion.tsx`** — focus mode `h-screen` → `h-[100dvh]`; normal mode applies bottom/left/right safe-area padding so tiles clear the home indicator / landscape notch.
- **`src/components/ui/dialog.tsx`** — `max-h-[90dvh] overflow-y-auto` so tall dialogs scroll internally and stay reachable now that the body can't scroll.
- **`src/AGENTS.md`** — documents the new app-wide "page never scrolls / use dvh + safe-area" invariant.

## Why

A homescreen-bookmarked life tracker should feel like a kiosk app: fixed to the screen, no address bar, no rubber-band. The previous setup let iOS scroll/shrink the chrome and clipped content under the notch, ruining the paper-play experience. Per maintainer decisions: fix is **app-wide**, zoom is **disabled**, and the app nav header is **kept** on companion.

## Test plan

- `prettier --check`, `tsc --noEmit`, `eslint` on changed files — pass (also enforced by pre-commit hooks).
- Desktop browser: resize `/companion` 1440px → 320px — no scrollbars, board + bar always fully visible.
- DevTools device toolbar: iPhone SE, iPhone 15 Pro Max, iPad — portrait/landscape, no scroll, tiles fill the area.
- Real iPhone (Safari): add `/companion` to homescreen → opens without address bar, no scroll/bounce on rapid taps, content clears notch + home indicator.
- Regression: lobby / deck editor still scroll their content inside `<main>`; tall dialogs scroll internally.

## Build artifacts

- [ ] Build macOS .dmg
- [ ] Build Windows .exe
