### PR TITLE
fix(node): always emit game-over prompt, even if final snapshot fails

### DIFF
--- a/forge-engine/crates/self-hosted-node/src/engine_backend/java_backend.rs
+++ b/forge-engine/crates/self-hosted-node/src/engine_backend/java_backend.rs
@@ -903,19 +903,32 @@ fn run_hosted_engine_game_inner(
 
         if engine.is_game_over(&session_id)? {
             info!("hosted java-forge session reached game over");
-            if let Ok(snapshot_json) = engine.get_snapshot(&session_id) {
-                if let Ok(raw_snapshot) = serde_json::from_str::<JavaRawSnapshot>(&snapshot_json) {
+            // Best-effort final state: it needs the snapshot, but the result
+            // screen must not depend on it. A snapshot fetch/parse failure here
+            // used to drop the whole game-over emission and soft-lock the client
+            // in a dead game view (#77).
+            match engine.get_snapshot(&session_id).and_then(|json| {
+                serde_json::from_str::<JavaRawSnapshot>(&json).map_err(|e| e.to_string())
+            }) {
+                Ok(raw_snapshot) => {
                     let state = AgentMessage::State(make_java_state_update(
                         &raw_snapshot,
                         Some(&session_id),
                         0,
                     ));
-                    let game_over = AgentMessage::Prompt(make_java_game_over_prompt());
                     for &agent_index in remote_response_rxs.keys() {
                         let _ = remote_prompt_tx.send((agent_index, state.clone()));
-                        let _ = remote_prompt_tx.send((agent_index, game_over.clone()));
                     }
                 }
+                Err(error) => {
+                    warn!(%error, "game over: final snapshot unavailable; sending game-over prompt only");
+                }
+            }
+            // Always send the GameOver prompt — it carries no snapshot data, so the
+            // client shows the result screen regardless of the snapshot above.
+            let game_over = AgentMessage::Prompt(make_java_game_over_prompt());
+            for &agent_index in remote_response_rxs.keys() {
+                let _ = remote_prompt_tx.send((agent_index, game_over.clone()));
             }
             let _ = game_over_tx.send(game_id.clone());
             engine.end_game(&session_id)?;


### PR DESCRIPTION
## Summary

Hosted java games would reach game-over but the client never showed the result screen — it soft-locked in a dead game view (#77).

**Root cause:** in `run_hosted_engine_game_inner`, both the final state **and** the `GameOver` result-screen prompt were emitted only inside `if let Ok(snapshot) = engine.get_snapshot(...)`. If the snapshot fetch/parse failed at game-over (plausible while the session is torn down), the whole block was skipped **silently** — no state, no prompt, no log — so the client got no game-over signal.

The `GameOver` prompt carries no snapshot data, so it never needed to be coupled to the snapshot.

## Why

I traced the full path and everything else is correct: the human seat is a broadcast target; the client applies a remote game-over state unconditionally and the `gameOver` prompt when `forPlayer === myPlayerSlot` (which matches); `GameOverScreen` renders on `gameView.gameOver || promptType === "gameOver"`. The only way to get "game ended, no screen" is the emission block being skipped — i.e. the snapshot guard. Not AI-specific; this path runs for every hosted game.

## Fix

- Final state stays **best-effort** (needs the snapshot) and now **`warn!`s** when the snapshot is unavailable — which also confirms the hypothesis on the next hosted game-over.
- The `GameOver` prompt is **always** sent, so the result screen shows regardless of snapshot state.

## Test plan

- `cargo check -p self-hosted-node --features java-forge` — clean.
- Live: finish a hosted game; the result screen should appear. If the snapshot path was the culprit, the node logs the new `game over: final snapshot unavailable …` warn.

## Build artifacts
- [ ] Build macOS .dmg
- [ ] Build Windows .exe
