### PR TITLE
feat(ui): clarify engine choice in room creation

### DIFF
--- a/src/components/game/GameIcon.tsx
+++ b/src/components/game/GameIcon.tsx
@@ -23,6 +23,8 @@ export type GameIconName =
   | "book-cover"
   | "book-aura"
   | "overlord-helm"
+  | "beer-stein"
+  | "anvil"
   | "muscle-up"
   | "skull-crack"
   | "shiny-omega"

--- a/src/components/lobby/CreateRoomDialog.tsx
+++ b/src/components/lobby/CreateRoomDialog.tsx
@@ -6,25 +6,23 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SetPicker } from "@/components/limited/SetPicker";
 import { DRAFTABLE_SET_TYPES } from "@/components/limited/setFilters";
-import { isHostedEngineAvailable } from "@/config/webRuntimeConfig";
 import { fetchCubeMetadata } from "@/api/limitedEdition";
 import { useScryfallStore } from "@/stores/useScryfallStore";
 import { useServerStore } from "@/stores/useServerStore";
 import type { CubeImportResult } from "@/types/limited";
 import { DEFAULT_RECONNECT_TIMEOUT_S } from "@/types/server";
-import type { DraftConfig, EngineKind, GameFormat, SealedConfig } from "@/types/server";
+import type { DraftConfig, GameFormat, SealedConfig } from "@/types/server";
 import { cn } from "@/lib/utils";
 import {
   Boxes,
-  Cloud,
   Coins,
-  Cpu,
   Gem,
   Layers,
   Loader2,
   Shield,
   Sparkles,
   Swords,
+  TriangleAlert,
   Users,
   Wand2,
 } from "lucide-react";
@@ -139,7 +137,6 @@ export function CreateRoomDialog({ open, onOpenChange }: CreateRoomDialogProps) 
   const [matchPlayers, setMatchPlayers] = useState(4);
   const [limitedPlayers, setLimitedPlayers] = useState(8);
   const [format, setFormat] = useState<GameFormat>("Standard");
-  const [engine, setEngine] = useState<EngineKind>("Wasm");
   const [reconnectTimeoutS, setReconnectTimeoutS] = useState<number>(DEFAULT_RECONNECT_TIMEOUT_S);
 
   const [draftSet, setDraftSet] = useState<string>("");
@@ -162,7 +159,6 @@ export function CreateRoomDialog({ open, onOpenChange }: CreateRoomDialogProps) 
   const [creating, setCreating] = useState(false);
 
   const defaultName = `${username ?? "Player"}'s Room`;
-  const hostedAvailable = isHostedEngineAvailable();
   const playerOptions = kind === "limited" ? PLAYER_OPTIONS_LIMITED : PLAYER_OPTIONS_MATCH;
   const maxPlayers = kind === "limited" ? limitedPlayers : matchPlayers;
   const setMaxPlayers = kind === "limited" ? setLimitedPlayers : setMatchPlayers;
@@ -205,7 +201,6 @@ export function CreateRoomDialog({ open, onOpenChange }: CreateRoomDialogProps) 
     setLimitedKind("draft");
     setRoomName("");
     setFormat("Standard");
-    setEngine("Wasm");
     setReconnectTimeoutS(DEFAULT_RECONNECT_TIMEOUT_S);
     setDraftSet("");
     setDraftRounds(3);
@@ -273,7 +268,7 @@ export function CreateRoomDialog({ open, onOpenChange }: CreateRoomDialogProps) 
         roomName.trim() || defaultName,
         maxPlayers,
         submittedFormat,
-        engine,
+        "Wasm",
         draftConfig,
         sealedConfig,
         reconnectTimeoutS,
@@ -350,31 +345,55 @@ export function CreateRoomDialog({ open, onOpenChange }: CreateRoomDialogProps) 
             />
           </div>
 
-          {/* Engine */}
+          {/* Engine — rooms created here always run the ManaBrew engine. Forge
+              rooms come from self-hosted nodes and are joined from the list, but
+              nodes only host constructed matches, not limited (draft/sealed). */}
           <div className="space-y-1.5">
             <Label className="text-xs font-medium">Engine</Label>
-            <div className="grid grid-cols-2 gap-2">
-              <EngineCard
-                selected={engine === "Wasm"}
-                onClick={() => setEngine("Wasm")}
-                icon={Cpu}
-                label="Rust (Wasm)"
-                badge="in-browser"
-                description="ManaBrew's own engine, running locally. Instant, no network."
-              />
-              <EngineCard
-                selected={engine === "Java"}
-                onClick={() => setEngine("Java")}
-                icon={Cloud}
-                label="Forge (hosted)"
-                badge={hostedAvailable ? "hosted" : "coming soon"}
-                description={
-                  hostedAvailable
-                    ? "Java Forge on a ManaBrew-hosted node. Full card support."
-                    : "Hosted multiplayer Java match requires a node-side host that isn't wired yet."
-                }
-                disabled={!hostedAvailable}
-              />
+            <div className={cn("grid gap-2", kind === "match" ? "grid-cols-2" : "grid-cols-1")}>
+              <div className="flex flex-col items-start gap-0.5 rounded-lg border border-primary bg-primary/5 p-2 text-left">
+                <div className="flex items-center gap-1.5">
+                  <GameIcon name="beer-stein" className="h-3.5 w-3.5 text-primary" />
+                  <span className="text-xs font-medium">ManaBrew</span>
+                  <Badge variant="outline" className="text-[9px]">
+                    in-browser
+                  </Badge>
+                </div>
+                <span className="text-[10px] text-muted-foreground leading-tight">
+                  ManaBrew's own engine, running locally. Instant, no network.
+                </span>
+              </div>
+              {kind === "match" && (
+                <div className="flex flex-col items-start gap-0.5 rounded-lg border border-border p-2 text-left">
+                  <div className="flex items-center gap-1.5">
+                    <GameIcon name="anvil" className="h-3.5 w-3.5 text-muted-foreground" />
+                    <span className="text-xs font-medium">Forge</span>
+                    <Badge variant="outline" className="text-[9px]">
+                      node-hosted
+                    </Badge>
+                  </div>
+                  <span className="text-[10px] text-muted-foreground leading-tight">
+                    Full card support, on self-hosted nodes. Join a Forge room from the list, or{" "}
+                    <a
+                      href="https://docs.manabrew.app/self-hosting/"
+                      target="_blank"
+                      rel="noreferrer"
+                      className="underline underline-offset-2"
+                    >
+                      host your own
+                    </a>
+                    .
+                  </span>
+                </div>
+              )}
+            </div>
+            <div className="flex items-start gap-2 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning">
+              <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <p>
+                {kind === "match"
+                  ? "The ManaBrew engine is a work in progress and may have bugs or missing cards. For the most stable experience, play on the Forge engine."
+                  : "Limited runs on the ManaBrew engine only — a work in progress that may have bugs or missing cards. Forge nodes host constructed matches, not drafts."}
+              </p>
             </div>
           </div>
 
@@ -748,50 +767,6 @@ function LimitedKindCard({
         )}
       </div>
       <span className="text-[11px] text-muted-foreground leading-snug">{meta.description}</span>
-    </button>
-  );
-}
-
-interface EngineCardProps {
-  selected: boolean;
-  onClick: () => void;
-  icon: React.ComponentType<{ className?: string }>;
-  label: string;
-  badge: string;
-  description: string;
-  disabled?: boolean;
-}
-
-function EngineCard({
-  selected,
-  onClick,
-  icon: Icon,
-  label,
-  badge,
-  description,
-  disabled,
-}: EngineCardProps) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      className={cn(
-        "flex flex-col items-start gap-0.5 rounded-lg border p-2 text-left transition-colors",
-        selected
-          ? "border-primary bg-primary/5"
-          : "border-border enabled:hover:border-primary/30 enabled:hover:bg-muted/30",
-        disabled && "opacity-50 cursor-not-allowed",
-      )}
-    >
-      <div className="flex items-center gap-1.5">
-        <Icon className={cn("h-3.5 w-3.5", selected ? "text-primary" : "text-muted-foreground")} />
-        <span className="text-xs font-medium">{label}</span>
-        <Badge variant="outline" className="text-[9px]">
-          {badge}
-        </Badge>
-      </div>
-      <span className="text-[10px] text-muted-foreground leading-tight">{description}</span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- Rework the engine section of the create-room dialog to reflect what's actually possible: rooms created from the UI always run the ManaBrew (Wasm) engine, so the old interactive Java/Wasm picker is gone.
- Keep the two-card visual (matching the room-list badges): a **ManaBrew** card (beer icon, `in-browser`) and, for **match** rooms only, an informational **Forge** card (anvil icon, `node-hosted`) explaining that Forge games come from self-hosted nodes — join one from the list, or host your own (links to the self-hosting docs).
- A WIP warning sits below, reworded per room kind. Limited (draft/sealed/winston/cube) shows only the ManaBrew card, since self-hosted nodes create constructed-match rooms only (`self-hosted-node` always sends `draft_config: None, sealed_config: None`) — no false Forge promise there.

## Why
The engine picker implied you could spin up a Forge multiplayer room from the UI, but nothing attaches a Java engine to a UI-created room — the only way to a Forge room is a self-hosted node registering itself on the relay. The control over-promised. This makes the UI match reality while keeping the nice two-engine visualization as information.

## Test plan
- `yarn lint` — eslint, prettier, tsc pass.
- Visual: Match tab shows both cards + 'play on Forge' warning; Limited tab shows only the ManaBrew card + a warning noting Forge nodes don't host drafts. Creating a room still works and always produces a Wasm room.

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main