### PR TITLE
feat(lobby): change player count and let any player add bots

### DIFF
--- a/forge-engine/crates/forge-agent-interface/src/protocol.rs
+++ b/forge-engine/crates/forge-agent-interface/src/protocol.rs
@@ -124,6 +124,10 @@ pub enum ClientMessage {
         format: GameFormat,
     },
 
+    SetMaxPlayers {
+        max_players: u8,
+    },
+
     StartGame {
         #[serde(default)]
         format: Option<GameFormat>,

--- a/forge-engine/crates/forge-agent-interface/src/protocol.rs
+++ b/forge-engine/crates/forge-agent-interface/src/protocol.rs
@@ -106,6 +106,8 @@ pub enum ClientMessage {
         room_id: String,
         #[serde(default)]
         observe: bool,
+        #[serde(default)]
+        as_bot: bool,
     },
 
     LeaveRoom,
@@ -270,6 +272,8 @@ pub struct RoomPlayerInfo {
     pub username: String,
     pub ready: bool,
     pub connected: bool,
+    #[serde(default)]
+    pub is_bot: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub selected_deck_name: Option<String>,
 }

--- a/forge-engine/crates/forge-bot/src/state.rs
+++ b/forge-engine/crates/forge-bot/src/state.rs
@@ -70,6 +70,7 @@ impl BotState {
                     vec![ClientMessage::JoinRoom {
                         room_id: self.config.room_id.clone(),
                         observe: false,
+                        as_bot: true,
                     }]
                 } else {
                     self.fail(format!("authentication failed: {:?}", error))

--- a/forge-engine/crates/forge-server/src/connection.rs
+++ b/forge-engine/crates/forge-server/src/connection.rs
@@ -613,14 +613,19 @@ fn handle_client_message(
             }
         }
 
-        ClientMessage::JoinRoom { room_id, observe } => {
+        ClientMessage::JoinRoom {
+            room_id,
+            observe,
+            as_bot,
+        } => {
             info!(
-                "[lobby] '{}' joining room {} (observe={})",
+                "[lobby] '{}' joining room {} (observe={}, bot={})",
                 username,
                 &room_id[..8.min(room_id.len())],
-                observe
+                observe,
+                as_bot
             );
-            match lobby::join_room_sync(state, player_id, &room_id, observe) {
+            match lobby::join_room_sync(state, player_id, &room_id, observe, as_bot) {
                 Ok(info) => {
                     info!("[lobby] '{}' joined room '{}'", username, info.room_name);
                     if !observe {

--- a/forge-engine/crates/forge-server/src/connection.rs
+++ b/forge-engine/crates/forge-server/src/connection.rs
@@ -787,6 +787,33 @@ fn handle_client_message(
             }
         }
 
+        ClientMessage::SetMaxPlayers { max_players } => {
+            info!("[lobby] '{}' set max_players={}", username, max_players);
+            match lobby::set_max_players_sync(state, player_id, max_players) {
+                Ok(room_id) => {
+                    if let Some(room) = state.rooms.get(&room_id) {
+                        broadcast_to_room(
+                            state,
+                            &room_id,
+                            &ServerMessage::RoomUpdate {
+                                room: room.to_room_info(),
+                            },
+                        );
+                    }
+                }
+                Err(e) => {
+                    warn!("[lobby] '{}' set max_players failed: {}", username, e);
+                    send_msg(
+                        sender,
+                        &ServerMessage::Error {
+                            code: e.code().into(),
+                            message: e.to_string(),
+                        },
+                    );
+                }
+            }
+        }
+
         ClientMessage::StartGame { format } => {
             info!("[game] '{}' starting game", username);
             match lobby::start_game_sync(state, player_id, format) {
@@ -946,6 +973,7 @@ fn client_msg_type(msg: &ClientMessage) -> &'static str {
         ClientMessage::SetReady { .. } => "SetReady",
         ClientMessage::SetDeckSelection { .. } => "SetDeckSelection",
         ClientMessage::SetFormat { .. } => "SetFormat",
+        ClientMessage::SetMaxPlayers { .. } => "SetMaxPlayers",
         ClientMessage::StartGame { .. } => "StartGame",
         ClientMessage::EndGame => "EndGame",
         ClientMessage::BroadcastState { .. } => "BroadcastState",

--- a/forge-engine/crates/forge-server/src/lobby.rs
+++ b/forge-engine/crates/forge-server/src/lobby.rs
@@ -312,8 +312,8 @@ pub fn set_max_players_sync(
             .get_mut(&room_id)
             .ok_or_else(|| ServerError::RoomNotFound(room_id.clone()))?;
 
-        if !room.players.iter().any(|p| p.player_id == player_id) {
-            return Err(ServerError::NotInRoom);
+        if !room.is_controller(player_id) {
+            return Err(ServerError::NotHost);
         }
 
         if room.status != RoomStatus::Lobby {

--- a/forge-engine/crates/forge-server/src/lobby.rs
+++ b/forge-engine/crates/forge-server/src/lobby.rs
@@ -293,6 +293,40 @@ pub fn set_format_sync(
     Ok(room_id)
 }
 
+pub fn set_max_players_sync(
+    state: &Arc<ServerState>,
+    player_id: &str,
+    max_players: u8,
+) -> Result<String, ServerError> {
+    let room_id = {
+        state
+            .players
+            .get(player_id)
+            .and_then(|p| p.room_id.clone())
+            .ok_or(ServerError::NotInRoom)?
+    };
+
+    {
+        let mut room = state
+            .rooms
+            .get_mut(&room_id)
+            .ok_or_else(|| ServerError::RoomNotFound(room_id.clone()))?;
+
+        if !room.players.iter().any(|p| p.player_id == player_id) {
+            return Err(ServerError::NotInRoom);
+        }
+
+        if room.status != RoomStatus::Lobby {
+            return Err(ServerError::GameAlreadyStarted);
+        }
+
+        let floor = (room.players.len() as u8).max(2);
+        room.max_players = max_players.clamp(floor, 8);
+    }
+
+    Ok(room_id)
+}
+
 pub fn start_game_sync(
     state: &Arc<ServerState>,
     player_id: &str,

--- a/forge-engine/crates/forge-server/src/lobby.rs
+++ b/forge-engine/crates/forge-server/src/lobby.rs
@@ -84,6 +84,7 @@ pub fn join_room_sync(
     player_id: &str,
     room_id: &str,
     observe: bool,
+    as_bot: bool,
 ) -> Result<RoomInfo, ServerError> {
     {
         if let Some(player) = state.players.get(player_id) {
@@ -115,7 +116,7 @@ pub fn join_room_sync(
             room.add_observer(player_id.to_string(), username)
                 .map_err(|_| ServerError::AlreadyInRoom(room_id.to_string()))?;
         } else {
-            room.add_player(player_id.to_string(), username)
+            room.add_player(player_id.to_string(), username, as_bot)
                 .map_err(|msg| {
                     if msg.contains("full") {
                         ServerError::RoomFull(room_id.to_string())
@@ -321,7 +322,7 @@ pub fn set_max_players_sync(
         }
 
         let floor = (room.players.len() as u8).max(2);
-        room.max_players = max_players.clamp(floor, 8);
+        room.max_players = max_players.clamp(floor, 4);
     }
 
     Ok(room_id)

--- a/forge-engine/crates/forge-server/src/room.rs
+++ b/forge-engine/crates/forge-server/src/room.rs
@@ -10,6 +10,7 @@ pub struct RoomSlot {
     pub username: String,
     pub ready: bool,
     pub connected: bool,
+    pub is_bot: bool,
     pub selected_deck_name: Option<String>,
     pub selected_deck: Option<Deck>,
     pub selected_commander_name: Option<String>,
@@ -59,6 +60,7 @@ impl Room {
                     username: host_username.clone(),
                     ready: false,
                     connected: true,
+                    is_bot: false,
                     selected_deck_name: None,
                     selected_deck: None,
                     selected_commander_name: None,
@@ -107,7 +109,12 @@ impl Room {
         self.players.len() >= min_players && self.players.iter().all(|p| p.ready)
     }
 
-    pub fn add_player(&mut self, player_id: String, username: String) -> Result<(), String> {
+    pub fn add_player(
+        &mut self,
+        player_id: String,
+        username: String,
+        is_bot: bool,
+    ) -> Result<(), String> {
         if self.is_full() {
             return Err("Room is full".into());
         }
@@ -122,6 +129,7 @@ impl Room {
             username,
             ready: false,
             connected: true,
+            is_bot,
             selected_deck_name: None,
             selected_deck: None,
             selected_commander_name: None,
@@ -241,14 +249,21 @@ impl Room {
         self.host_player_id == player_id
     }
 
-    /// The room controller is the first player to take a seat. The controller
-    /// drives the lobby (format, bots, start) regardless of who holds the
-    /// engine (`host`). In a normal self-created room the host is also the
-    /// first player, so the two coincide.
-    pub fn is_controller(&self, player_id: &str) -> bool {
+    /// The room controller is the first human (non-bot) player to take a seat.
+    /// They drive the lobby (format, seats, bots, start) regardless of who holds
+    /// the engine (`host`). Computed dynamically from current seats, so if the
+    /// controlling human leaves, control passes to the next human — never to a
+    /// bot. Falls back to the first seat only if every player is a bot.
+    pub fn controller_id(&self) -> Option<&str> {
         self.players
-            .first()
-            .is_some_and(|p| p.player_id == player_id)
+            .iter()
+            .find(|p| !p.is_bot)
+            .or_else(|| self.players.first())
+            .map(|p| p.player_id.as_str())
+    }
+
+    pub fn is_controller(&self, player_id: &str) -> bool {
+        self.controller_id() == Some(player_id)
     }
 
     pub fn host_username(&self) -> String {
@@ -298,6 +313,7 @@ impl Room {
                     username: p.username.clone(),
                     ready: p.ready,
                     connected: p.connected,
+                    is_bot: p.is_bot,
                     selected_deck_name: p.selected_deck_name.clone(),
                 })
                 .collect(),
@@ -335,9 +351,9 @@ mod tests {
         let mut r = room(false);
         assert!(r.is_host("host"));
         assert!(!r.is_controller("host"));
-        r.add_player("human".into(), "human".into()).unwrap();
+        r.add_player("human".into(), "human".into(), false).unwrap();
         assert!(r.is_controller("human"));
-        r.add_player("bot".into(), "bot".into()).unwrap();
+        r.add_player("bot".into(), "bot".into(), true).unwrap();
         assert!(!r.is_controller("bot"));
     }
 }

--- a/forge-engine/crates/self-hosted-node/src/main.rs
+++ b/forge-engine/crates/self-hosted-node/src/main.rs
@@ -260,6 +260,7 @@ async fn host_one_room(
         host.send(&ClientMessage::JoinRoom {
             room_id: room_id.clone(),
             observe: !config.host_plays,
+            as_bot: false,
         })
         .await?;
         info!(room_id, "joining configured room");

--- a/forge-engine/crates/self-hosted-node/tests/hosted_smoke.rs
+++ b/forge-engine/crates/self-hosted-node/tests/hosted_smoke.rs
@@ -132,6 +132,7 @@ async fn play_game(
             &ClientMessage::JoinRoom {
                 room_id: room_id.to_string(),
                 observe: false,
+                as_bot: false,
             },
         )
         .await?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -98,6 +98,7 @@ pub fn run() {
             server_commands::server_set_ready,
             server_commands::server_set_deck_selection,
             server_commands::server_set_format,
+            server_commands::server_set_max_players,
             server_commands::server_start_game,
             server_commands::server_end_game,
             server_commands::server_broadcast_state,

--- a/src-tauri/src/server_commands.rs
+++ b/src-tauri/src/server_commands.rs
@@ -177,6 +177,20 @@ pub async fn server_set_format(
 }
 
 #[tauri::command]
+pub async fn server_set_max_players(
+    client: State<'_, ServerClient>,
+    max_players: u8,
+) -> Result<(), String> {
+    send_server_message(
+        &client,
+        serde_json::json!({
+            "type": "SetMaxPlayers",
+            "max_players": max_players,
+        }),
+    )
+}
+
+#[tauri::command]
 pub async fn server_start_game(
     client: State<'_, ServerClient>,
     format: Option<String>,

--- a/src/components/lobby/TablesList.tsx
+++ b/src/components/lobby/TablesList.tsx
@@ -26,7 +26,7 @@ const HOST_SELECTABLE_FORMATS: GameFormat[] = [
   "Oathbreaker",
 ];
 
-const PLAYER_COUNT_OPTIONS = [2, 3, 4, 5, 6, 7, 8];
+const PLAYER_COUNT_OPTIONS = [2, 3, 4];
 
 interface TablesListProps {
   rooms: RoomInfo[];
@@ -78,11 +78,12 @@ export function TablesList({
   const inRoom = currentRoom != null;
   const myPlayer = currentRoom?.players.find((p) => p.username === username);
   const myPlayerHasDeck = !!myPlayer?.selected_deck_name;
-  // The controller is the first seated player — they drive the lobby (format,
-  // seats, bots, start) even when the host is a non-playing engine node. In a
-  // self-hosted room the host (the node) takes no seat, so the controller is
-  // the first human to join, not currentRoom.host.
-  const controllerName = currentRoom?.players[0]?.username;
+  // The controller is the first human (non-bot) player — they drive the lobby
+  // (format, seats, bots, start) even when the host is a non-playing engine
+  // node. Mirrors the server's Room::controller_id: first non-bot seat, falling
+  // back to the first seat only if every player is a bot.
+  const controllerName =
+    currentRoom?.players.find((p) => !p.is_bot)?.username ?? currentRoom?.players[0]?.username;
   const isController = controllerName === username;
   const isLimitedRoom = !!(currentRoom?.draft_config || currentRoom?.sealed_config);
   const isOpenFormat = currentRoom?.format === "Any" || isLimitedRoom;

--- a/src/components/lobby/TablesList.tsx
+++ b/src/components/lobby/TablesList.tsx
@@ -26,6 +26,8 @@ const HOST_SELECTABLE_FORMATS: GameFormat[] = [
   "Oathbreaker",
 ];
 
+const PLAYER_COUNT_OPTIONS = [2, 3, 4, 5, 6, 7, 8];
+
 interface TablesListProps {
   rooms: RoomInfo[];
   currentRoom: RoomInfo | null;
@@ -38,6 +40,7 @@ interface TablesListProps {
   onLeaveRoom: () => void;
   onSetReady: (ready: boolean) => void;
   onSetFormat?: (format: GameFormat) => void;
+  onSetMaxPlayers?: (maxPlayers: number) => void;
   onOpenDeckDialog: () => void;
   onStartGame: () => void;
   onStartTabletop?: () => void;
@@ -59,6 +62,7 @@ export function TablesList({
   onLeaveRoom,
   onSetReady,
   onSetFormat,
+  onSetMaxPlayers,
   onOpenDeckDialog,
   onStartGame,
   onStartTabletop,
@@ -78,6 +82,7 @@ export function TablesList({
   // bots, start) even when the host is a non-playing engine node. In a normal
   // self-created room the host is the first player, so the two coincide.
   const isController = currentRoom?.players[0]?.username === username;
+  const isSeated = !!myPlayer;
   const isLimitedRoom = !!(currentRoom?.draft_config || currentRoom?.sealed_config);
   const isOpenFormat = currentRoom?.format === "Any" || isLimitedRoom;
   const minReady = isOpenFormat ? 1 : 2;
@@ -165,6 +170,36 @@ export function TablesList({
                         : currentRoom.format}
                   </Badge>
                 )}
+                {isSeated &&
+                currentRoom.status === "Lobby" &&
+                currentRoom.hosted &&
+                !isLimitedRoom &&
+                onSetMaxPlayers ? (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        type="button"
+                        className="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-0.5 text-[10px] font-medium hover:bg-muted/60"
+                      >
+                        <Users className="h-2.5 w-2.5" />
+                        {currentRoom.players.length}/{currentRoom.max_players}
+                        <ChevronDown className="h-2.5 w-2.5" />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      {PLAYER_COUNT_OPTIONS.map((n) => (
+                        <DropdownMenuItem
+                          key={n}
+                          onSelect={() => onSetMaxPlayers(n)}
+                          disabled={n === currentRoom.max_players || n < currentRoom.players.length}
+                          className="text-xs"
+                        >
+                          {n} players
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                ) : null}
                 <Badge
                   variant={currentRoom.status === "Lobby" ? "outline" : "secondary"}
                   className="text-[10px]"
@@ -226,7 +261,7 @@ export function TablesList({
                           : (p.selected_deck_name ?? "No deck selected")}
                       </div>
                     </div>
-                    {canRemove && isController ? (
+                    {canRemove ? (
                       <Button
                         size="icon"
                         variant="ghost"
@@ -253,7 +288,7 @@ export function TablesList({
               })}
               {/* Hidden on Open rooms — draft bots come from the room's
                   draft_config.fill_with_bots, not this deck-picker flow. */}
-              {isController &&
+              {isSeated &&
                 !isOpenFormat &&
                 currentRoom.players.length < currentRoom.max_players &&
                 onAddBot && (

--- a/src/components/lobby/TablesList.tsx
+++ b/src/components/lobby/TablesList.tsx
@@ -79,10 +79,11 @@ export function TablesList({
   const myPlayer = currentRoom?.players.find((p) => p.username === username);
   const myPlayerHasDeck = !!myPlayer?.selected_deck_name;
   // The controller is the first seated player — they drive the lobby (format,
-  // bots, start) even when the host is a non-playing engine node. In a normal
-  // self-created room the host is the first player, so the two coincide.
-  const isController = currentRoom?.players[0]?.username === username;
-  const isSeated = !!myPlayer;
+  // seats, bots, start) even when the host is a non-playing engine node. In a
+  // self-hosted room the host (the node) takes no seat, so the controller is
+  // the first human to join, not currentRoom.host.
+  const controllerName = currentRoom?.players[0]?.username;
+  const isController = controllerName === username;
   const isLimitedRoom = !!(currentRoom?.draft_config || currentRoom?.sealed_config);
   const isOpenFormat = currentRoom?.format === "Any" || isLimitedRoom;
   const minReady = isOpenFormat ? 1 : 2;
@@ -93,8 +94,8 @@ export function TablesList({
 
   const orderedPlayers = currentRoom
     ? [...currentRoom.players].sort((a, b) => {
-        if (a.username === currentRoom.host) return -1;
-        if (b.username === currentRoom.host) return 1;
+        if (a.username === controllerName) return -1;
+        if (b.username === controllerName) return 1;
         return a.username.localeCompare(b.username);
       })
     : [];
@@ -170,7 +171,7 @@ export function TablesList({
                         : currentRoom.format}
                   </Badge>
                 )}
-                {isSeated &&
+                {isController &&
                 currentRoom.status === "Lobby" &&
                 currentRoom.hosted &&
                 !isLimitedRoom &&
@@ -180,6 +181,7 @@ export function TablesList({
                       <button
                         type="button"
                         className="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-0.5 text-[10px] font-medium hover:bg-muted/60"
+                        title="Change the number of seats"
                       >
                         <Users className="h-2.5 w-2.5" />
                         {currentRoom.players.length}/{currentRoom.max_players}
@@ -199,7 +201,12 @@ export function TablesList({
                       ))}
                     </DropdownMenuContent>
                   </DropdownMenu>
-                ) : null}
+                ) : (
+                  <Badge variant="outline" className="text-[10px] gap-1">
+                    <Users className="h-2.5 w-2.5" />
+                    {currentRoom.players.length}/{currentRoom.max_players}
+                  </Badge>
+                )}
                 <Badge
                   variant={currentRoom.status === "Lobby" ? "outline" : "secondary"}
                   className="text-[10px]"
@@ -246,10 +253,11 @@ export function TablesList({
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-1.5">
                         <span className="text-sm font-medium truncate">{p.username}</span>
-                        {p.username === currentRoom.host && (
+                        {p.username === controllerName && (
                           <GameIcon
                             name="overlord-helm"
                             className="h-3 w-3 text-commander shrink-0"
+                            title="Room host — controls seats, bots & start"
                           />
                         )}
                       </div>
@@ -261,7 +269,7 @@ export function TablesList({
                           : (p.selected_deck_name ?? "No deck selected")}
                       </div>
                     </div>
-                    {canRemove ? (
+                    {canRemove && isController ? (
                       <Button
                         size="icon"
                         variant="ghost"
@@ -288,7 +296,7 @@ export function TablesList({
               })}
               {/* Hidden on Open rooms — draft bots come from the room's
                   draft_config.fill_with_bots, not this deck-picker flow. */}
-              {isSeated &&
+              {isController &&
                 !isOpenFormat &&
                 currentRoom.players.length < currentRoom.max_players &&
                 onAddBot && (
@@ -379,6 +387,11 @@ export function TablesList({
                     </Button>
                   )}
                 </div>
+              )}
+              {!isController && currentRoom.status === "Lobby" && (
+                <span className="ml-auto text-[11px] text-muted-foreground">
+                  {controllerName ? `Only ${controllerName} (host) can add bots & start` : null}
+                </span>
               )}
             </div>
           </div>

--- a/src/platform/tauri.ts
+++ b/src/platform/tauri.ts
@@ -29,6 +29,7 @@ import type {
   SetDeckSelectionParams,
   StartServerGameParams,
   SetFormatParams,
+  SetMaxPlayersParams,
   SpawnAiBotParams,
 } from "./types";
 import type { RoomRelayEnvelope } from "@/types/server";
@@ -135,6 +136,10 @@ class TauriServerApi implements IServerApi {
 
   async setFormat(params: SetFormatParams): Promise<void> {
     return invoke<void>("server_set_format", { ...params });
+  }
+
+  async setMaxPlayers(params: SetMaxPlayersParams): Promise<void> {
+    return invoke<void>("server_set_max_players", { maxPlayers: params.maxPlayers });
   }
 
   async startGame(params?: StartServerGameParams): Promise<void> {

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -89,6 +89,10 @@ export interface SetFormatParams {
   format: GameFormat;
 }
 
+export interface SetMaxPlayersParams {
+  maxPlayers: number;
+}
+
 export type BotAgentKind = "simple";
 
 export interface SpawnAiBotParams extends SetDeckSelectionParams {
@@ -144,6 +148,7 @@ export interface IServerApi {
   setReady(params: SetReadyParams): Promise<void>;
   setDeckSelection(params: SetDeckSelectionParams): Promise<void>;
   setFormat(params: SetFormatParams): Promise<void>;
+  setMaxPlayers(params: SetMaxPlayersParams): Promise<void>;
   startGame(params?: StartServerGameParams): Promise<void>;
   endGame(): Promise<void>;
   broadcastState(state: Record<string, unknown>): Promise<void>;

--- a/src/platform/web.ts
+++ b/src/platform/web.ts
@@ -23,6 +23,7 @@ import type {
   SetDeckSelectionParams,
   StartServerGameParams,
   SetFormatParams,
+  SetMaxPlayersParams,
   SpawnAiBotParams,
 } from "./types";
 import { SERVER_ERROR_CODE } from "@/types/server";
@@ -798,6 +799,10 @@ class WebServerApi implements IServerApi {
 
   async setFormat(params: SetFormatParams): Promise<void> {
     this.send({ type: "SetFormat", format: params.format });
+  }
+
+  async setMaxPlayers(params: SetMaxPlayersParams): Promise<void> {
+    this.send({ type: "SetMaxPlayers", max_players: params.maxPlayers });
   }
 
   async startGame(params?: StartServerGameParams): Promise<void> {

--- a/src/stores/useServerStore.ts
+++ b/src/stores/useServerStore.ts
@@ -72,6 +72,7 @@ interface ServerState {
   setReady(ready: boolean): Promise<void>;
   setDeckSelection(deckName: string, deck: Deck, commanderName?: string): Promise<void>;
   setFormat(format: GameFormat): Promise<void>;
+  setMaxPlayers(maxPlayers: number): Promise<void>;
   startGame(format?: GameFormat): Promise<void>;
   endGame(): Promise<void>;
 
@@ -204,6 +205,12 @@ export const useServerStore = create<ServerState>()(
         const platform = getPlatform();
         if (!platform.server) return;
         await platform.server.setFormat({ format });
+      },
+
+      async setMaxPlayers(maxPlayers) {
+        const platform = getPlatform();
+        if (!platform.server) return;
+        await platform.server.setMaxPlayers({ maxPlayers });
       },
 
       async startGame(format) {

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -63,6 +63,7 @@ export interface RoomPlayerInfo {
   username: string;
   ready: boolean;
   connected: boolean;
+  is_bot?: boolean;
   selected_deck_name?: string;
 }
 

--- a/src/views/Lobby.tsx
+++ b/src/views/Lobby.tsx
@@ -121,6 +121,7 @@ export default function Lobby() {
     setDeckSelection,
     setReady,
     setFormat,
+    setMaxPlayers,
     startGame,
   } = useServerStore();
   const prefs = usePreferencesStore();
@@ -466,6 +467,14 @@ export default function Lobby() {
     }
   }
 
+  async function handleSetMaxPlayers(maxPlayers: number) {
+    try {
+      await setMaxPlayers(maxPlayers);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to change player count.");
+    }
+  }
+
   return (
     <div className="h-full w-full flex flex-col">
       {/* ── Header ── */}
@@ -593,6 +602,7 @@ export default function Lobby() {
             onLeaveRoom={leaveRoom}
             onSetReady={setReady}
             onSetFormat={setFormat}
+            onSetMaxPlayers={handleSetMaxPlayers}
             onOpenDeckDialog={() => setDeckDialogOpen(true)}
             onStartGame={startGame}
             onStartTabletop={handleStartTabletop}


### PR DESCRIPTION
## Summary
- Add a `SetMaxPlayers` message so a self-hosted room's seat count can be changed from the lobby (in-lobby only; options 2–4, clamped server-side to `[max(2, occupied seats) … 4]`, broadcast as a `RoomUpdate`).
- Seat-count change, **Add Bot**, and **Start** are reserved for the room **controller** — and the controller is now always the first **human** (non-bot) seat, resolved dynamically so control never lands on a bot (e.g. after the controlling human leaves).
- Bots identify themselves on join via a new `JoinRoom.as_bot` flag (set once in the shared `BotState`, covering web `WasmBot` and native/Tauri bots); the server tags the seat and exposes `is_bot` in `RoomInfo`.
- Clarify ownership in the lobby UX: the host crown marks the actual controller (in a self-hosted room `currentRoom.host` is the non-seated engine node, so it previously showed on nobody); the controller is sorted first; everyone sees the seat count; non-controllers get a "only `<host>` can add bots & start" hint.

## Why
Hosted self-hosted-node rooms had a seat count fixed at creation, nothing visibly marked who controlled the table, and a bot could end up as the first seat (so "controller") and stall the lobby. This makes the controller a clear, present human, lets them resize the table (2–4), and surfaces who's in charge.

## Test plan
- `cargo check` — `forge-server`, `forge-bot`, `self-hosted-node` (+ smoke test), and `manabrew` (Tauri) all compile.
- `cargo test -p forge-server first_user_is_controller` passes (exercises the bot flag / controller resolution).
- `cargo fmt` / `cargo clippy -p forge-server` — clean on changed code.
- `tsc -p tsconfig.app.json` / `prettier --check` / `eslint` — clean on changed files.
- Manual lobby verification still pending on the Mac mini node: resize a hosted room's count, add a bot, confirm the crown/controls land on the human and that a bot is never treated as controller.

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
