### PR TITLE
fix(hosted): harden Forge bridge prompt handling

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,4 +41,10 @@ export default defineConfig([
       ],
     },
   },
+  {
+    files: ["tests/**/*.ts", "vitest.*.config.ts"],
+    languageOptions: {
+      globals: globals.node,
+    },
+  },
 ]);

--- a/forge-engine/crates/forge-agent-interface/src/agent_impl/targeting.rs
+++ b/forge-engine/crates/forge-agent-interface/src/agent_impl/targeting.rs
@@ -24,6 +24,9 @@ pub(super) fn choose_target_player<T: Responder>(
             valid_player_ids,
             hostile,
             intent,
+            min_targets: 1,
+            max_targets: 1,
+            chosen_targets: 0,
         },
         source,
     );
@@ -123,6 +126,9 @@ pub(super) fn choose_target_any<T: Responder>(
             valid_card_ids,
             hostile,
             intent,
+            min_targets: 1,
+            max_targets: 1,
+            chosen_targets: 0,
         },
         source,
     );
@@ -159,6 +165,9 @@ pub(super) fn choose_target_spell<T: Responder>(
         AgentPromptInner::ChooseTargetSpell {
             valid_spell_ids,
             intent: TargetingIntent::Counter,
+            min_targets: 1,
+            max_targets: 1,
+            chosen_targets: 0,
         },
         source,
     );

--- a/forge-engine/crates/forge-agent-interface/src/bin/emit_prompt_fixtures.rs
+++ b/forge-engine/crates/forge-agent-interface/src/bin/emit_prompt_fixtures.rs
@@ -44,6 +44,9 @@ fn main() {
             valid_player_ids: vec![],
             hostile: false,
             intent: TargetingIntent::default(),
+            min_targets: 1,
+            max_targets: 1,
+            chosen_targets: 0,
         },
         ChooseTargetCard {
             valid_card_ids: vec![],
@@ -58,6 +61,9 @@ fn main() {
             valid_card_ids: vec![],
             hostile: false,
             intent: TargetingIntent::default(),
+            min_targets: 0,
+            max_targets: 3,
+            chosen_targets: 1,
         },
         ChooseTargetCardFromZone {
             valid_card_ids: vec![],
@@ -96,6 +102,9 @@ fn main() {
         ChooseTargetSpell {
             valid_spell_ids: vec![],
             intent: TargetingIntent::default(),
+            min_targets: 1,
+            max_targets: 1,
+            chosen_targets: 0,
         },
         ChooseOptionalTrigger {
             description: String::new(),

--- a/forge-engine/crates/forge-agent-interface/src/java_prompt_normalizer.rs
+++ b/forge-engine/crates/forge-agent-interface/src/java_prompt_normalizer.rs
@@ -600,6 +600,7 @@ struct NormalizedAction {
     label: String,
     card_id: Option<String>,
     kind: Option<&'static str>,
+    cost: Option<String>,
 }
 
 fn build_choose_action(
@@ -630,7 +631,7 @@ fn build_choose_action(
                     ability_index: action.index,
                     description: action.label.clone(),
                     is_mana_ability: true,
-                    cost: None,
+                    cost: action.cost.clone(),
                 });
             }
             Some("ability") => {
@@ -977,6 +978,7 @@ fn to_actions(actions: &[JavaRawAction]) -> Vec<NormalizedAction> {
                 label,
                 card_id: action.card_id.clone(),
                 kind: java_action_kind(action.kind.as_deref()),
+                cost: action.cost.clone(),
             })
         })
         .collect()

--- a/forge-engine/crates/forge-agent-interface/src/java_prompt_normalizer.rs
+++ b/forge-engine/crates/forge-agent-interface/src/java_prompt_normalizer.rs
@@ -268,6 +268,9 @@ pub fn normalize_java_prompt(prompt: JavaRawPrompt) -> AgentPrompt {
             api,
             destination,
             counter_type,
+            min_targets,
+            max_targets,
+            chosen_targets,
         } => {
             source_card_id = source;
             let intent = intent_from_api(&api, &destination, &counter_type);
@@ -275,6 +278,9 @@ pub fn normalize_java_prompt(prompt: JavaRawPrompt) -> AgentPrompt {
                 valid_player_ids: target_ids(&players),
                 hostile: intent.is_hostile(),
                 intent,
+                min_targets,
+                max_targets,
+                chosen_targets,
             }
         }
         JavaRawPromptBody::ChooseTargetCard {
@@ -317,6 +323,9 @@ pub fn normalize_java_prompt(prompt: JavaRawPrompt) -> AgentPrompt {
             api,
             destination,
             counter_type,
+            min_targets,
+            max_targets,
+            chosen_targets,
         } => {
             source_card_id = source;
             let intent = intent_from_api(&api, &destination, &counter_type);
@@ -325,6 +334,9 @@ pub fn normalize_java_prompt(prompt: JavaRawPrompt) -> AgentPrompt {
                 valid_card_ids: target_ids(&cards),
                 hostile: intent.is_hostile(),
                 intent,
+                min_targets,
+                max_targets,
+                chosen_targets,
             }
         }
         JavaRawPromptBody::ChooseTargetSpell {
@@ -333,11 +345,17 @@ pub fn normalize_java_prompt(prompt: JavaRawPrompt) -> AgentPrompt {
             api,
             destination,
             counter_type,
+            min_targets,
+            max_targets,
+            chosen_targets,
         } => {
             source_card_id = source;
             AgentPromptInner::ChooseTargetSpell {
                 valid_spell_ids: target_ids(&spells),
                 intent: intent_from_api(&api, &destination, &counter_type),
+                min_targets,
+                max_targets,
+                chosen_targets,
             }
         }
         JavaRawPromptBody::PayManaCost {

--- a/forge-engine/crates/forge-agent-interface/src/java_raw.rs
+++ b/forge-engine/crates/forge-agent-interface/src/java_raw.rs
@@ -355,6 +355,7 @@ pub struct JavaRawAction {
     #[serde(rename = "cardId")]
     pub card_id: Option<String>,
     pub kind: Option<String>,
+    pub cost: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]

--- a/forge-engine/crates/forge-agent-interface/src/java_raw.rs
+++ b/forge-engine/crates/forge-agent-interface/src/java_raw.rs
@@ -214,6 +214,12 @@ pub enum JavaRawPromptBody {
         destination: Option<String>,
         #[serde(rename = "counterType")]
         counter_type: Option<String>,
+        #[serde(rename = "minTargets", default)]
+        min_targets: i32,
+        #[serde(rename = "maxTargets", default)]
+        max_targets: i32,
+        #[serde(rename = "chosenTargets", default)]
+        chosen_targets: i32,
     },
     ChooseTargetCard {
         #[serde(default)]
@@ -243,6 +249,12 @@ pub enum JavaRawPromptBody {
         destination: Option<String>,
         #[serde(rename = "counterType")]
         counter_type: Option<String>,
+        #[serde(rename = "minTargets", default)]
+        min_targets: i32,
+        #[serde(rename = "maxTargets", default)]
+        max_targets: i32,
+        #[serde(rename = "chosenTargets", default)]
+        chosen_targets: i32,
     },
     ChooseTargetSpell {
         #[serde(default)]
@@ -253,6 +265,12 @@ pub enum JavaRawPromptBody {
         destination: Option<String>,
         #[serde(rename = "counterType")]
         counter_type: Option<String>,
+        #[serde(rename = "minTargets", default)]
+        min_targets: i32,
+        #[serde(rename = "maxTargets", default)]
+        max_targets: i32,
+        #[serde(rename = "chosenTargets", default)]
+        chosen_targets: i32,
     },
     PayManaCost {
         #[serde(rename = "cardId")]

--- a/forge-engine/crates/forge-agent-interface/src/prompt.rs
+++ b/forge-engine/crates/forge-agent-interface/src/prompt.rs
@@ -134,6 +134,12 @@ pub enum AgentPromptInner {
         /// Semantic classification used by the UI to pick a pointer icon / glow color.
         #[serde(default = "default_intent")]
         intent: TargetingIntent,
+        #[serde(rename = "minTargets", default)]
+        min_targets: i32,
+        #[serde(rename = "maxTargets", default)]
+        max_targets: i32,
+        #[serde(rename = "chosenTargets", default)]
+        chosen_targets: i32,
     },
     ChooseTargetCard {
         #[serde(rename = "validCardIds")]
@@ -158,6 +164,12 @@ pub enum AgentPromptInner {
         hostile: bool,
         #[serde(default = "default_intent")]
         intent: TargetingIntent,
+        #[serde(rename = "minTargets", default)]
+        min_targets: i32,
+        #[serde(rename = "maxTargets", default)]
+        max_targets: i32,
+        #[serde(rename = "chosenTargets", default)]
+        chosen_targets: i32,
     },
     ChooseTargetCardFromZone {
         #[serde(rename = "validCardIds")]
@@ -224,6 +236,12 @@ pub enum AgentPromptInner {
         valid_spell_ids: Vec<String>,
         #[serde(default = "default_intent")]
         intent: TargetingIntent,
+        #[serde(rename = "minTargets", default)]
+        min_targets: i32,
+        #[serde(rename = "maxTargets", default)]
+        max_targets: i32,
+        #[serde(rename = "chosenTargets", default)]
+        chosen_targets: i32,
     },
     /// Choose whether an optional triggered ability fires.
     ChooseOptionalTrigger {

--- a/forge-engine/crates/self-hosted-node/src/engine_backend/java_backend.rs
+++ b/forge-engine/crates/self-hosted-node/src/engine_backend/java_backend.rs
@@ -44,6 +44,11 @@ use tracing::{debug, info};
 
 use crate::config::workspace_root;
 
+pub struct HostedGameOver {
+    pub game_id: String,
+    pub messages: Vec<(usize, AgentMessage)>,
+}
+
 pub fn unsupported_message() -> &'static str {
     "hosted java-forge backend is unavailable; rebuild self-hosted-node with --features java-forge"
 }
@@ -704,7 +709,7 @@ pub fn run_hosted_engine_game(
     starting_life: i32,
     remote_prompt_tx: std_mpsc::Sender<(usize, AgentMessage)>,
     remote_response_rxs: Vec<(usize, std_mpsc::Receiver<PlayerAction>)>,
-    game_over_tx: std_mpsc::Sender<String>,
+    game_over_tx: std_mpsc::Sender<HostedGameOver>,
     cancel: Arc<AtomicBool>,
 ) {
     if let Err(error) = run_hosted_engine_game_inner(
@@ -735,7 +740,7 @@ pub fn run_hosted_engine_game(
     _starting_life: i32,
     _remote_prompt_tx: std_mpsc::Sender<(usize, AgentMessage)>,
     _remote_response_rxs: Vec<(usize, std_mpsc::Receiver<PlayerAction>)>,
-    _game_over_tx: std_mpsc::Sender<String>,
+    _game_over_tx: std_mpsc::Sender<HostedGameOver>,
     _cancel: Arc<AtomicBool>,
 ) {
     warn!(
@@ -755,7 +760,7 @@ fn run_hosted_engine_game_inner(
     starting_life: i32,
     remote_prompt_tx: std_mpsc::Sender<(usize, AgentMessage)>,
     remote_response_rxs: Vec<(usize, std_mpsc::Receiver<PlayerAction>)>,
-    game_over_tx: std_mpsc::Sender<String>,
+    game_over_tx: std_mpsc::Sender<HostedGameOver>,
     cancel: Arc<AtomicBool>,
 ) -> Result<(), String> {
     let engine = engine_handle()?;
@@ -903,10 +908,7 @@ fn run_hosted_engine_game_inner(
 
         if engine.is_game_over(&session_id)? {
             info!("hosted java-forge session reached game over");
-            // Best-effort final state: it needs the snapshot, but the result
-            // screen must not depend on it. A snapshot fetch/parse failure here
-            // used to drop the whole game-over emission and soft-lock the client
-            // in a dead game view (#77).
+            let mut final_messages = Vec::new();
             match engine.get_snapshot(&session_id).and_then(|json| {
                 serde_json::from_str::<JavaRawSnapshot>(&json).map_err(|e| e.to_string())
             }) {
@@ -917,20 +919,21 @@ fn run_hosted_engine_game_inner(
                         0,
                     ));
                     for &agent_index in remote_response_rxs.keys() {
-                        let _ = remote_prompt_tx.send((agent_index, state.clone()));
+                        final_messages.push((agent_index, state.clone()));
                     }
                 }
                 Err(error) => {
                     warn!(%error, "game over: final snapshot unavailable; sending game-over prompt only");
                 }
             }
-            // Always send the GameOver prompt — it carries no snapshot data, so the
-            // client shows the result screen regardless of the snapshot above.
             let game_over = AgentMessage::Prompt(make_java_game_over_prompt());
             for &agent_index in remote_response_rxs.keys() {
-                let _ = remote_prompt_tx.send((agent_index, game_over.clone()));
+                final_messages.push((agent_index, game_over.clone()));
             }
-            let _ = game_over_tx.send(game_id.clone());
+            let _ = game_over_tx.send(HostedGameOver {
+                game_id: game_id.clone(),
+                messages: final_messages,
+            });
             engine.end_game(&session_id)?;
             guard.armed.set(false);
             return Ok(());

--- a/forge-engine/crates/self-hosted-node/src/main.rs
+++ b/forge-engine/crates/self-hosted-node/src/main.rs
@@ -838,8 +838,8 @@ fn maybe_start_hosted_engine(
             drop(guard);
 
             spawn_remote_prompt_forwarder(outbound_tx.clone(), remote_prompt_rx);
-            let (game_over_tx, game_over_rx) = std_mpsc::channel::<String>();
-            spawn_game_over_forwarder(outbound_tx.clone(), game_over_rx);
+            let (game_over_tx, game_over_rx) = std_mpsc::channel::<java_backend::HostedGameOver>();
+            spawn_java_game_over_forwarder(outbound_tx.clone(), game_over_rx);
             spawn_engine_thread(move || {
                 info!(
                     game_id,
@@ -1087,6 +1087,55 @@ fn spawn_game_over_forwarder(
             }
             if outbound_tx.send(ClientMessage::EndGame).is_err() {
                 break;
+            }
+        }
+    });
+}
+
+fn spawn_java_game_over_forwarder(
+    outbound_tx: tokio_mpsc::UnboundedSender<ClientMessage>,
+    game_over_rx: std_mpsc::Receiver<java_backend::HostedGameOver>,
+) {
+    thread::spawn(move || {
+        while let Ok(game_over) = game_over_rx.recv() {
+            let mut last_state: Option<Value> = None;
+            for (player_index, message) in game_over.messages {
+                let envelope =
+                    StateEnvelope::for_agent_message(player_slot(player_index), &message);
+                let Ok(state) = serde_json::to_value(envelope) else {
+                    continue;
+                };
+                match &message {
+                    AgentMessage::State(_) if last_state.as_ref() == Some(&state) => continue,
+                    AgentMessage::State(_) => last_state = Some(state.clone()),
+                    AgentMessage::Display(_) | AgentMessage::Prompt(_) => {}
+                }
+                if outbound_tx
+                    .send(ClientMessage::BroadcastState { state })
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            let Ok(state) = serde_json::to_value(StateEnvelope::RoomRelay {
+                protocol: SELF_HOSTED_NODE_PROTOCOL.to_string(),
+                version: 1,
+                message_id: Uuid::new_v4().to_string(),
+                from_player: None,
+                target_player: None,
+                room_id: None,
+                payload: json!({ "type": "gameOver", "gameId": game_over.game_id }),
+            }) else {
+                continue;
+            };
+            if outbound_tx
+                .send(ClientMessage::BroadcastState { state })
+                .is_err()
+            {
+                return;
+            }
+            if outbound_tx.send(ClientMessage::EndGame).is_err() {
+                return;
             }
         }
     });

--- a/forge-harness/src/main/java/forge/harness/common/ActionSpace.java
+++ b/forge-harness/src/main/java/forge/harness/common/ActionSpace.java
@@ -6,6 +6,7 @@ import forge.card.mana.ManaAtom;
 import forge.card.mana.ManaCost;
 import forge.card.mana.ManaCostShard;
 import forge.game.Game;
+import forge.game.GameActionUtil;
 import forge.game.GameEntity;
 import forge.game.GameObject;
 import forge.game.card.Card;
@@ -109,27 +110,33 @@ public final class ActionSpace {
 
         final List<SpellAbility> actions = new ArrayList<>();
         for (final Card c : candidates) {
-            for (final SpellAbility sa : c.getAllPossibleAbilities(player, true)) {
-                sa.setActivatingPlayer(player);
-                final boolean hasManaCost = sa.getPayCosts() != null && sa.getPayCosts().hasManaCost();
-                final Set<Card> reservedSacrifices = getFixedReservedSacrifices(sa);
-                final boolean canPayMana = !hasManaCost
-                        || (reservedSacrifices.isEmpty()
-                        ? ComputerUtilMana.canPayManaCost(sa, player, 0, false)
-                        : canPayManaCostWithReservedSacrifices(sa, player, reservedSacrifices));
-                final boolean validTargets = hasValidTargets(sa);
-                // SpellAbility.canPlay() uses Cost.canPay(), and CostPartMana.canPay()
-                // is permissive in engine core. Add an explicit mana-feasibility check.
-                if (!canPayMana) {
-                    continue;
+            for (final SpellAbility original : c.getAllPossibleAbilities(player, true)) {
+                original.setActivatingPlayer(player);
+                final List<SpellAbility> expanded = original.isBasicSpell()
+                        ? GameActionUtil.getAdditionalCostSpell(original)
+                        : List.of(original);
+                for (final SpellAbility sa : expanded) {
+                    sa.setActivatingPlayer(player);
+                    final boolean hasManaCost = sa.getPayCosts() != null && sa.getPayCosts().hasManaCost();
+                    final Set<Card> reservedSacrifices = getFixedReservedSacrifices(sa);
+                    final boolean canPayMana = !hasManaCost
+                            || (reservedSacrifices.isEmpty()
+                            ? ComputerUtilMana.canPayManaCost(sa, player, 0, false)
+                            : canPayManaCostWithReservedSacrifices(sa, player, reservedSacrifices));
+                    final boolean validTargets = hasValidTargets(sa);
+                    // SpellAbility.canPlay() uses Cost.canPay(), and CostPartMana.canPay()
+                    // is permissive in engine core. Add an explicit mana-feasibility check.
+                    if (!canPayMana) {
+                        continue;
+                    }
+                    if (!includeManaAbilities && sa.isManaAbility()) {
+                        continue;
+                    }
+                    if (!validTargets) {
+                        continue;
+                    }
+                    actions.add(sa);
                 }
-                if (!includeManaAbilities && sa.isManaAbility()) {
-                    continue;
-                }
-                if (!validTargets) {
-                    continue;
-                }
-                actions.add(sa);
             }
         }
         return actions;

--- a/forge-harness/src/main/java/forge/harness/common/HarnessPlayPlumbing.java
+++ b/forge-harness/src/main/java/forge/harness/common/HarnessPlayPlumbing.java
@@ -135,6 +135,14 @@ public final class HarnessPlayPlumbing {
 
         sa = GameActionUtil.addExtraKeywordCost(sa);
 
+        if (!announceValuesLikeX(ai, sa)) {
+            if (sa.isSpell() && !source.isCopiedSpell() && hz != null) {
+                GameActionUtil.rollbackAbility(sa, hz, zonePosition,
+                        new CostPayment(sa.getPayCosts(), sa), host);
+            }
+            return false;
+        }
+
         if (!sa.setupTargets()) {
             if (sa.isSpell() && !source.isCopiedSpell() && hz != null) {
                 GameActionUtil.rollbackAbility(sa, hz, zonePosition,
@@ -196,6 +204,52 @@ public final class HarnessPlayPlumbing {
     private static void clearPaymentState(final SpellAbility sa) {
         sa.clearManaPaid();
         sa.getPayingManaAbilities().clear();
+    }
+
+    private static boolean announceValuesLikeX(final Player player, final SpellAbility ability) {
+        if (ability.isCopied() || ability.isWrapper()) {
+            return true;
+        }
+
+        final Cost cost = ability.getPayCosts();
+        final Card card = ability.getHostCard();
+        boolean needX = ability.getXManaCostPaid() == null;
+        final String announce = ability.getParam("Announce");
+        if (announce != null && needX) {
+            for (final String aVar : announce.split(",")) {
+                final String varName = aVar.trim();
+                final Integer value = player.getController().announceRequirements(ability, varName);
+                if (value == null) {
+                    return false;
+                }
+                if ("X".equalsIgnoreCase(varName)) {
+                    needX = false;
+                    ability.setXManaCostPaid(value);
+                } else {
+                    ability.setSVar(varName, value.toString());
+                    card.setSVar(varName, value.toString());
+                }
+            }
+        }
+
+        if (needX) {
+            if (cost != null && cost.hasXInAnyCostPart()) {
+                final String sVar = ability.getParamOrDefault("XAlternative", ability.getSVar("X"));
+                final boolean replacedXshard = ability.isSpell()
+                        && ability.getHostCard().getManaCost().countX() > 0
+                        && !cost.hasXInAnyCostPart();
+                if (("Count$xPaid".equals(sVar) && !replacedXshard) || sVar.isEmpty()) {
+                    final Integer value = player.getController().announceRequirements(ability, "X");
+                    if (value == null) {
+                        return false;
+                    }
+                    ability.setXManaCostPaid(value);
+                }
+            } else {
+                ability.setXManaCostPaid(null);
+            }
+        }
+        return true;
     }
 
     /**

--- a/forge-harness/src/main/java/forge/harness/common/SnapshotExtractor.java
+++ b/forge-harness/src/main/java/forge/harness/common/SnapshotExtractor.java
@@ -8,6 +8,7 @@ import forge.game.card.CounterEnumType;
 import forge.game.card.CounterType;
 import forge.game.phase.PhaseType;
 import forge.game.player.Player;
+import forge.game.player.RegisteredPlayer;
 import forge.game.spellability.SpellAbilityStackInstance;
 import forge.game.zone.ZoneType;
 
@@ -43,19 +44,7 @@ public final class SnapshotExtractor {
         snapshot.put("priority_player", playerIndex(game, game.getPhaseHandler().getPriorityPlayer()));
         snapshot.put("game_over", game.isGameOver());
 
-        // winner
-        if (game.getOutcome() != null && !game.getOutcome().isDraw() && game.getOutcome().getWinningLobbyPlayer() != null) {
-            String winnerName = game.getOutcome().getWinningLobbyPlayer().getName();
-            for (Player p : game.getPlayers()) {
-                if (p.getName().equals(winnerName)) {
-                    snapshot.put("winner", playerIndex(game, p));
-                    break;
-                }
-            }
-        }
-        if (!snapshot.containsKey("winner")) {
-            snapshot.put("winner", null);
-        }
+        snapshot.put("winner", winnerIndex(game));
 
         // players — use getRegisteredPlayers() to include lost players
         List<Map<String, Object>> players = new ArrayList<>();
@@ -153,6 +142,33 @@ public final class SnapshotExtractor {
         ps.put("library_top", libraryTop);
 
         return ps;
+    }
+
+    private static Integer winnerIndex(Game game) {
+        if (game.getOutcome() != null && !game.getOutcome().isDraw()) {
+            final RegisteredPlayer winner = game.getOutcome().getWinningPlayer();
+            if (winner != null) {
+                for (Player p : game.getRegisteredPlayers()) {
+                    if (p.getRegisteredPlayer().equals(winner)) {
+                        return playerIndex(game, p);
+                    }
+                }
+            }
+        }
+        if (!game.isGameOver()) {
+            return null;
+        }
+        Player winner = null;
+        for (Player p : game.getRegisteredPlayers()) {
+            if (p.hasLost()) {
+                continue;
+            }
+            if (winner != null) {
+                return null;
+            }
+            winner = p;
+        }
+        return winner == null ? null : playerIndex(game, winner);
     }
 
     private static Map<String, Object> snapshotCard(Game game, Card c) {

--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveController.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveController.java
@@ -145,6 +145,13 @@ public final class ManaBrewInteractiveController extends PlayerController implem
             }
             passUntilPhase = choice.untilPhase();
             final SpellAbility selected = choice.action();
+            if (selected != null && selected.isManaAbility() && selected.getManaPart() != null) {
+                if (choice.color() == null) {
+                    selected.getManaPart().clearExpressChoice();
+                } else {
+                    selected.getManaPart().setExpressChoice(shortColorName(choice.color()));
+                }
+            }
             return selected == null ? null : Lists.newArrayList(selected);
         }
     }
@@ -925,10 +932,11 @@ public final class ManaBrewInteractiveController extends PlayerController implem
         if (HarnessCostPlumbing.isSpellPaymentContext(sa)) {
             return true;
         }
+        final String description = sourceNamePrompt(prompt == null ? "Confirm payment?" : prompt, sa);
         return session.awaitBooleanChoice(
                 "confirm_action",
                 me(),
-                prompt == null ? "Confirm payment?" : prompt,
+                description,
                 sourceName(sa),
                 "confirm_payment",
                 costPart.getClass().getSimpleName(),
@@ -1875,6 +1883,14 @@ public final class ManaBrewInteractiveController extends PlayerController implem
         return sa == null || sa.getHostCard() == null ? null : sa.getHostCard().getName();
     }
 
+    private static String sourceNamePrompt(final String prompt, final SpellAbility sa) {
+        final String name = sourceName(sa);
+        if (name == null) {
+            return prompt;
+        }
+        return prompt.replace("CARDNAME", name).replace("NICKNAME", name);
+    }
+
     private static <T extends GameEntity> CardCollection cardOptions(final FCollectionView<T> optionList) {
         final CardCollection cards = new CardCollection();
         for (final T option : optionList) {
@@ -1922,6 +1938,25 @@ public final class ManaBrewInteractiveController extends PlayerController implem
             return Color.GREEN.getColorMask();
         }
         return Color.COLORLESS.getColorMask();
+    }
+
+    private static String shortColorName(final String color) {
+        if ("White".equals(color) || "W".equals(color)) {
+            return "W";
+        }
+        if ("Blue".equals(color) || "U".equals(color)) {
+            return "U";
+        }
+        if ("Black".equals(color) || "B".equals(color)) {
+            return "B";
+        }
+        if ("Red".equals(color) || "R".equals(color)) {
+            return "R";
+        }
+        if ("Green".equals(color) || "G".equals(color)) {
+            return "G";
+        }
+        return "C";
     }
 
     private Map<Card, Integer> fallbackCombatDamage(

--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveController.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveController.java
@@ -185,10 +185,30 @@ public final class ManaBrewInteractiveController extends PlayerController implem
     public boolean playChosenSpellAbility(final SpellAbility sa) {
         session.beginCast(sa);
         try {
-            return playPlumbing.handlePlayingSpellAbility(player, sa, getGame());
+            final SpellAbility chosen = chooseOptionalAdditionalCosts(sa);
+            if (chosen == null) {
+                return false;
+            }
+            return playPlumbing.handlePlayingSpellAbility(player, chosen, getGame());
         } finally {
             session.endCast();
         }
+    }
+
+    private SpellAbility chooseOptionalAdditionalCosts(final SpellAbility original) {
+        SpellAbility chosen = original;
+        if (original.isSpell() && original.isBasicSpell()) {
+            final List<SpellAbility> abilities = GameActionUtil.getAdditionalCostSpell(original);
+            chosen = getAbilityToPlay(original.getHostCard(), abilities);
+            if (chosen == null) {
+                return null;
+            }
+        }
+        List<OptionalCostValue> options = GameActionUtil.getOptionalCostValues(chosen);
+        if (!options.isEmpty()) {
+            options = chooseOptionalCosts(chosen, options);
+        }
+        return GameActionUtil.addOptionalCosts(chosen, options);
     }
 
     @Override

--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveSession.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveSession.java
@@ -129,6 +129,8 @@ public final class ManaBrewInteractiveSession {
             throw new IllegalStateException("session is closed");
         }
         JsonObject action = JsonParser.parseString(actionJson).getAsJsonObject();
+        // The published prompt is no longer actionable once the game thread accepts a response.
+        latestPromptJson = null;
         actions.offer(action);
         // No snapshot here — it would race the game thread this unblocks.
         return "";

--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveSession.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveSession.java
@@ -143,20 +143,23 @@ public final class ManaBrewInteractiveSession {
         private final SpellAbility action;
         private final String untilPhase;
         private final Card untapCard;
+        private final String color;
 
         private PriorityChoice(final PriorityActionKind kind, final SpellAbility action, final String untilPhase) {
-            this(kind, action, untilPhase, null);
+            this(kind, action, untilPhase, null, null);
         }
 
         private PriorityChoice(
                 final PriorityActionKind kind,
                 final SpellAbility action,
                 final String untilPhase,
-                final Card untapCard) {
+                final Card untapCard,
+                final String color) {
             this.kind = kind;
             this.action = action;
             this.untilPhase = untilPhase;
             this.untapCard = untapCard;
+            this.color = color;
         }
 
         PriorityActionKind kind() {
@@ -173,6 +176,10 @@ public final class ManaBrewInteractiveSession {
 
         Card untapCard() {
             return untapCard;
+        }
+
+        String color() {
+            return color;
         }
     }
 
@@ -200,7 +207,7 @@ public final class ManaBrewInteractiveSession {
             }
             if ("untap_land".equals(kind)) {
                 final Card untapCard = resolveUntapCard(action, untappableCards);
-                return new PriorityChoice(PriorityActionKind.UNDO, null, null, untapCard);
+                return new PriorityChoice(PriorityActionKind.UNDO, null, null, untapCard, null);
             }
             if ("choose_action".equals(kind)) {
                 final int index = action.get("index").getAsInt();
@@ -217,7 +224,10 @@ public final class ManaBrewInteractiveSession {
                 if (index < 0 || index >= actionsForPrompt.size()) {
                     throw new IllegalArgumentException("tap_land index out of range: " + index);
                 }
-                return new PriorityChoice(PriorityActionKind.ACTION, actionsForPrompt.get(index), null);
+                final String color = action.has("color") && !action.get("color").isJsonNull()
+                        ? action.get("color").getAsString()
+                        : null;
+                return new PriorityChoice(PriorityActionKind.ACTION, actionsForPrompt.get(index), null, null, color);
             }
             throw new UnsupportedOperationException("unsupported action kind: " + kind);
         }
@@ -1254,6 +1264,9 @@ public final class ManaBrewInteractiveSession {
             final Card host = sa.getHostCard();
             if (host != null) {
                 option.addProperty("cardId", SnapshotExtractor.javaCardId(host));
+            }
+            if (sa.isManaAbility() && sa.getManaPart() != null) {
+                option.addProperty("cost", sa.getManaPart().mana(sa));
             }
             options.add(option);
         }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "build:web": "yarn build:wasm && tsc -b && vite build",
     "prepare": "husky",
     "test": "vitest run",
+    "test:hosted-bridge": "yarn ensure:harness && vitest run --config vitest.hosted.config.ts",
     "test:watch": "vitest"
   },
   "lint-staged": {

--- a/src/components/game/manaUtils.test.ts
+++ b/src/components/game/manaUtils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { getExpandedManaAbilities } from "@/components/game/manaUtils";
+import type { ActivatableAbilityInfo } from "@/types/manabrew";
+
+function ability(partial: Partial<ActivatableAbilityInfo>): ActivatableAbilityInfo {
+  return {
+    cardId: "black-lotus",
+    abilityIndex: 0,
+    description: "Black Lotus",
+    isManaAbility: true,
+    ...partial,
+  };
+}
+
+describe("getExpandedManaAbilities", () => {
+  it("expands produced any-color mana into color choices", () => {
+    const expanded = getExpandedManaAbilities("black-lotus", [ability({ cost: "Any Any Any" })]);
+
+    expect(expanded.map((option) => option.description)).toEqual([
+      "Add {W}",
+      "Add {U}",
+      "Add {B}",
+      "Add {R}",
+      "Add {G}",
+    ]);
+  });
+
+  it("labels single-color produced mana when the description is just the source", () => {
+    const expanded = getExpandedManaAbilities("black-lotus", [ability({ cost: "G" })]);
+
+    expect(expanded).toHaveLength(1);
+    expect(expanded[0].description).toBe("Add {G}");
+  });
+});

--- a/src/components/game/manaUtils.ts
+++ b/src/components/game/manaUtils.ts
@@ -9,9 +9,44 @@ export function extractManaLetters(desc: string | undefined): string[] {
 
 export const ANY_COLOR_LETTERS = ["W", "U", "B", "R", "G"];
 
-/**
- * Expand mana abilities by detecting color options in descriptions.
- */
+const MANA_TOKEN_TO_LETTER: Record<string, string> = {
+  WHITE: "W",
+  W: "W",
+  BLUE: "U",
+  U: "U",
+  BLACK: "B",
+  B: "B",
+  RED: "R",
+  R: "R",
+  GREEN: "G",
+  G: "G",
+  COLORLESS: "C",
+  C: "C",
+};
+
+function extractProducedManaTokens(cost: string | undefined): string[] {
+  if (!cost) return [];
+  return cost
+    .replace(/[{}]/g, " ")
+    .split(/[\s,/]+/)
+    .map((token) => token.trim().toUpperCase())
+    .filter(Boolean);
+}
+
+function extractProducedManaLetters(cost: string | undefined): string[] {
+  return extractProducedManaTokens(cost)
+    .map((token) => MANA_TOKEN_TO_LETTER[token])
+    .filter((letter) => letter != null);
+}
+
+function hasAnyColorText(text: string): boolean {
+  return (
+    text.includes("any color") ||
+    text.includes("any one color") ||
+    text.includes("mana of any color")
+  );
+}
+
 export const getExpandedManaAbilities = (
   cardId: string,
   options: ActivatableAbilityInfo[],
@@ -24,14 +59,14 @@ export const getExpandedManaAbilities = (
   for (const ab of cardAbs) {
     const letters = extractManaLetters(ab.description);
     const desc = ab.description.toLowerCase();
+    const producedTokens = extractProducedManaTokens(ab.cost);
+    const cost = producedTokens.join(" ").toLowerCase();
+    const producedLetters = extractProducedManaLetters(ab.cost);
     const isAnyColor =
-      desc.includes("any color") ||
-      desc.includes("any one color") ||
-      desc.includes("mana of any color");
+      hasAnyColorText(desc) || hasAnyColorText(cost) || producedTokens.includes("ANY");
 
     if (letters.length > 1) {
-      // e.g. "Add {W} or {U}"
-      letters.forEach((letter) => {
+      [...new Set(letters)].forEach((letter) => {
         expanded.push({
           ...ab,
           description: `Add {${letter}}`,
@@ -46,6 +81,21 @@ export const getExpandedManaAbilities = (
           description: `Add {${letter}}`,
         });
       });
+    } else if (producedLetters.length > 0) {
+      const uniqueProducedLetters = [...new Set(producedLetters)];
+      if (uniqueProducedLetters.length === 1) {
+        expanded.push({
+          ...ab,
+          description: `Add {${uniqueProducedLetters[0]}}`,
+        });
+      } else {
+        uniqueProducedLetters.forEach((letter) => {
+          expanded.push({
+            ...ab,
+            description: `Add {${letter}}`,
+          });
+        });
+      }
     } else {
       expanded.push(ab);
     }

--- a/src/components/game/prompts/resolvers/forced.test.ts
+++ b/src/components/game/prompts/resolvers/forced.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { singleLegalAny, singleLegalCard, singleLegalPlayer } from "./forced";
+import type { ResolveCtx } from "../promptHandlers";
+import type { PromptRequest } from "@/protocol";
+import type * as ChooseTargetAny from "@/protocol/prompts/chooseTargetAny";
+import type * as ChooseTargetCard from "@/protocol/prompts/chooseTargetCard";
+import type * as ChooseTargetPlayer from "@/protocol/prompts/chooseTargetPlayer";
+import { TargetingIntent } from "@/types/promptType";
+
+const ctx: ResolveCtx = {
+  prefs: { show: {}, triggerMemory: {} },
+  targetIntents: {},
+};
+
+function targetCardPrompt(input: Partial<ChooseTargetCard.Input>) {
+  return {
+    sourceCardId: "source",
+    input: {
+      type: "chooseTargetCard",
+      validCardIds: ["card-1"],
+      hostile: true,
+      intent: TargetingIntent.Damage,
+      minTargets: 1,
+      maxTargets: 1,
+      chosenTargets: 0,
+      ...input,
+    },
+  } satisfies PromptRequest<ChooseTargetCard.Input>;
+}
+
+function targetPlayerPrompt(input: Partial<ChooseTargetPlayer.Input>) {
+  return {
+    sourceCardId: "source",
+    input: {
+      type: "chooseTargetPlayer",
+      validPlayerIds: ["player-1"],
+      hostile: true,
+      intent: TargetingIntent.Damage,
+      minTargets: 1,
+      maxTargets: 1,
+      chosenTargets: 0,
+      ...input,
+    },
+  } satisfies PromptRequest<ChooseTargetPlayer.Input>;
+}
+
+function targetAnyPrompt(input: Partial<ChooseTargetAny.Input>) {
+  return {
+    sourceCardId: "source",
+    input: {
+      type: "chooseTargetAny",
+      validPlayerIds: [],
+      validCardIds: ["card-1"],
+      hostile: true,
+      intent: TargetingIntent.Damage,
+      minTargets: 1,
+      maxTargets: 1,
+      chosenTargets: 0,
+      ...input,
+    },
+  } satisfies PromptRequest<ChooseTargetAny.Input>;
+}
+
+describe("target prompt auto-resolution", () => {
+  it("auto-selects a single required card target", () => {
+    expect(singleLegalCard(targetCardPrompt({}), ctx).kind).toBe("auto");
+  });
+
+  it("does not auto-select a single optional card target", () => {
+    expect(singleLegalCard(targetCardPrompt({ minTargets: 0 }), ctx).kind).toBe("force-show");
+  });
+
+  it("does not auto-select a single optional player target", () => {
+    expect(singleLegalPlayer(targetPlayerPrompt({ minTargets: 0 }), ctx).kind).toBe("force-show");
+  });
+
+  it("does not auto-select a single optional mixed target", () => {
+    expect(singleLegalAny(targetAnyPrompt({ minTargets: 0 }), ctx).kind).toBe("force-show");
+  });
+});

--- a/src/components/game/prompts/resolvers/forced.ts
+++ b/src/components/game/prompts/resolvers/forced.ts
@@ -40,6 +40,10 @@ function consumeIntentForSpell(
   return intent.id;
 }
 
+function needsTarget(prompt: { input: { minTargets?: number; chosenTargets?: number } }): boolean {
+  return (prompt.input.chosenTargets ?? 0) < (prompt.input.minTargets ?? 1);
+}
+
 export const singleLegalCard: PromptResolver<"chooseTargetCard" | "chooseTargetCardFromZone"> = (
   prompt,
   ctx,
@@ -52,6 +56,7 @@ export const singleLegalCard: PromptResolver<"chooseTargetCard" | "chooseTargetC
       reason: `pre-selected target ${preselected}`,
     };
   }
+  if (!needsTarget(prompt)) return { kind: "force-show" };
   const ids = prompt.input.validCardIds;
   if (ids.length !== 1) return { kind: "force-show" };
   return {
@@ -70,6 +75,7 @@ export const singleLegalPlayer: PromptResolver<"chooseTargetPlayer"> = (prompt, 
       reason: `pre-selected player ${preselected}`,
     };
   }
+  if (!needsTarget(prompt)) return { kind: "force-show" };
   const ids = prompt.input.validPlayerIds;
   if (ids.length !== 1) return { kind: "force-show" };
   return {
@@ -88,6 +94,7 @@ export const singleLegalSpell: PromptResolver<"chooseTargetSpell"> = (prompt, ct
       reason: `pre-selected spell ${preselected}`,
     };
   }
+  if (!needsTarget(prompt)) return { kind: "force-show" };
   const ids = prompt.input.validSpellIds;
   if (ids.length !== 1) return { kind: "force-show" };
   return {
@@ -220,6 +227,7 @@ export const singleLegalAny: PromptResolver<"chooseTargetAny"> = (prompt, ctx) =
       reason: `pre-selected target (player ${prePlayer})`,
     };
   }
+  if (!needsTarget(prompt)) return { kind: "force-show" };
   const cards = prompt.input.validCardIds;
   const players = prompt.input.validPlayerIds;
   const total = cards.length + players.length;

--- a/src/hooks/useGameEventListeners.ts
+++ b/src/hooks/useGameEventListeners.ts
@@ -1,7 +1,11 @@
 import { useEffect } from "react";
 import { toast } from "sonner";
 import { getPlatform } from "@/platform";
-import { getSelectedGameRuntime } from "@/game";
+import {
+  getSelectedGameRuntime,
+  isRoomRelayProtocol,
+  SELF_HOSTED_NODE_RELAY_PROTOCOL,
+} from "@/game";
 import { useGameStore } from "@/stores/useGameStore";
 import { clearActiveGameSession } from "@/lib/activeGameSession";
 import { normalizeGameLogPayload } from "@/types/gameLog";
@@ -9,7 +13,25 @@ import { normalizeSnapshotPayload } from "@/types/gameSnapshot";
 import { applyDisplay, applyPrompt, applyState } from "@/stores/gameStore.constants";
 import type { Prompt, StateUpdate } from "@/protocol";
 import type { DisplayEvent } from "@/protocol/display";
-import type { AuthResultPayload } from "@/types/server";
+import type { AuthResultPayload, RoomMessagePayload } from "@/types/server";
+
+type SelfHostedNodeRoomPayload = {
+  type?: unknown;
+};
+
+const GAME_OVER_PROMPT: Prompt = { input: { type: "gameOver" } };
+
+function isGameOverPrompt(prompt: Prompt | null): boolean {
+  return prompt?.input.type === "gameOver";
+}
+
+function isSelfHostedNodeGameOverPayload(payload: unknown): boolean {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    (payload as SelfHostedNodeRoomPayload).type === "gameOver"
+  );
+}
 
 function normalizeEnginePrompt(prompt: unknown): Prompt | null {
   return typeof prompt === "object" && prompt !== null && "input" in prompt
@@ -138,10 +160,35 @@ export function useGameEventListeners() {
       );
 
       unsubscribers.push(
+        platform.events.on<RoomMessagePayload<SelfHostedNodeRoomPayload>>(
+          "server:room_message",
+          (payload) => {
+            if (
+              !isRoomRelayProtocol<SelfHostedNodeRoomPayload>(
+                payload.state,
+                SELF_HOSTED_NODE_RELAY_PROTOCOL,
+              )
+            ) {
+              return;
+            }
+            if (!isSelfHostedNodeGameOverPayload(payload.state.payload)) return;
+            const state = getState();
+            if (!state.isMultiplayer || !state.isGameActive) return;
+            if (state.gameView?.gameOver || isGameOverPrompt(state.currentPrompt)) return;
+            setState({
+              currentPrompt: GAME_OVER_PROMPT,
+              isWaitingForResponse: false,
+              debugInfo: "Remote: gameOver",
+            });
+          },
+        ),
+      );
+
+      unsubscribers.push(
         platform.events.on("server:game_aborted", () => {
           const state = getState();
           if (!state.isMultiplayer || !state.isGameActive) return;
-          if (state.gameView?.gameOver) return;
+          if (state.gameView?.gameOver || isGameOverPrompt(state.currentPrompt)) return;
           clearActiveGameSession();
           toast.error("Game aborted — a player did not reconnect.");
           void useGameStore.getState().endGame();

--- a/src/hooks/useMultiplayerInterruption.ts
+++ b/src/hooks/useMultiplayerInterruption.ts
@@ -16,6 +16,7 @@ export function useMultiplayerInterruption(): MultiplayerInterruption {
   const isMultiplayer = useGameStore((s) => s.isMultiplayer);
   const isGameActive = useGameStore((s) => s.isGameActive);
   const gameOver = useGameStore((s) => s.gameView?.gameOver ?? false);
+  const gameOverPrompt = useGameStore((s) => s.currentPrompt?.input.type === "gameOver");
   const reconnectPhase = useServerStore((s) => s.reconnect.phase);
   const currentRoom = useServerStore((s) => s.currentRoom);
   const username = useServerStore((s) => s.username);
@@ -29,6 +30,7 @@ export function useMultiplayerInterruption(): MultiplayerInterruption {
     isMultiplayer &&
     isGameActive &&
     !gameOver &&
+    !gameOverPrompt &&
     (selfDisconnected || disconnectedNames.length > 0);
   const timeoutS = currentRoom?.reconnect_timeout_s ?? DEFAULT_RECONNECT_TIMEOUT_S;
 

--- a/src/protocol/prompts/chooseTargetAny.ts
+++ b/src/protocol/prompts/chooseTargetAny.ts
@@ -11,5 +11,8 @@ export type Input = {
   validCardIds: string[];
   hostile?: boolean;
   intent: TargetingIntent;
+  minTargets: number;
+  maxTargets: number;
+  chosenTargets: number;
 };
 export type Output = { type: "targetAny"; target: TargetChoice };

--- a/src/protocol/prompts/chooseTargetPlayer.ts
+++ b/src/protocol/prompts/chooseTargetPlayer.ts
@@ -6,5 +6,8 @@ export type Input = {
   validPlayerIds: string[];
   hostile?: boolean;
   intent: TargetingIntent;
+  minTargets: number;
+  maxTargets: number;
+  chosenTargets: number;
 };
 export type Output = { type: "targetPlayer"; playerId: string | null };

--- a/src/protocol/prompts/chooseTargetSpell.ts
+++ b/src/protocol/prompts/chooseTargetSpell.ts
@@ -5,5 +5,8 @@ export type Input = {
   type: Type;
   validSpellIds: string[];
   intent: TargetingIntent;
+  minTargets: number;
+  maxTargets: number;
+  chosenTargets: number;
 };
 export type Output = { type: "targetSpell"; spellId: string | null };

--- a/src/views/Game.tsx
+++ b/src/views/Game.tsx
@@ -6,7 +6,7 @@ import { useAutoResolvePrompt } from "@/components/game/prompts/useAutoResolvePr
 import { useShallow } from "zustand/react/shallow";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import type { GameCard, Player, StackObject, ActivatableAbilityInfo } from "@/types/manabrew";
+import type { ActivatableAbilityInfo, GameCard, Player, StackObject } from "@/types/manabrew";
 import { Card } from "@/components/game/Card";
 import { GameModals } from "@/components/game/GameModals";
 import { GameOverScreen } from "@/components/game/GameOverScreen";
@@ -21,7 +21,7 @@ import { PixiArrowsCanvas } from "@/pixi/PixiArrowsCanvas";
 import type { PixiGameScene } from "@/pixi/PixiGameScene";
 import { buildArrowSpecs } from "@/components/game/arrowSpecs";
 import { buildPointerSpecs } from "@/components/game/pointerSpecs";
-import { ANY_COLOR_LETTERS } from "@/components/game/manaUtils";
+import { getExpandedManaAbilities } from "@/components/game/manaUtils";
 import { PlayModePicker } from "@/components/game/PlayModePicker";
 import { HAND_CARD_BASES } from "@/components/game/game.styles";
 import { useHandScale } from "@/hooks/useHandScale";
@@ -279,6 +279,11 @@ export default function Game({ exitTo }: GameProps = {}) {
     cost: a.cost,
   });
 
+  const manaColorFromAction = (action: HandActionOption): string | null => {
+    const matches = action.label.match(/\{([WUBRGC])\}/);
+    return matches ? matches[1] : null;
+  };
+
   const castOptionsByCardId = useMemo(() => {
     const map = new Map<string, HandActionOption[]>();
     for (const o of chooseActionInput?.playableOptions ?? []) {
@@ -311,28 +316,7 @@ export default function Game({ exitTo }: GameProps = {}) {
       byCard.set(ab.cardId, arr);
     }
     for (const [cardId, abilities] of byCard) {
-      const expanded: ActivatableAbilityInfo[] = [];
-      for (const ab of abilities) {
-        const desc = ab.description.toLowerCase();
-        const matches = ab.description.matchAll(/\{([WUBRGC])\}/g);
-        const letters = Array.from(matches, (m) => m[1]);
-        const isAnyColor =
-          desc.includes("any color") ||
-          desc.includes("any one color") ||
-          desc.includes("mana of any color");
-        if (letters.length > 1) {
-          letters.forEach((letter) => expanded.push({ ...ab, description: `Add {${letter}}` }));
-        } else if (letters.length === 1) {
-          expanded.push(ab);
-        } else if (isAnyColor) {
-          ANY_COLOR_LETTERS.forEach((letter) =>
-            expanded.push({ ...ab, description: `Add {${letter}}` }),
-          );
-        } else {
-          expanded.push(ab);
-        }
-      }
-      map.set(cardId, expanded.map(toAbilityOption));
+      map.set(cardId, getExpandedManaAbilities(cardId, abilities).map(toAbilityOption));
     }
     return map;
   }, [chooseActionInput?.manaAbilityOptions, payManaCostInput?.manaAbilityOptions]);
@@ -415,9 +399,9 @@ export default function Game({ exitTo }: GameProps = {}) {
 
       const abilities = [...(abilitiesByCardId.get(card.id) ?? [])];
       const manaAbilities = manaAbilitiesByCardId.get(card.id) ?? [];
-      const isLandTappable = tappableLandIdSet.has(card.id) && card.types?.includes("Land");
+      const isManaSource = tappableLandIdSet.has(card.id);
 
-      if (isLandTappable && manaAbilities.length > 0) {
+      if (isManaSource && manaAbilities.length > 0) {
         // Use explicit mana abilities emitted by the engine instead of inventing a generic land tap action.
         abilities.unshift(...manaAbilities);
       }
@@ -586,23 +570,22 @@ export default function Game({ exitTo }: GameProps = {}) {
   // Land tap/untap handler — shows interactive preview for multi-ability lands
   const handleTapLand = (card: GameCard) => {
     if (payManaCostInput) {
-      const manaAbilities = payManaCostInput.manaAbilityOptions
-        .filter((a) => a.cardId === card.id)
-        .map((ability) => ({
-          kind: "ability" as const,
-          cardId: ability.cardId,
-          abilityIndex: ability.abilityIndex,
-          label: ability.description,
-          isManaAbility: true,
-          cost: ability.cost,
-        }));
+      const manaAbilities = getExpandedManaAbilities(
+        card.id,
+        payManaCostInput.manaAbilityOptions,
+      ).map(toAbilityOption);
 
       if (manaAbilities.length > 1) {
         preview.showSticky(card);
         return;
       }
       if (manaAbilities.length === 1) {
-        respond({ type: "tapLand", cardId: card.id, abilityIndex: manaAbilities[0].abilityIndex });
+        respond({
+          type: "tapLand",
+          cardId: card.id,
+          abilityIndex: manaAbilities[0].abilityIndex,
+          color: manaColorFromAction(manaAbilities[0]),
+        });
         return;
       }
       respond({ type: "tapLand", cardId: card.id });
@@ -624,11 +607,12 @@ export default function Game({ exitTo }: GameProps = {}) {
         isManaAbility: ability.isManaAbility,
         cost: ability.cost,
       }));
-    const manaAbilities = (chooseActionInput?.manaAbilityOptions ?? []).filter(
-      (a) => a.cardId === card.id,
-    );
+    const manaAbilities = getExpandedManaAbilities(
+      card.id,
+      chooseActionInput?.manaAbilityOptions ?? [],
+    ).map(toAbilityOption);
     const isManaSource = (chooseActionInput?.tappableLandIds ?? []).includes(card.id);
-    const hasManaAbility = isManaSource && card.types.includes("Land");
+    const hasManaAbility = isManaSource;
 
     // Multiple mana abilities (dual land) — show interactive preview for color choice
     if (manaAbilities.length > 1) {
@@ -637,7 +621,12 @@ export default function Game({ exitTo }: GameProps = {}) {
     }
     // Single mana ability — tap directly with that ability index
     if (manaAbilities.length === 1 && abilities.length === 0) {
-      respond({ type: "tapLand", cardId: card.id, abilityIndex: manaAbilities[0].abilityIndex });
+      respond({
+        type: "tapLand",
+        cardId: card.id,
+        abilityIndex: manaAbilities[0].abilityIndex,
+        color: manaColorFromAction(manaAbilities[0]),
+      });
       return;
     }
 
@@ -843,15 +832,11 @@ export default function Game({ exitTo }: GameProps = {}) {
       });
     } else if (action.abilityIndex != null) {
       if (action.isManaAbility) {
-        // Mana abilities use tapLand (ActivateMana) in both ChooseAction and PayManaCost.
-        // Extract color from label (e.g. "Add {G}") if present.
-        const matches = action.label.match(/\{([WUBRGC])\}/);
-        const color = matches ? matches[1] : undefined;
         respond({
           type: "tapLand",
           cardId: action.cardId,
           abilityIndex: action.abilityIndex,
-          color: color ?? null,
+          color: manaColorFromAction(action),
         });
       } else {
         respond({
@@ -1672,11 +1657,12 @@ export default function Game({ exitTo }: GameProps = {}) {
           } else if (ability.abilityIndex === -1) {
             respond({ type: "tapLand", cardId: abilityPickerState!.cardId });
           } else if (ability.abilityIndex != null) {
-            if (promptType === "payManaCost" && ability.isManaAbility) {
+            if (ability.isManaAbility) {
               respond({
                 type: "tapLand",
                 cardId: abilityPickerState!.cardId,
                 abilityIndex: ability.abilityIndex,
+                color: manaColorFromAction(ability),
               });
             } else {
               respond({

--- a/tests/hosted-bridge/castingPrompts.test.ts
+++ b/tests/hosted-bridge/castingPrompts.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, it } from "vitest";
 
-import { card, findAction, HostedHarness, type HostedPrompt, type PromptResult } from "./hostedClient";
+import {
+  card,
+  findAction,
+  HostedHarness,
+  type HostedPrompt,
+  type HostedSnapshot,
+  type PromptResult,
+} from "./hostedClient";
 
 type PriorityPrompt = HostedPrompt & {
   actions: Array<{ index: number; label?: string; kind?: string; cardId?: string; cost?: string }>;
@@ -28,6 +35,10 @@ afterEach(async () => {
 
 function simianSpiritGuides(count: number) {
   return Array.from({ length: count }, () => card("Simian Spirit Guide"));
+}
+
+function blackLotuses(count: number) {
+  return Array.from({ length: count }, () => card("Black Lotus"));
 }
 
 async function startAtOpeningPriority(deck: Array<{ name: string }>, opponent = opponentDeck) {
@@ -86,6 +97,47 @@ async function waitForGameOver(sessionId: string, timeoutMs = 10_000) {
   throw new Error("timed out waiting for game over");
 }
 
+async function waitForSnapshot(
+  sessionId: string,
+  accepts: (snapshot: HostedSnapshot) => boolean,
+  timeoutMs = 10_000,
+) {
+  if (!harness) {
+    throw new Error("harness not started");
+  }
+  const deadline = Date.now() + timeoutMs;
+  let last: HostedSnapshot | null = null;
+  while (Date.now() < deadline) {
+    last = await harness.getSnapshot(sessionId);
+    if (accepts(last)) {
+      return last;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`timed out waiting for snapshot; last=${JSON.stringify(last)}`);
+}
+
+function player(snapshot: HostedSnapshot, index: number) {
+  const candidate = snapshot.players?.[index];
+  if (!candidate) {
+    throw new Error(`missing player ${index}`);
+  }
+  return candidate;
+}
+
+function playerLife(snapshot: HostedSnapshot, index: number) {
+  const life = player(snapshot, index).life;
+  if (typeof life !== "number") {
+    throw new Error(`missing life for player ${index}`);
+  }
+  return life;
+}
+
+function zoneSize(snapshot: HostedSnapshot, index: number, zone: "hand" | "graveyard") {
+  const cards = player(snapshot, index)[zone];
+  return Array.isArray(cards) ? cards.length : 0;
+}
+
 async function passUntilAction(
   sessionId: string,
   current: PromptResult,
@@ -119,6 +171,84 @@ async function passUntilAction(
     }
   }
   throw new Error(`did not reach priority with ${cardName}`);
+}
+
+async function castSpellAndReturnPriority(
+  sessionId: string,
+  current: PromptResult,
+  cardName: string,
+) {
+  const spellPriority = await passUntilAction(sessionId, current, cardName, "spell");
+  const action = findAction(spellPriority.prompt, cardName);
+  return chooseAction(sessionId, spellPriority, action.index, "priority");
+}
+
+async function activatePriorityManaAbility(
+  sessionId: string,
+  current: PromptResult,
+  cardName: string,
+  color: string,
+) {
+  const manaPriority = await passUntilAction(sessionId, current, cardName, "mana");
+  const action = findAction(manaPriority.prompt, cardName, "mana");
+  if (cardName === "Black Lotus") {
+    expect(action.cost).toMatch(/\bAny\b/);
+  }
+  await harness!.submitAction(sessionId, {
+    kind: "tap_land",
+    manaAbilityIndex: action.index,
+    cardId: action.cardId,
+    color,
+  });
+  const cursor = await harness!.waitForPrompt(sessionId, {
+    kind: "confirm_action",
+    afterRaw: manaPriority.raw,
+  });
+  const description =
+    typeof cursor.prompt.description === "string" ? cursor.prompt.description : "";
+  expect(description).toContain(cardName);
+  expect(description).not.toContain("CARDNAME");
+  await harness!.submitAction(sessionId, { kind: "boolean_decision", accept: true });
+  return harness!.waitForPrompt<PriorityPrompt>(sessionId, {
+    kind: "priority",
+    afterRaw: cursor.raw,
+  });
+}
+
+async function addBlackLotusMana(
+  sessionId: string,
+  current: PromptResult,
+  count: number,
+  color: string,
+) {
+  let cursor = current;
+  for (let i = 0; i < count; i += 1) {
+    cursor = await castSpellAndReturnPriority(sessionId, cursor, "Black Lotus");
+    cursor = await activatePriorityManaAbility(sessionId, cursor, "Black Lotus", color);
+  }
+  return cursor;
+}
+
+async function castTormentForX(sessionId: string, current: PromptResult, xValue: number) {
+  const tormentPriority = await passUntilAction(sessionId, current, "Torment of Hailfire");
+  const action = findAction(tormentPriority.prompt, "Torment of Hailfire");
+  let cursor = await chooseAction(sessionId, tormentPriority, action.index, "choose_number");
+  await harness!.submitAction(sessionId, { kind: "number_decision", number: xValue });
+  cursor = await harness!.waitForPrompt(sessionId, {
+    kind: "pay_mana_cost",
+    afterRaw: cursor.raw,
+  });
+  await harness!.submitAction(sessionId, { kind: "pay_mana" });
+  await harness!.waitForPrompt<PriorityPrompt>(sessionId, {
+    kind: "priority",
+    afterRaw: cursor.raw,
+  });
+  await harness!.submitAction(sessionId, { kind: "pass" });
+  return harness!.waitForPrompt<PriorityPrompt>(sessionId, {
+    kind: "priority",
+    afterRaw: cursor.raw,
+    timeoutMs: 60_000,
+  });
 }
 
 describe.sequential("hosted Forge casting prompt flow", () => {
@@ -248,6 +378,89 @@ describe.sequential("hosted Forge casting prompt flow", () => {
     expect(prompt.prompt.options).toEqual(
       expect.arrayContaining([expect.stringContaining("Kicker")]),
     );
+  });
+
+  it("announces X for Sphinx's Revelation before mana", async () => {
+    const { sessionId, priority } = await startAtOpeningPriority([
+      card("Sphinx's Revelation"),
+      card("Sphinx's Revelation"),
+      ...blackLotuses(6),
+    ]);
+
+    let cursor = await castSpellAndReturnPriority(sessionId, priority, "Black Lotus");
+    cursor = await castSpellAndReturnPriority(sessionId, cursor, "Black Lotus");
+    cursor = await activatePriorityManaAbility(sessionId, cursor, "Black Lotus", "W");
+    cursor = await activatePriorityManaAbility(sessionId, cursor, "Black Lotus", "U");
+    const sphinxPriority = await passUntilAction(sessionId, cursor, "Sphinx's Revelation");
+    const action = findAction(sphinxPriority.prompt, "Sphinx's Revelation");
+    const prompt = await chooseAction(sessionId, sphinxPriority, action.index);
+
+    expect(prompt.prompt.kind).toBe("choose_number");
+    expect(prompt.prompt.sourceCardName).toBe("Sphinx's Revelation");
+    expect(prompt.prompt.description).toBe("Announce X");
+  });
+
+  it("announces X for Torment of Hailfire before mana", async () => {
+    const { sessionId, priority } = await startAtOpeningPriority([
+      card("Torment of Hailfire"),
+      card("Torment of Hailfire"),
+      ...blackLotuses(6),
+    ]);
+
+    let cursor = await castSpellAndReturnPriority(sessionId, priority, "Black Lotus");
+    cursor = await activatePriorityManaAbility(sessionId, cursor, "Black Lotus", "B");
+    const tormentPriority = await passUntilAction(sessionId, cursor, "Torment of Hailfire");
+    const action = findAction(tormentPriority.prompt, "Torment of Hailfire");
+    const prompt = await chooseAction(sessionId, tormentPriority, action.index);
+
+    expect(prompt.prompt.kind).toBe("choose_number");
+    expect(prompt.prompt.sourceCardName).toBe("Torment of Hailfire");
+    expect(prompt.prompt.description).toBe("Announce X");
+  });
+
+  it("uses selected Black Lotus priority mana color without a second color prompt", async () => {
+    const { sessionId, priority } = await startAtOpeningPriority([
+      card("Torment of Hailfire"),
+      card("Torment of Hailfire"),
+      ...blackLotuses(6),
+    ]);
+
+    let cursor = await castSpellAndReturnPriority(sessionId, priority, "Black Lotus");
+    cursor = await activatePriorityManaAbility(sessionId, cursor, "Black Lotus", "B");
+    const actions = Array.isArray(cursor.prompt.actions) ? cursor.prompt.actions : [];
+
+    expect(cursor.prompt.kind).toBe("priority");
+    expect(
+      actions.some(
+        (action) => action.kind === "spell" && action.label?.includes("Torment of Hailfire"),
+      ),
+    ).toBe(true);
+  });
+
+  it("resolves Torment of Hailfire empty-hand life loss choices", async () => {
+    const { sessionId, priority } = await startAtOpeningPriority([
+      card("Torment of Hailfire"),
+      card("Torment of Hailfire"),
+      ...blackLotuses(6),
+    ]);
+
+    let cursor = await addBlackLotusMana(sessionId, priority, 3, "B");
+    cursor = await castTormentForX(sessionId, cursor, 6);
+    const afterDiscard = await waitForSnapshot(
+      sessionId,
+      (snapshot) => zoneSize(snapshot, 1, "hand") === 0 && zoneSize(snapshot, 1, "graveyard") === 6,
+    );
+
+    expect(playerLife(afterDiscard, 1)).toBe(20);
+
+    cursor = await addBlackLotusMana(sessionId, cursor, 1, "B");
+    await castTormentForX(sessionId, cursor, 1);
+    const afterLifeLoss = await waitForSnapshot(
+      sessionId,
+      (snapshot) => playerLife(snapshot, 1) === 17 && zoneSize(snapshot, 1, "hand") === 0,
+    );
+
+    expect(zoneSize(afterLifeLoss, 1, "graveyard")).toBe(6);
   });
 
   it("preserves optional target counts for Jaya's Immolating Inferno", async () => {

--- a/tests/hosted-bridge/castingPrompts.test.ts
+++ b/tests/hosted-bridge/castingPrompts.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { card, findAction, HostedHarness, type HostedPrompt, type PromptResult } from "./hostedClient";
+
+type PriorityPrompt = HostedPrompt & {
+  actions: Array<{ index: number; label?: string; kind?: string; cardId?: string; cost?: string }>;
+};
+
+const opponentDeck = [
+  card("Mountain"),
+  card("Mountain"),
+  card("Mountain"),
+  card("Mountain"),
+  card("Mountain"),
+  card("Mountain"),
+  card("Mountain"),
+  card("Mountain"),
+];
+
+let harness: HostedHarness | null = null;
+
+afterEach(async () => {
+  if (harness) {
+    await harness.close();
+    harness = null;
+  }
+});
+
+function simianSpiritGuides(count: number) {
+  return Array.from({ length: count }, () => card("Simian Spirit Guide"));
+}
+
+async function startAtOpeningPriority(deck: Array<{ name: string }>, opponent = opponentDeck) {
+  const candidate = HostedHarness.launch();
+  const handle = await candidate.startGame({
+    gameId: `hosted-bridge-${Date.now()}`,
+    startingLife: 20,
+    seed: 1,
+    players: [
+      { name: "Tester", ai: false, deck },
+      { name: "Opponent", ai: true, deck: opponent },
+    ],
+  });
+  let cursor = await candidate.waitForPrompt(handle.sessionId);
+  if (cursor.prompt.kind === "first_player_roll") {
+    await candidate.submitAction(handle.sessionId, { kind: "first_player_roll_acknowledged" });
+    cursor = await candidate.waitForPrompt(handle.sessionId, {
+      kind: "mulligan",
+      afterRaw: cursor.raw,
+    });
+  }
+  expect(cursor.prompt.kind).toBe("mulligan");
+  await candidate.submitAction(handle.sessionId, { kind: "mulligan_decision", keep: true });
+  const priority = await candidate.waitForPrompt<PriorityPrompt>(handle.sessionId, {
+    kind: "priority",
+    afterRaw: cursor.raw,
+  });
+  harness = candidate;
+  return { sessionId: handle.sessionId, priority };
+}
+
+async function chooseAction(
+  sessionId: string,
+  current: PromptResult,
+  actionIndex: number,
+  kind?: string,
+) {
+  if (!harness) {
+    throw new Error("harness not started");
+  }
+  await harness.submitAction(sessionId, { kind: "choose_action", index: actionIndex });
+  return harness.waitForPrompt(sessionId, { kind, afterRaw: current.raw });
+}
+
+async function waitForGameOver(sessionId: string, timeoutMs = 10_000) {
+  if (!harness) {
+    throw new Error("harness not started");
+  }
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await harness.getGameOver(sessionId)) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error("timed out waiting for game over");
+}
+
+async function passUntilAction(
+  sessionId: string,
+  current: PromptResult,
+  cardName: string,
+  kind = "spell",
+  maxPasses = 40,
+) {
+  if (!harness) {
+    throw new Error("harness not started");
+  }
+  let cursor = current;
+  for (let i = 0; i < maxPasses; i += 1) {
+    if (cursor.prompt.kind === "priority") {
+      const actions = Array.isArray(cursor.prompt.actions) ? cursor.prompt.actions : [];
+      if (
+        actions.some(
+          (action) =>
+            action &&
+            typeof action === "object" &&
+            (action as { kind?: string }).kind === kind &&
+            (action as { label?: string }).label?.includes(cardName),
+        )
+      ) {
+        return cursor as PromptResult<PriorityPrompt>;
+      }
+      await harness.submitAction(sessionId, { kind: "pass" });
+      cursor = await harness.waitForPrompt(sessionId, { kind: "priority", afterRaw: cursor.raw });
+    } else {
+      await harness.submitAction(sessionId, { kind: "pass" });
+      cursor = await harness.waitForPrompt(sessionId, { afterRaw: cursor.raw });
+    }
+  }
+  throw new Error(`did not reach priority with ${cardName}`);
+}
+
+describe.sequential("hosted Forge casting prompt flow", () => {
+  it("prompts for Demand Answers' additional discard/sacrifice cost before mana", async () => {
+    const { sessionId, priority } = await startAtOpeningPriority([
+      card("Demand Answers"),
+      card("Demand Answers"),
+      ...simianSpiritGuides(6),
+    ]);
+
+    const spellPriority = await passUntilAction(sessionId, priority, "Demand Answers");
+    const action = findAction(spellPriority.prompt, "Demand Answers");
+    const prompt = await chooseAction(sessionId, spellPriority, action.index);
+
+    expect(prompt.prompt.kind).toBe("choose_cards_for_effect");
+    expect(prompt.prompt.min).toBe(1);
+    expect(prompt.prompt.max).toBe(1);
+  });
+
+  it("does not keep serving consumed priority after Demand Answers resolves to game over", async () => {
+    const { sessionId, priority } = await startAtOpeningPriority([
+      card("Demand Answers"),
+      card("Demand Answers"),
+      ...simianSpiritGuides(6),
+    ]);
+
+    const spellPriority = await passUntilAction(sessionId, priority, "Demand Answers");
+    const action = findAction(spellPriority.prompt, "Demand Answers");
+    let cursor = await chooseAction(
+      sessionId,
+      spellPriority,
+      action.index,
+      "choose_cards_for_effect",
+    );
+
+    const discard = Array.isArray(cursor.prompt.cards)
+      ? cursor.prompt.cards.find(
+          (candidate) =>
+            candidate &&
+            typeof candidate === "object" &&
+            (candidate as { label?: string }).label === "Simian Spirit Guide",
+        )
+      : null;
+    if (!discard || typeof discard !== "object" || !("id" in discard)) {
+      throw new Error("missing Simian Spirit Guide discard option");
+    }
+
+    await harness!.submitAction(sessionId, {
+      kind: "choose_cards",
+      card_ids: [(discard as { id: string }).id],
+    });
+    cursor = await harness!.waitForPrompt(sessionId, {
+      kind: "pay_mana_cost",
+      afterRaw: cursor.raw,
+    });
+
+    for (let i = 0; i < 2; i += 1) {
+      const sources = Array.isArray(cursor.prompt.manaAbilityOptions)
+        ? cursor.prompt.manaAbilityOptions
+        : [];
+      const source = sources.find(
+        (candidate) =>
+          candidate &&
+          typeof candidate === "object" &&
+          (candidate as { description?: string }).description === "Simian Spirit Guide",
+      );
+      if (!source || typeof source !== "object") {
+        throw new Error("missing Simian Spirit Guide mana source");
+      }
+      await harness!.submitAction(sessionId, {
+        kind: "tap_land",
+        cardId: (source as { cardId: string }).cardId,
+        manaAbilityIndex: (source as { abilityIndex: number }).abilityIndex,
+        color: "R",
+      });
+      cursor = await harness!.waitForPrompt(sessionId, {
+        kind: "confirm_action",
+        afterRaw: cursor.raw,
+      });
+      await harness!.submitAction(sessionId, { kind: "boolean_decision", accept: true });
+      cursor = await harness!.waitForPrompt(sessionId, {
+        kind: "pay_mana_cost",
+        afterRaw: cursor.raw,
+      });
+    }
+
+    await harness!.submitAction(sessionId, { kind: "pay_mana" });
+    cursor = await harness!.waitForPrompt(sessionId, { kind: "priority", afterRaw: cursor.raw });
+    const consumedPriority = cursor.raw;
+    await harness!.submitAction(sessionId, { kind: "pass" });
+
+    await waitForGameOver(sessionId);
+    expect(await harness!.getPromptRaw(sessionId)).not.toBe(consumedPriority);
+  });
+});

--- a/tests/hosted-bridge/castingPrompts.test.ts
+++ b/tests/hosted-bridge/castingPrompts.test.ts
@@ -213,4 +213,76 @@ describe.sequential("hosted Forge casting prompt flow", () => {
     await waitForGameOver(sessionId);
     expect(await harness!.getPromptRaw(sessionId)).not.toBe(consumedPriority);
   });
+
+  it("announces X for Banefire before targets or mana", async () => {
+    const { sessionId, priority } = await startAtOpeningPriority([
+      card("Banefire"),
+      card("Banefire"),
+      ...simianSpiritGuides(6),
+    ]);
+
+    const spellPriority = await passUntilAction(sessionId, priority, "Banefire");
+    const action = findAction(spellPriority.prompt, "Banefire");
+    const prompt = await chooseAction(sessionId, spellPriority, action.index);
+
+    expect(prompt.prompt.kind).toBe("choose_number");
+    expect(prompt.prompt.sourceCardName).toBe("Banefire");
+    expect(prompt.prompt.description).toBe("Announce X");
+  });
+
+  it("prompts for optional kicker costs before Burst Lightning targets or mana", async () => {
+    const { sessionId, priority } = await startAtOpeningPriority([
+      card("Burst Lightning"),
+      card("Burst Lightning"),
+      ...simianSpiritGuides(6),
+    ]);
+
+    const spellPriority = await passUntilAction(sessionId, priority, "Burst Lightning");
+    const action = findAction(spellPriority.prompt, "Burst Lightning");
+    const prompt = await chooseAction(sessionId, spellPriority, action.index);
+
+    expect(prompt.prompt.kind).toBe("choose_mode");
+    expect(prompt.prompt.sourceCardName).toBe("Burst Lightning");
+    expect(prompt.prompt.min).toBe(0);
+    expect(prompt.prompt.max).toBeGreaterThanOrEqual(1);
+    expect(prompt.prompt.options).toEqual(
+      expect.arrayContaining([expect.stringContaining("Kicker")]),
+    );
+  });
+
+  it("preserves optional target counts for Jaya's Immolating Inferno", async () => {
+    const { sessionId, priority } = await startAtOpeningPriority([
+      card("Rograkh, Son of Rohgahh"),
+      card("Rograkh, Son of Rohgahh"),
+      card("Jaya's Immolating Inferno"),
+      card("Jaya's Immolating Inferno"),
+      ...simianSpiritGuides(4),
+    ]);
+
+    const rograkhPriority = await passUntilAction(sessionId, priority, "Rograkh, Son of Rohgahh");
+    const rograkh = findAction(rograkhPriority.prompt, "Rograkh, Son of Rohgahh");
+    const stackPriority = await chooseAction(sessionId, rograkhPriority, rograkh.index, "priority");
+    const jayaPriority = await passUntilAction(
+      sessionId,
+      stackPriority,
+      "Jaya's Immolating Inferno",
+    );
+    const jaya = findAction(jayaPriority.prompt, "Jaya's Immolating Inferno");
+    const announce = await chooseAction(sessionId, jayaPriority, jaya.index, "choose_number");
+
+    expect(announce.prompt.description).toBe("Announce X");
+    await harness!.submitAction(sessionId, { kind: "number_decision", number: 0 });
+    const targetPrompt = await harness!.waitForPrompt(sessionId, {
+      kind: "choose_target_any",
+      afterRaw: announce.raw,
+    });
+
+    expect(targetPrompt.prompt.minTargets).toBe(0);
+    expect(targetPrompt.prompt.maxTargets).toBe(3);
+    expect(targetPrompt.prompt.chosenTargets).toBe(0);
+
+    await harness!.submitAction(sessionId, { kind: "pass" });
+    const afterPass = await harness!.waitForPrompt(sessionId, { afterRaw: targetPrompt.raw });
+    expect(afterPass.prompt.kind).not.toBe("choose_target_any");
+  });
 });

--- a/tests/hosted-bridge/castingPrompts.test.ts
+++ b/tests/hosted-bridge/castingPrompts.test.ts
@@ -251,6 +251,25 @@ async function castTormentForX(sessionId: string, current: PromptResult, xValue:
   });
 }
 
+async function castSphinxForX(sessionId: string, current: PromptResult, xValue: number) {
+  const sphinxPriority = await passUntilAction(sessionId, current, "Sphinx's Revelation");
+  const action = findAction(sphinxPriority.prompt, "Sphinx's Revelation");
+  let cursor = await chooseAction(sessionId, sphinxPriority, action.index, "choose_number");
+  await harness!.submitAction(sessionId, { kind: "number_decision", number: xValue });
+  cursor = await harness!.waitForPrompt(sessionId, {
+    kind: "pay_mana_cost",
+    afterRaw: cursor.raw,
+  });
+  await harness!.submitAction(sessionId, { kind: "pay_mana" });
+  await harness!.waitForPrompt<PriorityPrompt>(sessionId, {
+    kind: "priority",
+    afterRaw: cursor.raw,
+  });
+  await harness!.submitAction(sessionId, { kind: "pass" });
+  await waitForGameOver(sessionId);
+  return harness!.getSnapshot(sessionId);
+}
+
 describe.sequential("hosted Forge casting prompt flow", () => {
   it("prompts for Demand Answers' additional discard/sacrifice cost before mana", async () => {
     const { sessionId, priority } = await startAtOpeningPriority([
@@ -398,6 +417,24 @@ describe.sequential("hosted Forge casting prompt flow", () => {
     expect(prompt.prompt.kind).toBe("choose_number");
     expect(prompt.prompt.sourceCardName).toBe("Sphinx's Revelation");
     expect(prompt.prompt.description).toBe("Announce X");
+  });
+
+  it("marks self-decking Sphinx's Revelation as a loss", async () => {
+    const { sessionId, priority } = await startAtOpeningPriority([
+      card("Sphinx's Revelation"),
+      card("Sphinx's Revelation"),
+      ...blackLotuses(6),
+    ]);
+
+    let cursor = await castSpellAndReturnPriority(sessionId, priority, "Black Lotus");
+    cursor = await castSpellAndReturnPriority(sessionId, cursor, "Black Lotus");
+    cursor = await activatePriorityManaAbility(sessionId, cursor, "Black Lotus", "W");
+    cursor = await activatePriorityManaAbility(sessionId, cursor, "Black Lotus", "U");
+    const snapshot = await castSphinxForX(sessionId, cursor, 2);
+
+    expect(snapshot.game_over).toBe(true);
+    expect(snapshot.winner).toBe(1);
+    expect(player(snapshot, 0).has_lost).toBe(true);
   });
 
   it("announces X for Torment of Hailfire before mana", async () => {

--- a/tests/hosted-bridge/hostedClient.ts
+++ b/tests/hosted-bridge/hostedClient.ts
@@ -1,0 +1,248 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import path from "node:path";
+import { createInterface, type Interface } from "node:readline";
+import { fileURLToPath } from "node:url";
+
+type RpcResponse = { ok: true; result: string } | { ok: false; error: string };
+
+type LineWaiter = {
+  resolve: (line: string) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+export type HostedPrompt = {
+  kind: string;
+  [key: string]: unknown;
+};
+
+export type PromptResult<TPrompt extends HostedPrompt = HostedPrompt> = {
+  raw: string;
+  prompt: TPrompt;
+};
+
+export type HostedAction = {
+  index: number;
+  label?: string;
+  kind?: string;
+  cardId?: string;
+  cost?: string;
+};
+
+export type HostedStartGameRequest = {
+  gameId: string;
+  startingLife: number;
+  seed: number;
+  players: Array<{
+    name: string;
+    ai?: boolean;
+    commanderName?: string | null;
+    deck: Array<{ name: string; setCode?: string | null }>;
+  }>;
+};
+
+export type HostedSessionHandle = {
+  sessionId: string;
+  playerIndexes: number[];
+};
+
+export type HostedSnapshotPlayer = {
+  life?: number;
+  hand?: unknown[];
+  graveyard?: unknown[];
+  [key: string]: unknown;
+};
+
+export type HostedSnapshot = {
+  players?: HostedSnapshotPlayer[];
+  stack?: unknown[];
+  [key: string]: unknown;
+};
+
+const root = path.resolve(fileURLToPath(new URL("../..", import.meta.url)));
+const jarPath = path.join(
+  root,
+  "forge-harness",
+  "target",
+  "forge-harness-jar-with-dependencies.jar",
+);
+const forgeHome = path.join(root, "forge", "forge-gui");
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parsePrompt(raw: string): HostedPrompt {
+  return JSON.parse(raw) as HostedPrompt;
+}
+
+export class HostedHarness {
+  private readonly child: ChildProcessWithoutNullStreams;
+  private readonly stdout: Interface;
+  private readonly lines: string[] = [];
+  private readonly waiters: LineWaiter[] = [];
+  private stderrTail = "";
+  private exited = false;
+  private exitStatus = "";
+
+  private constructor(child: ChildProcessWithoutNullStreams) {
+    this.child = child;
+    this.stdout = createInterface({ input: child.stdout });
+    this.stdout.on("line", (line) => this.pushLine(line));
+    child.stderr.on("data", (chunk: Buffer) => {
+      this.stderrTail = `${this.stderrTail}${chunk.toString("utf8")}`.slice(-8000);
+    });
+    child.on("exit", (code, signal) => {
+      this.exited = true;
+      this.exitStatus = `java exited code=${code ?? "null"} signal=${signal ?? "null"}`;
+      const error = new Error(`${this.exitStatus}\n${this.stderrTail}`);
+      while (this.waiters.length > 0) {
+        const waiter = this.waiters.shift()!;
+        clearTimeout(waiter.timer);
+        waiter.reject(error);
+      }
+    });
+  }
+
+  static launch() {
+    const child = spawn(
+      "java",
+      ["-jar", jarPath, "--interactive-server", "--forge-home", forgeHome],
+      {
+        cwd: root,
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+    return new HostedHarness(child);
+  }
+
+  async close() {
+    if (!this.exited) {
+      try {
+        await this.request("quit", {}, 5_000);
+      } catch (_error) {
+        this.child.kill("SIGKILL");
+      }
+    }
+    this.stdout.close();
+  }
+
+  async reset() {
+    await this.request("reset");
+  }
+
+  async startGame(request: HostedStartGameRequest) {
+    const raw = await this.request("startGame", { payload: JSON.stringify(request) }, 120_000);
+    return JSON.parse(raw) as HostedSessionHandle;
+  }
+
+  async abortGame(sessionId: string) {
+    await this.request("abortGame", { sessionId }, 30_000);
+  }
+
+  async submitAction(sessionId: string, action: Record<string, unknown>) {
+    await this.request("submitAction", { sessionId, payload: JSON.stringify(action) }, 30_000);
+  }
+
+  async getPromptRaw(sessionId: string, playerIndex = 0) {
+    return this.request("getPrompt", { sessionId, playerIndex }, 30_000);
+  }
+
+  async getGameOver(sessionId: string) {
+    return (await this.request("getGameOver", { sessionId }, 30_000)) === "true";
+  }
+
+  async getSnapshot(sessionId: string) {
+    const raw = await this.request("getSnapshot", { sessionId }, 30_000);
+    return JSON.parse(raw) as HostedSnapshot;
+  }
+
+  async waitForPrompt<TPrompt extends HostedPrompt>(
+    sessionId: string,
+    options: { kind?: string; afterRaw?: string; timeoutMs?: number } = {},
+  ): Promise<PromptResult<TPrompt>> {
+    const timeoutMs = options.timeoutMs ?? 60_000;
+    const deadline = Date.now() + timeoutMs;
+    let lastKind = "<none>";
+    while (Date.now() < deadline) {
+      const raw = await this.getPromptRaw(sessionId);
+      if (raw && raw !== options.afterRaw) {
+        const prompt = parsePrompt(raw);
+        lastKind = prompt.kind;
+        if (!options.kind || prompt.kind === options.kind) {
+          return { raw, prompt: prompt as TPrompt };
+        }
+      }
+      await delay(25);
+    }
+    throw new Error(
+      `timed out waiting for prompt ${options.kind ?? "<any>"}; last kind=${lastKind}\n${this.stderrTail}`,
+    );
+  }
+
+  private async request(command: string, fields: Record<string, unknown> = {}, timeoutMs = 60_000) {
+    if (this.exited) {
+      throw new Error(`${this.exitStatus}\n${this.stderrTail}`);
+    }
+    this.child.stdin.write(`${JSON.stringify({ command, ...fields })}\n`);
+    const line = await this.readLine(timeoutMs);
+    let response: RpcResponse;
+    try {
+      response = JSON.parse(line) as RpcResponse;
+    } catch (error) {
+      throw new Error(`malformed harness response: ${line}\n${String(error)}\n${this.stderrTail}`);
+    }
+    if (!response.ok) {
+      throw new Error(`harness command ${command} failed: ${response.error}\n${this.stderrTail}`);
+    }
+    return response.result;
+  }
+
+  private readLine(timeoutMs: number) {
+    const line = this.lines.shift();
+    if (line !== undefined) {
+      return Promise.resolve(line);
+    }
+    if (this.exited) {
+      return Promise.reject(new Error(`${this.exitStatus}\n${this.stderrTail}`));
+    }
+    return new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const index = this.waiters.findIndex((waiter) => waiter.resolve === resolve);
+        if (index >= 0) {
+          this.waiters.splice(index, 1);
+        }
+        reject(new Error(`timed out waiting for harness response\n${this.stderrTail}`));
+      }, timeoutMs);
+      this.waiters.push({ resolve, reject, timer });
+    });
+  }
+
+  private pushLine(line: string) {
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      clearTimeout(waiter.timer);
+      waiter.resolve(line);
+    } else {
+      this.lines.push(line);
+    }
+  }
+}
+
+export function card(name: string) {
+  return { name };
+}
+
+export function findAction(prompt: HostedPrompt, cardName: string, kind = "spell") {
+  const actions = Array.isArray(prompt.actions) ? prompt.actions : [];
+  for (const action of actions) {
+    if (!action || typeof action !== "object") {
+      continue;
+    }
+    const candidate = action as HostedAction;
+    if (candidate.kind === kind && candidate.label?.includes(cardName)) {
+      return candidate;
+    }
+  }
+  throw new Error(`no ${kind} action found for ${cardName}: ${JSON.stringify(actions)}`);
+}

--- a/vitest.hosted.config.ts
+++ b/vitest.hosted.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/hosted-bridge/**/*.test.ts"],
+    testTimeout: 180_000,
+    hookTimeout: 60_000,
+    pool: "forks",
+    fileParallelism: false,
+  },
+});


### PR DESCRIPTION
## Summary

- add hosted Forge bridge test harness utilities and hosted prompt regressions
- route additional costs, optional costs, X announcements, optional target counts, and mana source choices through the Java bridge
- preserve hosted Java game-over winners and final state delivery

## Why

Hosted Forge separates Forge's engine from its original client, so prompts that were locally enforced by Forge's GUI can be lost or answered out of order through ManaBrew. This fixes Demand Answers additional costs, X spell prompt ordering, Black Lotus and other nonland mana source choices, optional target handling, and self-decking game-over outcomes.

## Test plan

- `yarn test src/components/game/prompts/resolvers/forced.test.ts src/components/game/manaUtils.test.ts`
- `cargo check -p self-hosted-node --features java-forge`
- `yarn test:hosted-bridge` on the integrated development branch before refreshing onto current upstream `main`

## Build artifacts

- [ ] Build macOS .dmg
- [ ] Build Windows .exe
