### PR TITLE
chore: reserve manabrew package names on npm and crates.io

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@manabrew/core",
+  "version": "0.0.1",
+  "description": "Reserved package name for ManaBrew, a Magic: The Gathering client. See https://github.com/witchesofthehill/manabrew",
+  "license": "GPL-3.0-or-later",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/install/package.json
+++ b/packages/install/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@manabrew/install",
+  "version": "0.0.1",
+  "description": "Reserved package name for ManaBrew, a Magic: The Gathering client. See https://github.com/witchesofthehill/manabrew",
+  "license": "GPL-3.0-or-later",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@manabrew/protocol",
+  "version": "0.0.1",
+  "description": "Reserved package name for ManaBrew, a Magic: The Gathering client. See https://github.com/witchesofthehill/manabrew",
+  "license": "GPL-3.0-or-later",
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
## Summary
- `packages/{core,install,protocol}`: placeholder `package.json` files for `@manabrew/core`, `@manabrew/install`, `@manabrew/protocol` on npm
- Same dirs plus `packages/manabrew`: placeholder crates for `manabrew-core`, `manabrew-install`, `manabrew-protocol`, `manabrew` on crates.io (no scopes there — flat namespace)
- `packages/*` excluded from the root cargo workspace; build artifacts gitignored

## Why
Claiming the `@manabrew` npm scope and matching crates.io names before someone else does. All names verified free. Placeholders will be published manually once the npm org `manabrew` exists.

Note: the `manabrew` crate name is already used by `src-tauri` locally — the placeholder in `packages/manabrew` only reserves the name on crates.io; they never build in the same workspace.

## Test plan
- `npx prettier --check packages/` — clean
- `cargo check` + `cargo fmt --check` in each placeholder crate — clean
- `cargo metadata` on root workspace — resolves, placeholders correctly excluded
- `yarn lint:all` — eslint/prettier/tsc pass; `cargo clippy` fails with 62 pre-existing errors on main (local rustc 1.89), unrelated to this change

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main