### PR TITLE
fix(web): strip x-forwarded-host on spellbook proxy to avoid django 400

### DIFF
--- a/ops/Caddyfile
+++ b/ops/Caddyfile
@@ -43,6 +43,9 @@ manabrew.app {
         rewrite * /{re.spellbook.1}
         reverse_proxy https://backend.commanderspellbook.com {
             header_up Host backend.commanderspellbook.com
+            # Django rejects the request (DisallowedHost 400) if the
+            # forwarded host leaks through.
+            header_up -X-Forwarded-Host
             header_down -Access-Control-Allow-Origin
         }
         header Cross-Origin-Resource-Policy "same-origin"

--- a/ops/staging.Caddyfile
+++ b/ops/staging.Caddyfile
@@ -43,6 +43,9 @@
         rewrite * /{re.spellbook.1}
         reverse_proxy https://backend.commanderspellbook.com {
             header_up Host backend.commanderspellbook.com
+            # Django rejects the request (DisallowedHost 400) if the
+            # forwarded host leaks through.
+            header_up -X-Forwarded-Host
             header_down -Access-Control-Allow-Origin
         }
         header Cross-Origin-Resource-Policy "same-origin"


### PR DESCRIPTION
## Summary
- Follow-up to #151: the deployed `/spellbook-api` proxy returned HTTP 400 from Commander Spellbook.
- Caddy's `reverse_proxy` forwards `X-Forwarded-Host: manabrew.app` by default; their Django backend honors it for host validation and rejects the request (`DisallowedHost` 400) even though `Host` is overridden.
- Strip `X-Forwarded-Host` in the proxy block (prod + staging Caddyfiles).

## Why
Combo lookup on manabrew.app failed with `POST /spellbook-api/find-my-combos 400 (Bad Request)` after #151 deployed.

## Test plan
- Reproduced against their backend directly: identical payload returns 400 with `X-Forwarded-Host: manabrew.app` set, 200 without — confirms the header is the cause.
- `caddy validate` on both Caddyfiles (via `caddy:2-alpine`) — valid.
- After deploy: `curl -X POST https://manabrew.app/spellbook-api/find-my-combos -H 'content-type: application/json' -d '{"commanders":[],"main":[]}'` should return 200 JSON, and the deck editor combo panel should populate.

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main