### PR TITLE
fix(ci): reload caddy when caddyfile changes during deploy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -21,7 +21,7 @@ trap on_failure ERR
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$REPO_DIR"
 
-COMPOSE_FILE="${COMPOSE_FILE:-forge-engine/crates/forge-server/compose.yml}"
+COMPOSE_FILE="${COMPOSE_FILE:-compose.production.yml}"
 RAW_LOG="/tmp/deploy-raw.log"
 : > "$RAW_LOG"   # truncate
 
@@ -104,6 +104,11 @@ CARDDATA_CHANGED=false
 # longer compiles the engine), so a change anywhere else under forge-engine/ must
 # NOT redeploy it.
 FORGE_SERVER_CHANGED=false
+# The Caddyfile is volume-mounted into the manabrew container, not baked into
+# the image, and caddy does not watch its config file. Rebuilding the image
+# can't apply it (identical image → `up -d` won't recreate the container), so
+# it needs an explicit `caddy reload`.
+CADDYFILE_CHANGED=false
 
 while IFS= read -r file; do
     case "$file" in
@@ -126,11 +131,10 @@ while IFS= read -r file; do
             WEB_CHANGED=true ;;
         forge-engine/crates/forge-wasm/*)
             WEB_CHANGED=true ;;
+    esac
+    case "$file" in
         ops/Caddyfile)
-            # Caddyfile is mounted into the manabrew container at runtime,
-            # but a `docker compose up -d` is the cheapest way to pick up
-            # config changes (caddy auto-reloads on mount change too).
-            WEB_CHANGED=true ;;
+            CADDYFILE_CHANGED=true ;;
     esac
     case "$file" in
         *Dockerfile*|*compose*|.dockerignore|deploy.sh)
@@ -184,7 +188,7 @@ elif $WEB_CHANGED || $RUST_CHANGED || $CARDDATA_CHANGED; then
     SERVICES_TO_RESTART="$SERVICES_TO_RESTART manabrew"
 fi
 
-if [ -z "$SERVICES_TO_RESTART" ]; then
+if [ -z "$SERVICES_TO_RESTART" ] && ! $CADDYFILE_CHANGED; then
     echo "🧹 No Java/Rust/infra changes — skipping build."
     exit 0
 fi
@@ -198,7 +202,15 @@ fi
 # nginx→caddy consolidation that dropped the separate `caddy` service),
 # the old container otherwise lingers and can hold the host ports the new
 # one needs — exactly what took prod down on the #19 merge deploy.
-docker compose -f "$COMPOSE_FILE" $PROFILE_FLAG up -d --remove-orphans $SERVICES_TO_RESTART >> "$RAW_LOG" 2>&1
+if [ -n "$SERVICES_TO_RESTART" ]; then
+    docker compose -f "$COMPOSE_FILE" $PROFILE_FLAG up -d --remove-orphans $SERVICES_TO_RESTART >> "$RAW_LOG" 2>&1
+fi
+
+if $CADDYFILE_CHANGED; then
+    echo "Reloading caddy config..." >> "$RAW_LOG"
+    docker compose -f "$COMPOSE_FILE" exec -T manabrew \
+        caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile >> "$RAW_LOG" 2>&1
+fi
 
 BUILD_END=$(date +%s)
 BUILD_DURATION=$(( BUILD_END - BUILD_START ))
@@ -208,10 +220,11 @@ SERVICES_FMT=$(echo "$SERVICES_TO_RESTART" | xargs -n1 | sed 's/^/  - /' | tr '\
 
 # Build change flags string (with per-stack emoji)
 CHANGES=""
-$JAVA_CHANGED  && CHANGES="${CHANGES} ☕ Java"
-$RUST_CHANGED  && CHANGES="${CHANGES} 🦀 Rust"
-$WEB_CHANGED   && CHANGES="${CHANGES} 🌐 Web"
-$INFRA_CHANGED && CHANGES="${CHANGES} 🐳 Infra"
+$JAVA_CHANGED      && CHANGES="${CHANGES} ☕ Java"
+$RUST_CHANGED      && CHANGES="${CHANGES} 🦀 Rust"
+$WEB_CHANGED       && CHANGES="${CHANGES} 🌐 Web"
+$INFRA_CHANGED     && CHANGES="${CHANGES} 🐳 Infra"
+$CADDYFILE_CHANGED && CHANGES="${CHANGES} ⚙️ Caddy"
 CHANGES=$(echo "$CHANGES" | xargs)
 
 cat <<EOF


### PR DESCRIPTION
## Summary
- The `X-Forwarded-Host` fix (#154) never reached prod: `ops/Caddyfile` is volume-mounted into the manabrew container, so the deploy's image rebuild produced a byte-identical image and `docker compose up -d` left the running container (and its loaded Caddy config) untouched. Caddy does not watch its config file — the old comment claiming it auto-reloads on mount change was wrong.
- Track `ops/Caddyfile` changes separately (`CADDYFILE_CHANGED`) instead of folding them into `WEB_CHANGED`, and run `docker compose exec manabrew caddy reload` after `up -d` whenever it changed. A Caddyfile-only push now skips the pointless image rebuild entirely and just reloads (zero-downtime, admin API).
- Update the stale `COMPOSE_FILE` default: it pointed at `forge-engine/crates/forge-server/compose.yml`, deleted in #147 (prod works only because the server env overrides it). Now defaults to `compose.production.yml`.

## Why
`POST https://manabrew.app/spellbook-api/find-my-combos` still returns the Django 400 after #154 merged and the deploy reported success — the running Caddy still forwards `X-Forwarded-Host`. #151 only appeared to deploy its Caddyfile because it also touched `src/`, which genuinely changed the image and recreated the container.

Merging this PR also heals prod: `deploy.sh` is in the diff → `INFRA_CHANGED` → full rebuild + container recreate → Caddy restarts with the #154 config already on main.

## Test plan
- `bash -n deploy.sh` passes.
- Before merge (current prod): `curl -X POST https://manabrew.app/spellbook-api/find-my-combos -H 'content-type: application/json' -d '{"commanders":[],"main":[]}'` → Django 400 page.
- After merge + deploy: same curl → 200 JSON (`{"count":...,"results":{...}}`), and the deck-editor combo panel populates without `[deck-analysis] combo lookup failed`.
- Note: `INFRA_CHANGED` does a `--no-cache` rebuild of forge-server + manabrew and restarts both — the relay bounce will interrupt any live games.

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main