### PR TITLE
fix(ci): match nested artifact paths when attaching release assets

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -504,9 +504,9 @@ jobs:
           draft: false
           prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') }}
           files: |
-            release-assets/macos/*.dmg
-            release-assets/windows/*.exe
-            release-assets/windows/*.msi
+            release-assets/macos/**/*.dmg
+            release-assets/windows/**/*.exe
+            release-assets/windows/**/*.msi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Use recursive globs (`**/*.exe`, `**/*.msi`, `**/*.dmg`) in the release job when attaching installers to the GitHub Release.

## Why
The v0.3.0 release was published with only the `.dmg` attached. The Windows upload-artifact step has two paths (`nsis/*.exe`, `msi/*.msi`), so the artifact preserves the `nsis/` and `msi/` subdirectories relative to their common ancestor. The release job downloads them to `release-assets/windows/nsis/…` and `release-assets/windows/msi/…`, but the single-level globs `release-assets/windows/*.exe` / `*.msi` matched nothing — `softprops/action-gh-release` logged `Pattern does not match any files` and skipped them without failing the job. The macOS artifact has a single upload path, so it flattened and `*.dmg` matched.

## Test plan
- Verified against run 27344102623 logs: the two `Pattern does not match any files` warnings for the Windows globs.
- Downloaded the `windows-exe-*` artifact locally and confirmed the `nsis/` + `msi/` nesting that the new `**` globs match.
- v0.3.0 itself was backfilled manually via `gh release upload`; this fix covers future tags.

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main