### PR TITLE
feat: Join player, clear room mode init, and correct reset

### DIFF
--- a/forge-engine/crates/forge-server/src/lobby.rs
+++ b/forge-engine/crates/forge-server/src/lobby.rs
@@ -454,6 +454,10 @@ pub fn end_game_sync(
         let cleared: Vec<String> = room.players.iter().map(|p| p.player_id.clone()).collect();
         room.status = RoomStatus::Lobby;
         room.players.clear();
+        if room.draft_config.is_none() && room.sealed_config.is_none() {
+            room.format = GameFormat::Any;
+            room.max_players = 4;
+        }
         (room.to_room_info(), cleared)
     };
 

--- a/src/components/lobby/ChooseFormatDialog.tsx
+++ b/src/components/lobby/ChooseFormatDialog.tsx
@@ -1,0 +1,47 @@
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { FormatPicker } from "@/components/lobby/FormatPicker";
+import { GAME_FORMATS } from "@/lib/formats";
+import type { GameFormat, RoomInfo } from "@/types/server";
+
+const SELECTABLE_FORMATS: GameFormat[] = [
+  "Standard",
+  "Pioneer",
+  "Modern",
+  "Legacy",
+  "Vintage",
+  "Pauper",
+  "Commander",
+  "Brawl",
+  "Oathbreaker",
+];
+
+const PICKER_FORMATS = GAME_FORMATS.filter((f) =>
+  SELECTABLE_FORMATS.some((s) => s.toLowerCase() === f.id),
+);
+
+interface ChooseFormatDialogProps {
+  room: RoomInfo | null;
+  onClose: () => void;
+  onSelect: (room: RoomInfo, format: GameFormat) => void;
+}
+
+export function ChooseFormatDialog({ room, onClose, onSelect }: ChooseFormatDialogProps) {
+  function handleSelect(formatId: string) {
+    if (!room) return;
+    const format = SELECTABLE_FORMATS.find((s) => s.toLowerCase() === formatId);
+    if (!format) return;
+    onClose();
+    onSelect(room, format);
+  }
+
+  return (
+    <Dialog open={room != null} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-4xl p-0 overflow-hidden">
+        <DialogTitle className="sr-only">Choose a format</DialogTitle>
+        <div className="h-[min(42rem,85dvh)]">
+          <FormatPicker formats={PICKER_FORMATS} onSelect={handleSelect} />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/lobby/FormatPicker.tsx
+++ b/src/components/lobby/FormatPicker.tsx
@@ -2,10 +2,11 @@ import { FormatBadge } from "@/components/game/FormatBadge";
 import { GAME_FORMATS, type GameFormat } from "@/lib/formats";
 
 interface FormatPickerProps {
+  formats?: GameFormat[];
   onSelect: (formatId: string) => void;
 }
 
-export function FormatPicker({ onSelect }: FormatPickerProps) {
+export function FormatPicker({ formats = GAME_FORMATS, onSelect }: FormatPickerProps) {
   return (
     <div className="flex h-full flex-col overflow-y-auto px-6 py-10">
       <div className="mx-auto flex w-full max-w-5xl flex-col">
@@ -21,7 +22,7 @@ export function FormatPicker({ onSelect }: FormatPickerProps) {
         </header>
 
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {GAME_FORMATS.map((format) => (
+          {formats.map((format) => (
             <FormatTile key={format.id} format={format} onClick={() => onSelect(format.id)} />
           ))}
         </div>

--- a/src/components/lobby/JoinPasswordDialog.tsx
+++ b/src/components/lobby/JoinPasswordDialog.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Lock } from "lucide-react";
+import type { RoomInfo } from "@/types/server";
+
+interface JoinPasswordDialogProps {
+  room: RoomInfo | null;
+  onClose: () => void;
+  onSubmit: (roomId: string, password: string) => void;
+}
+
+export function JoinPasswordDialog({ room, onClose, onSubmit }: JoinPasswordDialogProps) {
+  const [password, setPassword] = useState("");
+
+  function close() {
+    setPassword("");
+    onClose();
+  }
+
+  function submit() {
+    if (!room) return;
+    onSubmit(room.room_id, password);
+    close();
+  }
+
+  return (
+    <Dialog open={room != null} onOpenChange={(open) => !open && close()}>
+      <DialogContent className="max-w-sm">
+        <DialogTitle className="flex items-center gap-2">
+          <Lock className="h-4 w-4" />
+          Private room
+        </DialogTitle>
+        <DialogDescription>Enter the password to join {room?.room_name}.</DialogDescription>
+        <Input
+          type="password"
+          autoFocus
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") submit();
+          }}
+          placeholder="Password"
+        />
+        <DialogFooter>
+          <Button variant="ghost" onClick={close}>
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={password.length === 0}>
+            Join
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/lobby/TablesList.tsx
+++ b/src/components/lobby/TablesList.tsx
@@ -3,13 +3,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { JoinPasswordDialog } from "@/components/lobby/JoinPasswordDialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -136,7 +130,6 @@ export function TablesList({
 }: TablesListProps) {
   const [joiningRoomId, setJoiningRoomId] = useState<string | null>(null);
   const [passwordRoom, setPasswordRoom] = useState<RoomInfo | null>(null);
-  const [passwordValue, setPasswordValue] = useState("");
   const [search, setSearch] = useState("");
 
   const inRoom = currentRoom != null;
@@ -177,18 +170,10 @@ export function TablesList({
 
   function requestJoin(room: RoomInfo) {
     if (room.password_protected) {
-      setPasswordValue("");
       setPasswordRoom(room);
     } else {
       void handleJoinRoom(room.room_id);
     }
-  }
-
-  function submitPasswordJoin() {
-    if (!passwordRoom) return;
-    const roomId = passwordRoom.room_id;
-    setPasswordRoom(null);
-    void handleJoinRoom(roomId, passwordValue);
   }
 
   const trimmedSearch = search.trim().toLowerCase();
@@ -627,35 +612,11 @@ export function TablesList({
         </div>
       </ScrollArea>
 
-      <Dialog open={passwordRoom != null} onOpenChange={(open) => !open && setPasswordRoom(null)}>
-        <DialogContent className="max-w-sm">
-          <DialogTitle className="flex items-center gap-2">
-            <Lock className="h-4 w-4" />
-            Private room
-          </DialogTitle>
-          <DialogDescription>
-            Enter the password to join {passwordRoom?.room_name}.
-          </DialogDescription>
-          <Input
-            type="password"
-            autoFocus
-            value={passwordValue}
-            onChange={(e) => setPasswordValue(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") submitPasswordJoin();
-            }}
-            placeholder="Password"
-          />
-          <DialogFooter>
-            <Button variant="ghost" onClick={() => setPasswordRoom(null)}>
-              Cancel
-            </Button>
-            <Button onClick={submitPasswordJoin} disabled={passwordValue.length === 0}>
-              Join
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <JoinPasswordDialog
+        room={passwordRoom}
+        onClose={() => setPasswordRoom(null)}
+        onSubmit={(roomId, password) => void handleJoinRoom(roomId, password)}
+      />
     </div>
   );
 }

--- a/src/components/lobby/TablesList.tsx
+++ b/src/components/lobby/TablesList.tsx
@@ -3,6 +3,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { ChooseFormatDialog } from "@/components/lobby/ChooseFormatDialog";
 import { JoinPasswordDialog } from "@/components/lobby/JoinPasswordDialog";
 import {
   DropdownMenu,
@@ -91,7 +92,7 @@ interface TablesListProps {
   onRefresh: () => void;
   refreshing: boolean;
   refreshDisabled: boolean;
-  onJoinRoom: (roomId: string, password?: string) => Promise<void>;
+  onJoinRoom: (roomId: string, password?: string, format?: GameFormat) => Promise<void>;
   onLeaveRoom: () => void;
   onSetReady: (ready: boolean) => void;
   onSetFormat?: (format: GameFormat) => void;
@@ -130,6 +131,8 @@ export function TablesList({
 }: TablesListProps) {
   const [joiningRoomId, setJoiningRoomId] = useState<string | null>(null);
   const [passwordRoom, setPasswordRoom] = useState<RoomInfo | null>(null);
+  const [formatRoom, setFormatRoom] = useState<RoomInfo | null>(null);
+  const [pendingFormat, setPendingFormat] = useState<GameFormat | undefined>(undefined);
   const [search, setSearch] = useState("");
 
   const inRoom = currentRoom != null;
@@ -158,21 +161,39 @@ export function TablesList({
       })
     : [];
 
-  async function handleJoinRoom(roomId: string, password?: string) {
+  async function handleJoinRoom(roomId: string, password?: string, format?: GameFormat) {
     if (joiningRoomId) return;
     setJoiningRoomId(roomId);
     try {
-      await onJoinRoom(roomId, password);
+      await onJoinRoom(roomId, password, format);
     } finally {
       setJoiningRoomId(null);
     }
   }
 
+  function needsFormatChoice(room: RoomInfo) {
+    return (
+      room.format === "Any" &&
+      !room.draft_config &&
+      !room.sealed_config &&
+      room.players.every((p) => p.is_bot)
+    );
+  }
+
   function requestJoin(room: RoomInfo) {
+    if (needsFormatChoice(room)) {
+      setFormatRoom(room);
+    } else {
+      joinWithFormat(room, undefined);
+    }
+  }
+
+  function joinWithFormat(room: RoomInfo, format?: GameFormat) {
     if (room.password_protected) {
+      setPendingFormat(format);
       setPasswordRoom(room);
     } else {
-      void handleJoinRoom(room.room_id);
+      void handleJoinRoom(room.room_id, undefined, format);
     }
   }
 
@@ -612,10 +633,16 @@ export function TablesList({
         </div>
       </ScrollArea>
 
+      <ChooseFormatDialog
+        room={formatRoom}
+        onClose={() => setFormatRoom(null)}
+        onSelect={(room, format) => joinWithFormat(room, format)}
+      />
+
       <JoinPasswordDialog
         room={passwordRoom}
         onClose={() => setPasswordRoom(null)}
-        onSubmit={(roomId, password) => void handleJoinRoom(roomId, password)}
+        onSubmit={(roomId, password) => void handleJoinRoom(roomId, password, pendingFormat)}
       />
     </div>
   );

--- a/src/components/lobby/UserList.tsx
+++ b/src/components/lobby/UserList.tsx
@@ -1,16 +1,22 @@
+import { useState } from "react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { JoinPasswordDialog } from "@/components/lobby/JoinPasswordDialog";
 import { Wifi, WifiOff, Loader2 } from "lucide-react";
-import type { PlayerInfo } from "@/types/server";
+import type { PlayerInfo, RoomInfo } from "@/types/server";
 import { cn } from "@/lib/utils";
 
 export type ConnectionState = "connected" | "connecting" | "disconnected";
 
 interface UserListProps {
   players: PlayerInfo[];
+  rooms: RoomInfo[];
+  currentRoom: RoomInfo | null;
   currentPlayerId: string | null;
   currentUsername: string | null;
   connectionState: ConnectionState;
+  onJoinRoom: (roomId: string, password?: string) => Promise<void>;
 }
 
 const CONNECTION_STATUS: Record<
@@ -32,12 +38,23 @@ const CONNECTION_STATUS: Record<
   },
 };
 
+function playerStatus(room: RoomInfo | undefined): string {
+  if (!room) return "Chilling";
+  return room.status === "InGame" ? "In game" : "In lobby";
+}
+
 export function UserList({
   players,
+  rooms,
+  currentRoom,
   currentPlayerId,
   currentUsername,
   connectionState,
+  onJoinRoom,
 }: UserListProps) {
+  const [joiningRoomId, setJoiningRoomId] = useState<string | null>(null);
+  const [passwordRoom, setPasswordRoom] = useState<RoomInfo | null>(null);
+
   const myEntry = players.find(
     (p) =>
       (currentPlayerId != null && p.player_id === currentPlayerId) ||
@@ -46,6 +63,24 @@ export function UserList({
   const others = players.filter((p) => p !== myEntry);
   const myUsername = myEntry?.username ?? currentUsername;
   const status = CONNECTION_STATUS[connectionState];
+
+  async function handleJoinRoom(roomId: string, password?: string) {
+    if (joiningRoomId) return;
+    setJoiningRoomId(roomId);
+    try {
+      await onJoinRoom(roomId, password);
+    } finally {
+      setJoiningRoomId(null);
+    }
+  }
+
+  function requestJoin(room: RoomInfo) {
+    if (room.password_protected) {
+      setPasswordRoom(room);
+    } else {
+      void handleJoinRoom(room.room_id);
+    }
+  }
 
   return (
     <div className="flex flex-col h-full">
@@ -89,34 +124,55 @@ export function UserList({
             </div>
           )}
 
-          {others.map((player) => (
-            <div
-              key={player.player_id}
-              className="flex items-center gap-2.5 px-2 py-1.5 rounded-md hover:bg-muted/40 transition-colors"
-            >
-              <div className="relative shrink-0">
-                <Avatar className="h-7 w-7">
-                  <AvatarFallback className="text-[10px]">
-                    {player.username.slice(0, 2).toUpperCase()}
-                  </AvatarFallback>
-                </Avatar>
-                <span
-                  className={cn(
-                    "absolute -bottom-0.5 -right-0.5 w-2 h-2 rounded-full border-2 border-background",
-                    player.connected ? "bg-primary" : "bg-muted-foreground/40",
-                  )}
-                />
+          {others.map((player) => {
+            const room = rooms.find((r) => r.room_id === player.room_id);
+            const joinable =
+              room != null &&
+              room.status === "Lobby" &&
+              currentRoom == null &&
+              room.players.length < room.max_players;
+
+            return (
+              <div
+                key={player.player_id}
+                className="flex items-center gap-2.5 px-2 py-1.5 rounded-md"
+              >
+                <div className="relative shrink-0">
+                  <Avatar className="h-7 w-7">
+                    <AvatarFallback className="text-[10px]">
+                      {player.username.slice(0, 2).toUpperCase()}
+                    </AvatarFallback>
+                  </Avatar>
+                  <span
+                    className={cn(
+                      "absolute -bottom-0.5 -right-0.5 w-2 h-2 rounded-full border-2 border-background",
+                      player.connected ? "bg-primary" : "bg-muted-foreground/40",
+                    )}
+                  />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <span className="text-xs font-medium leading-none truncate block">
+                    {player.username}
+                  </span>
+                  <span className="text-[10px] text-muted-foreground" title={room?.room_name}>
+                    {playerStatus(room)}
+                  </span>
+                </div>
+                {joinable && (
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    className="h-6 px-2 text-[11px] shrink-0 hover:bg-primary hover:text-primary-foreground hover:shadow"
+                    disabled={joiningRoomId === room.room_id}
+                    onClick={() => requestJoin(room)}
+                    title={`Join ${room.room_name}`}
+                  >
+                    {joiningRoomId === room.room_id ? "Joining..." : "Join"}
+                  </Button>
+                )}
               </div>
-              <div className="flex-1 min-w-0">
-                <span className="text-xs font-medium leading-none truncate block">
-                  {player.username}
-                </span>
-                <span className="text-[10px] text-muted-foreground">
-                  {player.room_id ? "In room" : "In lobby"}
-                </span>
-              </div>
-            </div>
-          ))}
+            );
+          })}
 
           {!myUsername && others.length === 0 && (
             <p className="text-xs text-muted-foreground italic text-center py-6">
@@ -125,6 +181,12 @@ export function UserList({
           )}
         </div>
       </ScrollArea>
+
+      <JoinPasswordDialog
+        room={passwordRoom}
+        onClose={() => setPasswordRoom(null)}
+        onSubmit={(roomId, password) => void handleJoinRoom(roomId, password)}
+      />
     </div>
   );
 }

--- a/src/views/Lobby.tsx
+++ b/src/views/Lobby.tsx
@@ -602,9 +602,12 @@ export default function Lobby() {
         <div className="w-72 shrink-0 border-l h-full">
           <UserList
             players={players}
+            rooms={rooms}
+            currentRoom={currentRoom}
             currentPlayerId={playerId}
             currentUsername={myUsername}
             connectionState={connectionState}
+            onJoinRoom={joinRoom}
           />
         </div>
       )}
@@ -615,9 +618,12 @@ export default function Lobby() {
             <SheetTitle className="sr-only">Players</SheetTitle>
             <UserList
               players={players}
+              rooms={rooms}
+              currentRoom={currentRoom}
               currentPlayerId={playerId}
               currentUsername={myUsername}
               connectionState={connectionState}
+              onJoinRoom={joinRoom}
             />
           </SheetContent>
         </Sheet>

--- a/src/views/Lobby.tsx
+++ b/src/views/Lobby.tsx
@@ -19,6 +19,7 @@ import { getPlatform } from "@/platform";
 import { START_GAME_FAILURE_CODES } from "@/types/server";
 import type {
   DraftConfig,
+  GameFormat,
   GameStartedPayload,
   RoomMessagePayload,
   ServerErrorCode,
@@ -277,6 +278,11 @@ export default function Lobby() {
     } finally {
       setRefreshingLobby(false);
     }
+  }
+
+  async function handleJoinRoom(roomId: string, password?: string, format?: GameFormat) {
+    await joinRoom(roomId, password);
+    if (format) await setFormat(format);
   }
 
   async function handleDeckSelection(deckName: string, deck: Deck, commanderName?: string) {
@@ -580,7 +586,7 @@ export default function Lobby() {
             onRefresh={refreshLobbyData}
             refreshing={refreshingLobby}
             refreshDisabled={!connected || connecting}
-            onJoinRoom={joinRoom}
+            onJoinRoom={handleJoinRoom}
             onLeaveRoom={leaveRoom}
             onSetReady={setReady}
             onSetFormat={setFormat}


### PR DESCRIPTION
## Summary
* Fix reset for rooms so that they correctly return to base state
* Fix lobby state being incorrect
* Allow joining a player
* Clearly initialize room mode on enter


## Build artifacts
<!--
  Check the boxes below to build the corresponding installer on merge to main
  (uploaded to the Actions run, 30-day retention).
  Leave unchecked to skip — faster CI, no binaries produced.
  Tag pushes (v*) always build both and publish a GitHub Release regardless.
-->
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
