### PR TITLE
feat(ai): Forge's native AI in the bot seat (in-engine opponent)

### DIFF
--- a/forge-engine/crates/self-hosted-node/src/config.rs
+++ b/forge-engine/crates/self-hosted-node/src/config.rs
@@ -21,6 +21,7 @@ pub struct Config {
     pub host_plays: bool,
     pub bot_enabled: bool,
     pub bot_username: String,
+    pub forge_ai: bool,
     pub host_deck: DeckSelection,
     pub bot_deck: DeckSelection,
 }
@@ -107,6 +108,7 @@ impl Config {
                 false,
             ),
             bot_username,
+            forge_ai: env_bool("SELF_HOSTED_NODE_FORGE_AI", "FORGE_ROOM_FORGE_AI", false),
             host_deck: load_deck_selection(&host_deck_id, host_commander),
             bot_deck: load_deck_selection(&bot_deck_id, bot_commander),
         }

--- a/forge-engine/crates/self-hosted-node/src/engine_backend/java_backend.rs
+++ b/forge-engine/crates/self-hosted-node/src/engine_backend/java_backend.rs
@@ -689,6 +689,7 @@ pub fn run_hosted_engine_game(
     decks: Vec<Deck>,
     commander_names: Vec<Option<String>>,
     local_player_index: Option<usize>,
+    ai_player_index: Option<usize>,
     starting_life: i32,
     remote_prompt_tx: std_mpsc::Sender<(usize, AgentPrompt)>,
     remote_response_rxs: Vec<(usize, std_mpsc::Receiver<PlayerAction>)>,
@@ -701,6 +702,7 @@ pub fn run_hosted_engine_game(
         decks,
         commander_names,
         local_player_index,
+        ai_player_index,
         starting_life,
         remote_prompt_tx,
         remote_response_rxs,
@@ -718,6 +720,7 @@ pub fn run_hosted_engine_game(
     _decks: Vec<Deck>,
     _commander_names: Vec<Option<String>>,
     _local_player_index: Option<usize>,
+    _ai_player_index: Option<usize>,
     _starting_life: i32,
     _remote_prompt_tx: std_mpsc::Sender<(usize, AgentPrompt)>,
     _remote_response_rxs: Vec<(usize, std_mpsc::Receiver<PlayerAction>)>,
@@ -737,6 +740,7 @@ fn run_hosted_engine_game_inner(
     decks: Vec<Deck>,
     commander_names: Vec<Option<String>>,
     local_player_index: Option<usize>,
+    ai_player_index: Option<usize>,
     starting_life: i32,
     remote_prompt_tx: std_mpsc::Sender<(usize, AgentPrompt)>,
     remote_response_rxs: Vec<(usize, std_mpsc::Receiver<PlayerAction>)>,
@@ -753,6 +757,11 @@ fn run_hosted_engine_game_inner(
             &identities,
             commander_names[index].clone(),
         ));
+    }
+    if let Some(idx) = ai_player_index {
+        if let Some(player) = players.get_mut(idx) {
+            player.ai = true;
+        }
     }
     let request = StartGameRequest::new(game_id.clone(), starting_life, rand::random(), players);
     let session_id = engine.start_game(&request.to_json().map_err(|err| err.to_string())?)?;
@@ -1741,6 +1750,7 @@ pub struct PlayerConfig {
     name: String,
     deck: Vec<CardIdentityForJava>,
     commander_name: Option<String>,
+    ai: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1779,6 +1789,7 @@ impl PlayerConfig {
             name,
             deck: deck.iter().map(CardIdentityForJava::from).collect(),
             commander_name,
+            ai: false,
         }
     }
 }

--- a/forge-engine/crates/self-hosted-node/src/main.rs
+++ b/forge-engine/crates/self-hosted-node/src/main.rs
@@ -750,6 +750,13 @@ fn maybe_start_hosted_engine(
     }
 
     let player_names = player_order;
+    let bot_index = if config.forge_ai && config.bot_enabled {
+        player_names
+            .iter()
+            .position(|name| name == &config.bot_username)
+    } else {
+        None
+    };
     let game_id = format!("room-game-{}", Uuid::new_v4());
 
     match backend {
@@ -835,6 +842,7 @@ fn maybe_start_hosted_engine(
                         ordered_decks,
                         commander_names,
                         local_player_index,
+                        bot_index,
                         starting_life,
                         remote_prompt_tx,
                         remote_response_rxs,

--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewEngineAdapter.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewEngineAdapter.java
@@ -9,6 +9,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import forge.ai.LobbyPlayerAi;
 import forge.deck.CardPool;
 import forge.deck.Deck;
 import forge.deck.DeckSection;
@@ -84,8 +85,12 @@ public final class ManaBrewEngineAdapter {
             Deck deck = buildDeck(playerConfig);
             RegisteredPlayer registeredPlayer = RegisteredPlayer.forVariants(
                     playerCount, variants, deck, null, false, null, null);
-            registeredPlayer.setPlayer(new ManaBrewInteractiveLobbyPlayer(
-                    playerConfig.getName(), session));
+            if (playerConfig.isAi()) {
+                registeredPlayer.setPlayer(new LobbyPlayerAi(playerConfig.getName(), null));
+            } else {
+                registeredPlayer.setPlayer(new ManaBrewInteractiveLobbyPlayer(
+                        playerConfig.getName(), session));
+            }
             registeredPlayers.add(registeredPlayer);
         }
 
@@ -225,7 +230,10 @@ public final class ManaBrewEngineAdapter {
                         requiredString(cardObject, "name"),
                         optionalString(cardObject, "setCode")));
             }
-            players.add(new PlayerConfig(name, deck, commanderName));
+            boolean ai = playerObject.has("ai")
+                    && !playerObject.get("ai").isJsonNull()
+                    && playerObject.get("ai").getAsBoolean();
+            players.add(new PlayerConfig(name, deck, commanderName, ai));
         }
         return new StartGameRequest(gameId, startingLife, seed, players);
     }
@@ -290,11 +298,13 @@ public final class ManaBrewEngineAdapter {
         private final String name;
         private final List<CardIdentity> deck;
         private final String commanderName;
+        private final boolean ai;
 
         public PlayerConfig(
                 final String name,
                 final List<CardIdentity> deck,
-                final String commanderName
+                final String commanderName,
+                final boolean ai
         ) {
             if (name == null || name.isBlank()) {
                 throw new IllegalArgumentException("player name is required");
@@ -305,6 +315,7 @@ public final class ManaBrewEngineAdapter {
             this.name = name;
             this.deck = List.copyOf(deck);
             this.commanderName = commanderName;
+            this.ai = ai;
         }
 
         public String getName() {
@@ -317,6 +328,10 @@ public final class ManaBrewEngineAdapter {
 
         public String getCommanderName() {
             return commanderName;
+        }
+
+        public boolean isAi() {
+            return ai;
         }
     }
 


### PR DESCRIPTION
## Summary

Puts **Forge's own mature AI** (`PlayerControllerAi` + `AiController`) in the hosted-game bot seat, replacing today's opponent — a first-legal-action/pass stub. Native to the engine hosted games already run on; the strongest opponent available.

**Design A — "bot-as-presence"** (chosen after mapping the room lifecycle): `run_bot` still joins/sets-deck/readies so the lobby's start condition holds, but the node marks its seat `ai: true` so the **engine drives it in-engine via Forge's AI**. The engine emits no prompts for that seat, so `run_bot` idles harmlessly — disconnect-grace and start logic untouched, no relay/protocol changes.

### What's here (Java + Rust, complete)
- **Harness:** `ManaBrewEngineAdapter` assigns `LobbyPlayerAi` to any seat with `ai:true` (swap is local — same `IGameEntitiesFactory` interface; `forge-ai` already a dep). `PlayerConfig` parses `ai`.
- **Node:** `config.forge_ai` (env `SELF_HOSTED_NODE_FORGE_AI`, **default off**). When on + a bot is enabled, the node finds the bot's seat by `bot_username` in `player_order` and sets `PlayerConfig.ai=true` in the `StartGameRequest`. `run_bot`/`spawn_bot` unchanged.

### Why it's safe across concurrent rooms
Each hosted game runs in its own JVM subprocess (`JavaEnginePool`), so the per-game `ai` flag isolates cleanly; the node IDs each room's bot by its per-room labeled username. Uses the rules-based AI (`LobbyPlayerAi(name, null)`, not `USE_SIMULATION`), so per-decision CPU stays modest (bounded by `MAX_GAMES`).

### The engine still prompts the human
`match.startGame()` is Forge's native loop — it calls each player's `PlayerController` in turn. The human's controller blocks on the relay (gets prompts); the AI's resolves in-engine. This is exactly how Forge's own GUI runs human-vs-AI.

## Test plan

- `cargo check -p self-hosted-node` clean (default **and** `--features java-forge`), via the dedicated target dir (`/tmp/mb-ai`) — the shared `target` symlink bleeds a sibling project's stale `forge-server`. fmt/clippy clean on the touched files.
- Java harness can't be `-pl` compiled offline (needs the Forge Maven reactor); CI/Docker builds it.
- **End-to-end not yet run.** Deploy path: merge → mini auto-deploys → set `SELF_HOSTED_NODE_FORGE_AI=true` (with `bot_enabled`) in `~/manabrew-node.env` → hosted games use Forge's AI.

## Trade-off / follow-up

Keeps an idle bot WebSocket open (cheap). A future opt-in **Design B** (relay carries an `as_bot` hint + phantom AI seat) could retire it, backward-compatibly.

## Build artifacts

- [ ] Build macOS .dmg
- [ ] Build Windows .exe
