### PR TITLE
fix(ci): bad secret overwrite

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,6 @@ jobs:
           HOST: ${{ secrets.DEPLOY_HOST }}
           USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
-          SECRET_MANABREW_KEY: ${{ secrets.SECRET_MANABREW_KEY }}
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh
@@ -39,7 +38,7 @@ jobs:
               -o ServerAliveInterval=30 \
               -o ServerAliveCountMax=120 \
               "$USER@$HOST" \
-            "cd '$DEPLOY_PATH' && SECRET_MANABREW_KEY='$SECRET_MANABREW_KEY' ./deploy.sh 2>&1" 2>&1 | tee deploy.log
+            "cd '$DEPLOY_PATH' && ./deploy.sh 2>&1" 2>&1 | tee deploy.log
           exit ${PIPESTATUS[0]}
 
       - name: Fetch raw deploy log on failure


### PR DESCRIPTION
## Build artifacts
<!--
  Check the boxes below to build the corresponding installer on merge to main
  (uploaded to the Actions run, 30-day retention).
  Leave unchecked to skip — faster CI, no binaries produced.
  Tag pushes (v*) always build both and publish a GitHub Release regardless.
-->
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
