### PR TITLE
feat(bot): hand-fair protocol-only PhaseEval AI

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -55,6 +55,22 @@ this project uses it.
 The full text of GPL-3.0-or-later is in `LICENSE-GPL-3.0-or-later` at the
 repository root.
 
+## Phase (phase-rs/phase)
+
+- **Origin:** https://github.com/phase-rs/phase (crate `phase-ai`)
+- **License:** Apache-2.0 OR MIT
+
+### Use in this project
+
+The bot AI in `forge-engine/crates/forge-bot/src/agent/phase_eval/` is adapted
+from the `phase-ai` crate, used with the maintainer's permission. The board and
+creature evaluation heuristics, keyword-bonus weights, strategic-intent
+classification, and combat decision logic are reworked from `phase-ai` to read
+only this project's agent protocol (`GameViewDto`) rather than the Phase engine
+state. As an adaptation incorporated into this GPL-3.0-or-later project, the
+adapted code is distributed under GPL-3.0-or-later; the original `phase-ai`
+remains available under Apache-2.0 OR MIT from the origin above.
+
 ## Magic: The Gathering — name, rules, card content
 
 Magic: The Gathering is a property of Wizards of the Coast LLC. Card names,

--- a/forge-engine/crates/forge-bot/src/agent/mod.rs
+++ b/forge-engine/crates/forge-bot/src/agent/mod.rs
@@ -6,10 +6,13 @@
 //! picks which agent to spawn via the `agent` field of the bot config.
 
 use forge_agent_interface::agent_impl::Responder;
+use forge_agent_interface::game_view_dto::GameViewDto;
 use forge_agent_interface::prompt::{AgentPrompt, PlayerAction};
 use serde::{Deserialize, Serialize};
 
+pub mod phase_eval;
 pub mod simple_ai;
+pub use phase_eval::PhaseEvalAi;
 pub use simple_ai::SimpleAi;
 
 /// A bot's decision strategy. Each call to `decide` may consult per-bot state
@@ -19,6 +22,11 @@ pub trait BotAgent: Send {
     /// kinds (`StateUpdate`, `GameOver`); every decision prompt yields `Some`
     /// (an explicit `Pass` yields priority). Callers supply their own fallback.
     fn decide(&mut self, prompt: AgentPrompt) -> Option<PlayerAction>;
+
+    /// Observe a `StateUpdate`'s game view. Stateful agents cache it to reason
+    /// over the board, since decision prompts no longer carry the view. The
+    /// default ignores it (stateless agents need nothing).
+    fn observe(&mut self, _view: &GameViewDto) {}
 }
 
 /// Wire-level selector for which built-in agent the bot should use.
@@ -27,12 +35,14 @@ pub trait BotAgent: Send {
 pub enum AgentKind {
     #[default]
     Simple,
+    PhaseEval,
 }
 
 impl AgentKind {
     pub fn build(self) -> Box<dyn BotAgent + Send> {
         match self {
             AgentKind::Simple => Box::<SimpleAi>::default(),
+            AgentKind::PhaseEval => Box::<PhaseEvalAi>::default(),
         }
     }
 }

--- a/forge-engine/crates/forge-bot/src/agent/phase_eval/combat.rs
+++ b/forge-engine/crates/forge-bot/src/agent/phase_eval/combat.rs
@@ -1,0 +1,209 @@
+// Adapted from phase-rs/phase crates/phase-ai (Apache-2.0). See THIRD-PARTY-NOTICES.md.
+use std::collections::HashSet;
+
+use forge_agent_interface::game_view_dto::{CardDto, GameViewDto};
+use forge_agent_interface::prompt::{
+    AttackAssignment, BlockAssignment, DefenderIdDto, PlayerAction,
+};
+
+use super::eval::{
+    creature_combat_value, strategic_intent, threat_level, KeywordBonuses, StrategicIntent,
+};
+use super::view::{has_kw, power_of, toughness_of, BotView};
+
+fn first_strike(c: &CardDto) -> bool {
+    has_kw(c, "first strike") || has_kw(c, "double strike")
+}
+
+fn can_block(attacker: &CardDto, blocker: &CardDto) -> bool {
+    if has_kw(attacker, "flying") && !has_kw(blocker, "flying") && !has_kw(blocker, "reach") {
+        return false;
+    }
+    true
+}
+
+fn deals_lethal(attacker: &CardDto, defender: &CardDto) -> bool {
+    if has_kw(defender, "indestructible") {
+        return false;
+    }
+    let p = power_of(attacker);
+    p > 0 && (has_kw(attacker, "deathtouch") || p >= toughness_of(defender))
+}
+
+fn combat_outcome(attacker: &CardDto, blocker: &CardDto) -> (bool, bool) {
+    let mut attacker_dies = deals_lethal(blocker, attacker);
+    let mut blocker_dies = deals_lethal(attacker, blocker);
+
+    if first_strike(attacker) && !first_strike(blocker) && blocker_dies {
+        attacker_dies = false;
+    }
+    if first_strike(blocker) && !first_strike(attacker) && attacker_dies {
+        blocker_dies = false;
+    }
+
+    (attacker_dies, blocker_dies)
+}
+
+fn best_defender(view: &BotView, defenders: &[DefenderIdDto]) -> String {
+    defenders
+        .iter()
+        .filter(|d| d.id.starts_with("player-"))
+        .max_by(|a, b| threat_level(view, &a.id).total_cmp(&threat_level(view, &b.id)))
+        .map(|d| d.id.clone())
+        .or_else(|| defenders.first().map(|d| d.id.clone()))
+        .unwrap_or_else(|| "player-1".to_string())
+}
+
+pub fn choose_attackers(
+    me: &str,
+    game_view: &GameViewDto,
+    available_attacker_ids: &[String],
+    possible_defender_ids: &[DefenderIdDto],
+) -> PlayerAction {
+    let view = BotView::new(game_view, me);
+    let defender = best_defender(&view, possible_defender_ids);
+    let intent = strategic_intent(&view);
+    let bonuses = KeywordBonuses::default();
+
+    let blockers: Vec<&CardDto> = view
+        .opponents()
+        .iter()
+        .flat_map(|o| view.creatures_of(&o.id))
+        .filter(|c| !c.tapped)
+        .collect();
+
+    let mut assignments = Vec::new();
+    for id in available_attacker_ids {
+        let Some(attacker) = view.card_by_id(id) else {
+            continue;
+        };
+        if power_of(attacker) <= 0 {
+            continue;
+        }
+
+        let attack = if intent == StrategicIntent::PushLethal {
+            true
+        } else {
+            should_attack(attacker, &blockers, &bonuses)
+        };
+
+        if attack {
+            assignments.push(AttackAssignment {
+                attacker_id: id.clone(),
+                defender_id: defender.clone(),
+            });
+        }
+    }
+
+    PlayerAction::DeclareAttackers { assignments }
+}
+
+fn should_attack(attacker: &CardDto, blockers: &[&CardDto], bonuses: &KeywordBonuses) -> bool {
+    let viable: Vec<&&CardDto> = blockers.iter().filter(|b| can_block(attacker, b)).collect();
+    if viable.is_empty() {
+        return true;
+    }
+    if has_kw(attacker, "vigilance") {
+        return true;
+    }
+
+    viable.iter().all(|b| {
+        let (attacker_dies, blocker_dies) = combat_outcome(attacker, b);
+        if !attacker_dies {
+            return true;
+        }
+        blocker_dies
+            && creature_combat_value(attacker, bonuses) <= creature_combat_value(b, bonuses)
+    })
+}
+
+pub fn choose_blockers(
+    me: &str,
+    game_view: &GameViewDto,
+    attacker_ids: &[String],
+    available_blocker_ids: &[String],
+) -> PlayerAction {
+    let view = BotView::new(game_view, me);
+    let bonuses = KeywordBonuses::default();
+
+    let mut attackers: Vec<&CardDto> = attacker_ids
+        .iter()
+        .filter_map(|id| view.card_by_id(id))
+        .collect();
+    attackers.sort_by_key(|c| -power_of(c));
+
+    let blockers: Vec<&CardDto> = available_blocker_ids
+        .iter()
+        .filter_map(|id| view.card_by_id(id))
+        .collect();
+
+    let incoming: i32 = attackers.iter().map(|a| power_of(a)).sum();
+    let must_survive = incoming >= view.my_life();
+
+    let mut used: HashSet<String> = HashSet::new();
+    let mut assignments = Vec::new();
+
+    for attacker in &attackers {
+        let choice = blockers
+            .iter()
+            .filter(|b| !used.contains(&b.id) && can_block(attacker, b))
+            .filter_map(|b| {
+                let (attacker_dies, blocker_dies) = combat_outcome(attacker, b);
+                if !attacker_dies {
+                    return None;
+                }
+                let survives = !blocker_dies;
+                let trades_up = blocker_dies
+                    && creature_combat_value(b, &bonuses)
+                        <= creature_combat_value(attacker, &bonuses);
+                if survives || trades_up {
+                    Some((b, creature_combat_value(b, &bonuses)))
+                } else {
+                    None
+                }
+            })
+            .min_by(|a, b| a.1.total_cmp(&b.1));
+
+        if let Some((blocker, _)) = choice {
+            used.insert(blocker.id.clone());
+            assignments.push(BlockAssignment {
+                blocker_id: blocker.id.clone(),
+                attacker_id: attacker.id.clone(),
+            });
+        }
+    }
+
+    if must_survive {
+        let mut unblocked: i32 = attackers
+            .iter()
+            .filter(|a| !assignments.iter().any(|x| x.attacker_id == a.id))
+            .map(|a| power_of(a))
+            .sum();
+
+        for attacker in &attackers {
+            if unblocked < view.my_life() {
+                break;
+            }
+            if assignments.iter().any(|x| x.attacker_id == attacker.id) {
+                continue;
+            }
+            let chump = blockers
+                .iter()
+                .filter(|b| !used.contains(&b.id) && can_block(attacker, b))
+                .min_by(|a, b| {
+                    creature_combat_value(a, &bonuses)
+                        .total_cmp(&creature_combat_value(b, &bonuses))
+                });
+            if let Some(blocker) = chump {
+                used.insert(blocker.id.clone());
+                unblocked -= power_of(attacker);
+                assignments.push(BlockAssignment {
+                    blocker_id: blocker.id.clone(),
+                    attacker_id: attacker.id.clone(),
+                });
+            }
+        }
+    }
+
+    PlayerAction::DeclareBlockers { assignments }
+}

--- a/forge-engine/crates/forge-bot/src/agent/phase_eval/eval.rs
+++ b/forge-engine/crates/forge-bot/src/agent/phase_eval/eval.rs
@@ -1,0 +1,149 @@
+// Adapted from phase-rs/phase crates/phase-ai (Apache-2.0). See THIRD-PARTY-NOTICES.md.
+use forge_agent_interface::game_view_dto::CardDto;
+
+use super::view::{has_kw, power_of, toughness_of, BotView};
+
+#[derive(Debug, Clone)]
+pub struct KeywordBonuses {
+    pub flying_mult: f64,
+    pub trample_mult: f64,
+    pub deathtouch_flat: f64,
+    pub lifelink_mult: f64,
+    pub hexproof_flat: f64,
+    pub indestructible_flat: f64,
+    pub first_strike_mult: f64,
+    pub vigilance_flat: f64,
+    pub menace_mult: f64,
+    pub tapped_penalty: f64,
+}
+
+impl Default for KeywordBonuses {
+    fn default() -> Self {
+        Self {
+            flying_mult: 1.0,
+            trample_mult: 0.5,
+            deathtouch_flat: 3.0,
+            lifelink_mult: 0.5,
+            hexproof_flat: 2.0,
+            indestructible_flat: 4.0,
+            first_strike_mult: 0.8,
+            vigilance_flat: 1.0,
+            menace_mult: 0.5,
+            tapped_penalty: 1.5,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StrategicIntent {
+    PushLethal,
+    Stabilize,
+    PreserveAdvantage,
+    Develop,
+}
+
+pub fn creature_combat_value(c: &CardDto, bonuses: &KeywordBonuses) -> f64 {
+    let power = power_of(c) as f64;
+    let toughness = toughness_of(c) as f64;
+    let mut value = power * 1.5 + toughness;
+
+    if has_kw(c, "flying") {
+        value += power * bonuses.flying_mult;
+    }
+    if has_kw(c, "trample") {
+        value += power * bonuses.trample_mult;
+    }
+    if has_kw(c, "deathtouch") {
+        value += bonuses.deathtouch_flat;
+    }
+    if has_kw(c, "lifelink") {
+        value += power * bonuses.lifelink_mult;
+    }
+    if has_kw(c, "hexproof") {
+        value += bonuses.hexproof_flat;
+    }
+    if has_kw(c, "indestructible") {
+        value += bonuses.indestructible_flat;
+    }
+    if has_kw(c, "first strike") || has_kw(c, "double strike") {
+        value += power * bonuses.first_strike_mult;
+    }
+    if has_kw(c, "vigilance") {
+        value += bonuses.vigilance_flat;
+    }
+    if has_kw(c, "menace") {
+        value += power * bonuses.menace_mult;
+    }
+
+    value
+}
+
+pub fn evaluate_creature(c: &CardDto, bonuses: &KeywordBonuses) -> f64 {
+    let mut value = creature_combat_value(c, bonuses);
+    if c.tapped {
+        value -= bonuses.tapped_penalty;
+    }
+    value
+}
+
+fn board_stats(view: &BotView, pid: &str) -> (i32, i32, i32, i32) {
+    let mut creatures = 0;
+    let mut total_power = 0;
+    let mut total_toughness = 0;
+    let mut non_creatures = 0;
+
+    for c in &view.view.battlefield {
+        if c.controller_id != pid {
+            continue;
+        }
+        if super::view::is_creature(c) {
+            creatures += 1;
+            total_power += power_of(c);
+            total_toughness += toughness_of(c);
+        } else if !super::view::is_land(c) {
+            non_creatures += 1;
+        }
+    }
+
+    (creatures, total_power, total_toughness, non_creatures)
+}
+
+pub fn threat_level(view: &BotView, target: &str) -> f64 {
+    let Some(tp) = view.player(target) else {
+        return 0.0;
+    };
+    let starting_life = view.starting_life().max(1.0);
+    let (creatures, power, _, _) = board_stats(view, target);
+
+    let board_score = (creatures as f64 * 0.3 + power as f64 * 0.7).min(10.0) / 10.0;
+    let life_ratio = (tp.life as f64 / starting_life).clamp(0.0, 2.0) / 2.0;
+    let hand_score = (tp.hand.len() as f64).min(7.0) / 7.0;
+    let cmd_threat =
+        (tp.commander_damage.values().copied().max().unwrap_or(0) as f64 / 21.0).min(1.0);
+
+    board_score * 0.4 + life_ratio * 0.2 + hand_score * 0.15 + cmd_threat * 0.25
+}
+
+pub fn strategic_intent(view: &BotView) -> StrategicIntent {
+    let opponents = view.opponents();
+    if opponents.is_empty() {
+        return StrategicIntent::PreserveAdvantage;
+    }
+
+    let (_, my_power, _, _) = board_stats(view, &view.me);
+    let total_opp_power: i32 = opponents.iter().map(|o| board_stats(view, &o.id).1).sum();
+    let min_opp_life = opponents.iter().map(|o| o.life).min().unwrap_or(i32::MAX);
+    let my_life = view.my_life();
+    let avg_opp_life =
+        opponents.iter().map(|o| o.life).sum::<i32>() as f64 / opponents.len() as f64;
+
+    if min_opp_life > 0 && my_power >= min_opp_life {
+        StrategicIntent::PushLethal
+    } else if my_life <= total_opp_power.max(1) {
+        StrategicIntent::Stabilize
+    } else if my_power >= total_opp_power && my_life as f64 >= avg_opp_life {
+        StrategicIntent::PreserveAdvantage
+    } else {
+        StrategicIntent::Develop
+    }
+}

--- a/forge-engine/crates/forge-bot/src/agent/phase_eval/mod.rs
+++ b/forge-engine/crates/forge-bot/src/agent/phase_eval/mod.rs
@@ -1,0 +1,92 @@
+//! Heuristic AI adapted from the phase-rs/phase `phase-ai` crate (Apache-2.0).
+//! Reads only the agent protocol — and only public information: it caches the
+//! latest `StateUpdate` view and never inspects opponents' hand contents (see
+//! [`view::BotView::card_by_id`]). Specializes combat (attackers/blockers) with
+//! a 1-ply damage-resolution lookahead and hostile/friendly targeting;
+//! delegates every other decision to [`SimpleAi`].
+
+mod combat;
+mod eval;
+mod targeting;
+mod view;
+
+use forge_agent_interface::game_view_dto::GameViewDto;
+use forge_agent_interface::prompt::{AgentPrompt, AgentPromptInner, PlayerAction};
+
+use super::{BotAgent, SimpleAi};
+
+#[derive(Default)]
+pub struct PhaseEvalAi {
+    fallback: SimpleAi,
+    latest_view: Option<GameViewDto>,
+}
+
+impl PhaseEvalAi {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl BotAgent for PhaseEvalAi {
+    fn observe(&mut self, view: &GameViewDto) {
+        self.latest_view = Some(view.clone());
+    }
+
+    fn decide(&mut self, prompt: AgentPrompt) -> Option<PlayerAction> {
+        let me = prompt.deciding_player_id.clone();
+        if let Some(view) = self.latest_view.as_ref() {
+            match &prompt.input {
+                AgentPromptInner::ChooseAttackers {
+                    available_attacker_ids,
+                    possible_defender_ids,
+                    ..
+                } => {
+                    return Some(combat::choose_attackers(
+                        &me,
+                        view,
+                        available_attacker_ids,
+                        possible_defender_ids,
+                    ))
+                }
+                AgentPromptInner::ChooseBlockers {
+                    attacker_ids,
+                    available_blocker_ids,
+                    ..
+                } => {
+                    return Some(combat::choose_blockers(
+                        &me,
+                        view,
+                        attacker_ids,
+                        available_blocker_ids,
+                    ))
+                }
+                AgentPromptInner::ChooseTargetPlayer {
+                    valid_player_ids,
+                    intent,
+                    ..
+                } => {
+                    return Some(targeting::choose_target_player(
+                        &me,
+                        view,
+                        valid_player_ids,
+                        intent.is_hostile(),
+                    ))
+                }
+                AgentPromptInner::ChooseTargetCard {
+                    valid_card_ids,
+                    intent,
+                    ..
+                } => {
+                    return Some(targeting::choose_target_card(
+                        &me,
+                        view,
+                        valid_card_ids,
+                        intent.is_hostile(),
+                    ))
+                }
+                _ => {}
+            }
+        }
+        self.fallback.decide(prompt)
+    }
+}

--- a/forge-engine/crates/forge-bot/src/agent/phase_eval/targeting.rs
+++ b/forge-engine/crates/forge-bot/src/agent/phase_eval/targeting.rs
@@ -1,0 +1,55 @@
+// Adapted from phase-rs/phase crates/phase-ai (Apache-2.0). See THIRD-PARTY-NOTICES.md.
+use forge_agent_interface::game_view_dto::GameViewDto;
+use forge_agent_interface::prompt::PlayerAction;
+
+use super::eval::{evaluate_creature, threat_level, KeywordBonuses};
+use super::view::{is_creature, BotView};
+
+pub fn choose_target_player(
+    me: &str,
+    game_view: &GameViewDto,
+    valid_player_ids: &[String],
+    hostile: bool,
+) -> PlayerAction {
+    let view = BotView::new(game_view, me);
+    let chosen = if hostile {
+        valid_player_ids
+            .iter()
+            .filter(|id| id.as_str() != me)
+            .max_by(|a, b| threat_level(&view, a).total_cmp(&threat_level(&view, b)))
+            .or_else(|| valid_player_ids.first())
+            .cloned()
+    } else {
+        valid_player_ids
+            .iter()
+            .find(|id| id.as_str() == me)
+            .or_else(|| valid_player_ids.first())
+            .cloned()
+    };
+    PlayerAction::TargetPlayer { player_id: chosen }
+}
+
+pub fn choose_target_card(
+    me: &str,
+    game_view: &GameViewDto,
+    valid_card_ids: &[String],
+    hostile: bool,
+) -> PlayerAction {
+    let view = BotView::new(game_view, me);
+    let bonuses = KeywordBonuses::default();
+    let chosen = valid_card_ids
+        .iter()
+        .filter_map(|id| view.card_by_id(id))
+        .filter(|c| {
+            is_creature(c)
+                && (if hostile {
+                    c.controller_id != me
+                } else {
+                    c.controller_id == me
+                })
+        })
+        .max_by(|a, b| evaluate_creature(a, &bonuses).total_cmp(&evaluate_creature(b, &bonuses)))
+        .map(|c| c.id.clone())
+        .or_else(|| valid_card_ids.first().cloned());
+    PlayerAction::TargetCard { card_id: chosen }
+}

--- a/forge-engine/crates/forge-bot/src/agent/phase_eval/view.rs
+++ b/forge-engine/crates/forge-bot/src/agent/phase_eval/view.rs
@@ -1,0 +1,111 @@
+// Adapted from phase-rs/phase crates/phase-ai (Apache-2.0). See THIRD-PARTY-NOTICES.md.
+use forge_agent_interface::game_view_dto::{CardDto, GameViewDto, PlayerDto};
+
+pub struct BotView<'a> {
+    pub view: &'a GameViewDto,
+    pub me: String,
+}
+
+impl<'a> BotView<'a> {
+    pub fn new(view: &'a GameViewDto, me: &str) -> Self {
+        Self {
+            view,
+            me: me.to_string(),
+        }
+    }
+
+    pub fn player(&self, id: &str) -> Option<&'a PlayerDto> {
+        self.view.player(id)
+    }
+
+    pub fn my_life(&self) -> i32 {
+        self.player(&self.me).map_or(0, |p| p.life)
+    }
+
+    pub fn opponents(&self) -> Vec<&'a PlayerDto> {
+        self.view
+            .players
+            .iter()
+            .filter(|p| p.id != self.me)
+            .collect()
+    }
+
+    pub fn creatures_of(&self, id: &str) -> Vec<&'a CardDto> {
+        self.view
+            .battlefield
+            .iter()
+            .filter(|c| c.controller_id == id && is_creature(c))
+            .collect()
+    }
+
+    /// Look up a card by id across only the zones a fair player can see:
+    /// the shared battlefield, every player's public graveyard / exile /
+    /// command zone, and the bot's own hand. Opponents' hand contents are
+    /// deliberately excluded so the AI never reads hidden information.
+    pub fn card_by_id(&self, id: &str) -> Option<&'a CardDto> {
+        if let Some(c) = self.view.battlefield.iter().find(|c| c.id == id) {
+            return Some(c);
+        }
+        for p in &self.view.players {
+            if p.id == self.me {
+                if let Some(c) = p.hand.iter().find(|c| c.id == id) {
+                    return Some(c);
+                }
+            }
+            if let Some(c) = p
+                .graveyard
+                .iter()
+                .chain(p.exile.iter())
+                .chain(p.command_zone.iter())
+                .find(|c| c.id == id)
+            {
+                return Some(c);
+            }
+        }
+        None
+    }
+
+    pub fn commander_format(&self) -> bool {
+        self.view.players.iter().any(|p| !p.command_zone.is_empty())
+    }
+
+    pub fn starting_life(&self) -> f64 {
+        if self.commander_format() {
+            40.0
+        } else {
+            20.0
+        }
+    }
+}
+
+pub fn is_creature(c: &CardDto) -> bool {
+    c.types.iter().any(|t| t.eq_ignore_ascii_case("creature"))
+}
+
+pub fn is_land(c: &CardDto) -> bool {
+    c.types.iter().any(|t| t.eq_ignore_ascii_case("land"))
+}
+
+pub fn power_of(c: &CardDto) -> i32 {
+    c.power
+        .as_deref()
+        .and_then(parse_stat)
+        .or(c.base_power)
+        .unwrap_or(0)
+}
+
+pub fn toughness_of(c: &CardDto) -> i32 {
+    c.toughness
+        .as_deref()
+        .and_then(parse_stat)
+        .or(c.base_toughness)
+        .unwrap_or(0)
+}
+
+fn parse_stat(s: &str) -> Option<i32> {
+    s.trim().parse::<i32>().ok()
+}
+
+pub fn has_kw(c: &CardDto, kw: &str) -> bool {
+    c.keywords.iter().any(|k| k.eq_ignore_ascii_case(kw))
+}

--- a/forge-engine/crates/forge-bot/src/state.rs
+++ b/forge-engine/crates/forge-bot/src/state.rs
@@ -1,6 +1,6 @@
 use forge_agent_interface::deck_dto::Deck;
 use forge_agent_interface::ids_codec::player_slot;
-use forge_agent_interface::prompt::AgentPrompt;
+use forge_agent_interface::prompt::{AgentPrompt, StateUpdate};
 use forge_agent_interface::protocol::{ClientMessage, ServerMessage, StateEnvelope};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -140,8 +140,15 @@ impl BotState {
             Ok(envelope) => envelope,
             Err(_) => return Vec::new(),
         };
-        let StateEnvelope::Prompt { for_player, prompt } = envelope else {
-            return Vec::new();
+        let (for_player, prompt) = match envelope {
+            StateEnvelope::State { state } => {
+                if let Ok(update) = serde_json::from_value::<StateUpdate>(state) {
+                    self.agent.observe(&update.game_view);
+                }
+                return Vec::new();
+            }
+            StateEnvelope::Prompt { for_player, prompt } => (for_player, prompt),
+            _ => return Vec::new(),
         };
         let prompt_type = prompt
             .get("type")

--- a/forge-engine/crates/self-hosted-node/src/config.rs
+++ b/forge-engine/crates/self-hosted-node/src/config.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::path::{Path, PathBuf};
 
 use forge_agent_interface::deck_dto::{CardIdentity, Deck, DeckCard};
+use forge_bot::AgentKind;
 use forge_server::protocol::GameFormat;
 use serde::Deserialize;
 use tracing::warn;
@@ -21,6 +22,7 @@ pub struct Config {
     pub host_plays: bool,
     pub bot_enabled: bool,
     pub bot_username: String,
+    pub bot_agent: AgentKind,
     pub host_deck: DeckSelection,
     pub bot_deck: DeckSelection,
 }
@@ -107,9 +109,19 @@ impl Config {
                 false,
             ),
             bot_username,
+            bot_agent: env_first("SELF_HOSTED_NODE_BOT_AGENT", "FORGE_ROOM_BOT_AGENT")
+                .map(|value| parse_agent(&value))
+                .unwrap_or_default(),
             host_deck: load_deck_selection(&host_deck_id, host_commander),
             bot_deck: load_deck_selection(&bot_deck_id, bot_commander),
         }
+    }
+}
+
+fn parse_agent(value: &str) -> AgentKind {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "phaseeval" | "phase_eval" | "phase-eval" => AgentKind::PhaseEval,
+        _ => AgentKind::Simple,
     }
 }
 

--- a/forge-engine/crates/self-hosted-node/src/main.rs
+++ b/forge-engine/crates/self-hosted-node/src/main.rs
@@ -13,7 +13,7 @@ use engine_backend::{java_backend, rust_backend, EngineBackendKind};
 use forge_agent_interface::deck_dto::Deck;
 use forge_agent_interface::ids_codec::{parse_player_slot, player_slot};
 use forge_agent_interface::prompt::{AgentMessage, PlayerAction};
-use forge_bot::{run_bot, AgentKind, BotConfig};
+use forge_bot::{run_bot, BotConfig};
 use forge_engine_core::game::TypeRegistry;
 use forge_server::protocol::{
     ClientMessage, EngineKind, GameFormat, PlayerDeckInfo, RoomInfo, RoomStatus, ServerMessage,
@@ -332,7 +332,7 @@ fn spawn_bot(config: &Config, deck: &DeckSelection, room_id: String, bot_state: 
         deck_name: deck.name.clone(),
         deck: deck.deck.clone(),
         commander_name: deck.commander_name.clone(),
-        agent: AgentKind::Simple,
+        agent: config.bot_agent,
     };
     let handle = tokio::spawn(async move {
         if let Err(error) = run_bot(relay_url, bot_config).await {


### PR DESCRIPTION
## Summary

A self-contained, hand-fair `PhaseEvalAi` for the relay-client bot path (`forge-bot`) — the cross-engine/relay fallback opponent. It plays over the protocol-v2 agent wire format:

- Caches the latest `StateUpdate` view via a new `BotAgent::observe` hook (decision prompts no longer carry the view); `state.rs` routes `StateEnvelope::State` to it.
- Eval-driven **combat** (attacker/blocker selection with a 1-ply damage-resolution lookahead — deathtouch, first/double strike, indestructible, flying/reach) and hostile/friendly **targeting**.
- **Fairness:** reads only the bot's own hand + public zones and never inspects opponents' hand contents — only the public hand count — even though protocol-v2 ships every hand in the DTO.
- Non-combat/targeting prompts delegate to `SimpleAi`, so behaviour is a strict superset. Selectable on the node via `SELF_HOSTED_NODE_BOT_AGENT=phaseEval` (default `Simple`).

Eval heuristics adapted from phase-rs/phase `phase-ai` (Apache-2.0, with the maintainer's permission; credited in `THIRD-PARTY-NOTICES.md`).

Scope note: this is the **relay-path** bot. The stronger in-engine opponent (Forge's native AI) is a separate PR — Forge's `AiController` can't run as a relay client, so this bot remains the fallback for cross-engine/relay games.

## Test plan

- `cargo check -p forge-bot` clean; clippy/fmt clean on the new files.
- Not yet validated in a live game; exercise via `SELF_HOSTED_NODE_BOT_AGENT=phaseEval`.

## Build artifacts

- [ ] Build macOS .dmg
- [ ] Build Windows .exe