### PR TITLE
fix(node): emit game-over prompt from hosted java sessions

### DIFF
--- a/forge-engine/crates/self-hosted-node/src/engine_backend/java_backend.rs
+++ b/forge-engine/crates/self-hosted-node/src/engine_backend/java_backend.rs
@@ -23,10 +23,12 @@ use forge_agent_interface::deck_dto::{CardIdentity, Deck};
 use crate::config::DeckSelection;
 #[cfg(feature = "java-forge")]
 use forge_agent_interface::java_prompt_normalizer::{
-    normalize_java_prompt, translate_java_player_action,
+    make_java_game_over_prompt, normalize_java_prompt, translate_java_player_action,
 };
 #[cfg(feature = "java-forge")]
-use forge_agent_interface::java_raw::{JavaAction, JavaRawPrompt, JavaRawPromptBody};
+use forge_agent_interface::java_raw::{
+    JavaAction, JavaRawPrompt, JavaRawPromptBody, JavaRawSnapshot,
+};
 use forge_agent_interface::prompt::{AgentPrompt, PlayerAction};
 #[cfg(feature = "java-forge")]
 use forge_bot::{BotAgent, SimpleAi};
@@ -423,6 +425,14 @@ impl JavaEngineHandle {
             .lock()
             .map_err(|_| "java subprocess mutex poisoned".to_string())?;
         guard.is_game_over(session_id)
+    }
+
+    pub fn get_snapshot(&self, session_id: &str) -> Result<String, String> {
+        let bridge = self.bridge_for(session_id)?;
+        let mut guard = bridge
+            .lock()
+            .map_err(|_| "java subprocess mutex poisoned".to_string())?;
+        guard.get_snapshot(session_id)
     }
 
     pub fn end_game(&self, session_id: &str) -> Result<(), String> {
@@ -870,6 +880,14 @@ fn run_hosted_engine_game_inner(
 
         if engine.is_game_over(&session_id)? {
             info!("hosted java-forge session reached game over");
+            if let Ok(snapshot_json) = engine.get_snapshot(&session_id) {
+                if let Ok(raw_snapshot) = serde_json::from_str::<JavaRawSnapshot>(&snapshot_json) {
+                    let prompt = make_java_game_over_prompt(&raw_snapshot, Some(&session_id));
+                    for &agent_index in remote_response_rxs.keys() {
+                        let _ = remote_prompt_tx.send((agent_index, prompt.clone()));
+                    }
+                }
+            }
             let _ = game_over_tx.send(game_id.clone());
             engine.end_game(&session_id)?;
             guard.armed.set(false);


### PR DESCRIPTION
## Summary

- hosted "play vs ai" rooms never showed a result — when a game ended (the bot takes lethal and dies), the client sat stuck on a dead board with no win/lose screen.
- the node's java poll loop (`drive_game_via_handle` in `self-hosted-node/src/engine_backend/java_backend.rs`) saw `game_over` and tore the session down without ever sending `AgentPromptInner::GameOver`, so `GameOverScreen` and the auto-return to lobby never fired.
- **fix shape:** mirror #99's tauri-path fix on the node loop — build the GameOver prompt from the final snapshot via the existing `make_java_game_over_prompt` helper and broadcast it to the remote seats before `end_game`. adds a small `get_snapshot` passthrough on `JavaEngineHandle` (mirrors the neighbouring `is_game_over`).

## Why

this is the exact bug #99 fixed, but #99 only patched `src-tauri/src/engine_backend/java_backend.rs` (the tauri desktop path) and missed the identical loop in `self-hosted-node/src/engine_backend/java_backend.rs` (the hosted path). no new logic — same helper, same `JavaRawSnapshot`, just the missing second call site. addresses the soft-lock in #77 (the stuck-game half; the bot's weak blocking is separate and out of scope here).

## Test plan

- `cargo clippy -p self-hosted-node --features java-forge` — clean, no new warnings.
- `cargo fmt -p self-hosted-node -- --check` — clean.
- traced against live node logs: the session logged `reached game over` then `hosted engine thread finished` while the client stayed in-game — confirms the missing prompt was the cause.
- end-to-end hosted commander game on this branch: **not yet run** (needs a deploy of the branch to the node + a played game). happy to deploy and confirm before merge.

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
