### PR TITLE
fix(hosted): preserve java game over outcomes

### DIFF
--- a/forge-engine/crates/self-hosted-node/src/engine_backend.rs
+++ b/forge-engine/crates/self-hosted-node/src/engine_backend.rs
@@ -1,6 +1,13 @@
 pub mod java_backend;
 pub mod rust_backend;
 
+use forge_agent_interface::prompt::AgentMessage;
+
+pub struct HostedGameOver {
+    pub game_id: String,
+    pub messages: Vec<(usize, AgentMessage)>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EngineBackendKind {
     Rust,

--- a/forge-engine/crates/self-hosted-node/src/engine_backend/java_backend.rs
+++ b/forge-engine/crates/self-hosted-node/src/engine_backend/java_backend.rs
@@ -42,12 +42,8 @@ use tracing::warn;
 #[cfg(feature = "java-forge")]
 use tracing::{debug, info};
 
+use super::HostedGameOver;
 use crate::config::workspace_root;
-
-pub struct HostedGameOver {
-    pub game_id: String,
-    pub messages: Vec<(usize, AgentMessage)>,
-}
 
 pub fn unsupported_message() -> &'static str {
     "hosted java-forge backend is unavailable; rebuild self-hosted-node with --features java-forge"

--- a/forge-engine/crates/self-hosted-node/src/engine_backend/java_backend.rs
+++ b/forge-engine/crates/self-hosted-node/src/engine_backend/java_backend.rs
@@ -44,6 +44,11 @@ use tracing::{debug, info};
 
 use crate::config::workspace_root;
 
+pub struct HostedGameOver {
+    pub game_id: String,
+    pub messages: Vec<(usize, AgentMessage)>,
+}
+
 pub fn unsupported_message() -> &'static str {
     "hosted java-forge backend is unavailable; rebuild self-hosted-node with --features java-forge"
 }
@@ -704,7 +709,7 @@ pub fn run_hosted_engine_game(
     starting_life: i32,
     remote_prompt_tx: std_mpsc::Sender<(usize, AgentMessage)>,
     remote_response_rxs: Vec<(usize, std_mpsc::Receiver<PlayerAction>)>,
-    game_over_tx: std_mpsc::Sender<String>,
+    game_over_tx: std_mpsc::Sender<HostedGameOver>,
     cancel: Arc<AtomicBool>,
 ) {
     if let Err(error) = run_hosted_engine_game_inner(
@@ -735,7 +740,7 @@ pub fn run_hosted_engine_game(
     _starting_life: i32,
     _remote_prompt_tx: std_mpsc::Sender<(usize, AgentMessage)>,
     _remote_response_rxs: Vec<(usize, std_mpsc::Receiver<PlayerAction>)>,
-    _game_over_tx: std_mpsc::Sender<String>,
+    _game_over_tx: std_mpsc::Sender<HostedGameOver>,
     _cancel: Arc<AtomicBool>,
 ) {
     warn!(
@@ -755,7 +760,7 @@ fn run_hosted_engine_game_inner(
     starting_life: i32,
     remote_prompt_tx: std_mpsc::Sender<(usize, AgentMessage)>,
     remote_response_rxs: Vec<(usize, std_mpsc::Receiver<PlayerAction>)>,
-    game_over_tx: std_mpsc::Sender<String>,
+    game_over_tx: std_mpsc::Sender<HostedGameOver>,
     cancel: Arc<AtomicBool>,
 ) -> Result<(), String> {
     let engine = engine_handle()?;
@@ -903,10 +908,7 @@ fn run_hosted_engine_game_inner(
 
         if engine.is_game_over(&session_id)? {
             info!("hosted java-forge session reached game over");
-            // Best-effort final state: it needs the snapshot, but the result
-            // screen must not depend on it. A snapshot fetch/parse failure here
-            // used to drop the whole game-over emission and soft-lock the client
-            // in a dead game view (#77).
+            let mut final_messages = Vec::new();
             match engine.get_snapshot(&session_id).and_then(|json| {
                 serde_json::from_str::<JavaRawSnapshot>(&json).map_err(|e| e.to_string())
             }) {
@@ -917,20 +919,21 @@ fn run_hosted_engine_game_inner(
                         0,
                     ));
                     for &agent_index in remote_response_rxs.keys() {
-                        let _ = remote_prompt_tx.send((agent_index, state.clone()));
+                        final_messages.push((agent_index, state.clone()));
                     }
                 }
                 Err(error) => {
                     warn!(%error, "game over: final snapshot unavailable; sending game-over prompt only");
                 }
             }
-            // Always send the GameOver prompt — it carries no snapshot data, so the
-            // client shows the result screen regardless of the snapshot above.
             let game_over = AgentMessage::Prompt(make_java_game_over_prompt());
             for &agent_index in remote_response_rxs.keys() {
-                let _ = remote_prompt_tx.send((agent_index, game_over.clone()));
+                final_messages.push((agent_index, game_over.clone()));
             }
-            let _ = game_over_tx.send(game_id.clone());
+            let _ = game_over_tx.send(HostedGameOver {
+                game_id: game_id.clone(),
+                messages: final_messages,
+            });
             engine.end_game(&session_id)?;
             guard.armed.set(false);
             return Ok(());

--- a/forge-engine/crates/self-hosted-node/src/engine_backend/rust_backend.rs
+++ b/forge-engine/crates/self-hosted-node/src/engine_backend/rust_backend.rs
@@ -22,6 +22,7 @@ use memmap2::Mmap;
 use rand::SeedableRng;
 use tracing::{info, warn};
 
+use super::HostedGameOver;
 use crate::config::workspace_root;
 
 pub fn run_hosted_engine_game(
@@ -33,7 +34,7 @@ pub fn run_hosted_engine_game(
     starting_life: i32,
     remote_prompt_tx: std_mpsc::Sender<(usize, AgentMessage)>,
     remote_response_rxs: Vec<(usize, std_mpsc::Receiver<PlayerAction>)>,
-    game_over_tx: std_mpsc::Sender<String>,
+    game_over_tx: std_mpsc::Sender<HostedGameOver>,
 ) {
     let prepared_players = prepare_players(
         &player_names,
@@ -84,7 +85,12 @@ pub fn run_hosted_engine_game(
             }
         },
     );
-    let _ = game_over_tx.send(game_id);
+    let _ = game_over_tx.send(HostedGameOver {
+        game_id,
+        // Assuming that Rust currently has no final messages that must precede EndGame.
+        // If that changes, bundle them here so the game-over forwarder preserves ordering.
+        messages: Vec::new(),
+    });
 }
 
 pub fn run_self_play(

--- a/forge-engine/crates/self-hosted-node/src/main.rs
+++ b/forge-engine/crates/self-hosted-node/src/main.rs
@@ -1092,6 +1092,10 @@ fn spawn_game_over_forwarder(
     });
 }
 
+// Java game over is an ordered sequence: final state updates and the
+// gameOver prompt must reach clients before EndGame resets the room.
+// This forwarder receives the sequence as one bundle so EndGame cannot
+// overtake the final engine messages on outbound_tx.
 fn spawn_java_game_over_forwarder(
     outbound_tx: tokio_mpsc::UnboundedSender<ClientMessage>,
     game_over_rx: std_mpsc::Receiver<java_backend::HostedGameOver>,

--- a/forge-engine/crates/self-hosted-node/src/main.rs
+++ b/forge-engine/crates/self-hosted-node/src/main.rs
@@ -838,8 +838,8 @@ fn maybe_start_hosted_engine(
             drop(guard);
 
             spawn_remote_prompt_forwarder(outbound_tx.clone(), remote_prompt_rx);
-            let (game_over_tx, game_over_rx) = std_mpsc::channel::<String>();
-            spawn_game_over_forwarder(outbound_tx.clone(), game_over_rx);
+            let (game_over_tx, game_over_rx) = std_mpsc::channel::<java_backend::HostedGameOver>();
+            spawn_java_game_over_forwarder(outbound_tx.clone(), game_over_rx);
             spawn_engine_thread(move || {
                 info!(
                     game_id,
@@ -1087,6 +1087,55 @@ fn spawn_game_over_forwarder(
             }
             if outbound_tx.send(ClientMessage::EndGame).is_err() {
                 break;
+            }
+        }
+    });
+}
+
+fn spawn_java_game_over_forwarder(
+    outbound_tx: tokio_mpsc::UnboundedSender<ClientMessage>,
+    game_over_rx: std_mpsc::Receiver<java_backend::HostedGameOver>,
+) {
+    thread::spawn(move || {
+        while let Ok(game_over) = game_over_rx.recv() {
+            let mut last_state: Option<Value> = None;
+            for (player_index, message) in game_over.messages {
+                let envelope =
+                    StateEnvelope::for_agent_message(player_slot(player_index), &message);
+                let Ok(state) = serde_json::to_value(envelope) else {
+                    continue;
+                };
+                match &message {
+                    AgentMessage::State(_) if last_state.as_ref() == Some(&state) => continue,
+                    AgentMessage::State(_) => last_state = Some(state.clone()),
+                    AgentMessage::Display(_) | AgentMessage::Prompt(_) => {}
+                }
+                if outbound_tx
+                    .send(ClientMessage::BroadcastState { state })
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            let Ok(state) = serde_json::to_value(StateEnvelope::RoomRelay {
+                protocol: SELF_HOSTED_NODE_PROTOCOL.to_string(),
+                version: 1,
+                message_id: Uuid::new_v4().to_string(),
+                from_player: None,
+                target_player: None,
+                room_id: None,
+                payload: json!({ "type": "gameOver", "gameId": game_over.game_id }),
+            }) else {
+                continue;
+            };
+            if outbound_tx
+                .send(ClientMessage::BroadcastState { state })
+                .is_err()
+            {
+                return;
+            }
+            if outbound_tx.send(ClientMessage::EndGame).is_err() {
+                return;
             }
         }
     });

--- a/forge-engine/crates/self-hosted-node/src/main.rs
+++ b/forge-engine/crates/self-hosted-node/src/main.rs
@@ -9,7 +9,7 @@ mod config;
 mod engine_backend;
 
 use config::{workspace_root, Config, DeckSelection, SelfPlayConfig};
-use engine_backend::{java_backend, rust_backend, EngineBackendKind};
+use engine_backend::{java_backend, rust_backend, EngineBackendKind, HostedGameOver};
 use forge_agent_interface::deck_dto::Deck;
 use forge_agent_interface::ids_codec::{parse_player_slot, player_slot};
 use forge_agent_interface::prompt::{AgentMessage, PlayerAction};
@@ -791,7 +791,7 @@ fn maybe_start_hosted_engine(
             drop(guard);
 
             spawn_remote_prompt_forwarder(outbound_tx.clone(), remote_prompt_rx);
-            let (game_over_tx, game_over_rx) = std_mpsc::channel::<String>();
+            let (game_over_tx, game_over_rx) = std_mpsc::channel::<HostedGameOver>();
             spawn_game_over_forwarder(outbound_tx.clone(), game_over_rx);
             spawn_engine_thread(move || {
                 info!(
@@ -838,8 +838,8 @@ fn maybe_start_hosted_engine(
             drop(guard);
 
             spawn_remote_prompt_forwarder(outbound_tx.clone(), remote_prompt_rx);
-            let (game_over_tx, game_over_rx) = std_mpsc::channel::<java_backend::HostedGameOver>();
-            spawn_java_game_over_forwarder(outbound_tx.clone(), game_over_rx);
+            let (game_over_tx, game_over_rx) = std_mpsc::channel::<HostedGameOver>();
+            spawn_game_over_forwarder(outbound_tx.clone(), game_over_rx);
             spawn_engine_thread(move || {
                 info!(
                     game_id,
@@ -1064,44 +1064,13 @@ fn spawn_remote_prompt_forwarder(
 
 fn spawn_game_over_forwarder(
     outbound_tx: tokio_mpsc::UnboundedSender<ClientMessage>,
-    game_over_rx: std_mpsc::Receiver<String>,
-) {
-    thread::spawn(move || {
-        while let Ok(game_id) = game_over_rx.recv() {
-            let Ok(state) = serde_json::to_value(StateEnvelope::RoomRelay {
-                protocol: SELF_HOSTED_NODE_PROTOCOL.to_string(),
-                version: 1,
-                message_id: Uuid::new_v4().to_string(),
-                from_player: None,
-                target_player: None,
-                room_id: None,
-                payload: json!({ "type": "gameOver", "gameId": game_id }),
-            }) else {
-                continue;
-            };
-            if outbound_tx
-                .send(ClientMessage::BroadcastState { state })
-                .is_err()
-            {
-                break;
-            }
-            if outbound_tx.send(ClientMessage::EndGame).is_err() {
-                break;
-            }
-        }
-    });
-}
-
-// Java game over is an ordered sequence: final state updates and the
-// gameOver prompt must reach clients before EndGame resets the room.
-// This forwarder receives the sequence as one bundle so EndGame cannot
-// overtake the final engine messages on outbound_tx.
-fn spawn_java_game_over_forwarder(
-    outbound_tx: tokio_mpsc::UnboundedSender<ClientMessage>,
-    game_over_rx: std_mpsc::Receiver<java_backend::HostedGameOver>,
+    game_over_rx: std_mpsc::Receiver<HostedGameOver>,
 ) {
     thread::spawn(move || {
         while let Ok(game_over) = game_over_rx.recv() {
+            // Final engine messages must reach clients before EndGame resets the room.
+            // Java uses this bundle for final state and the gameOver prompt; Rust
+            // currently sends an empty bundle.
             let mut last_state: Option<Value> = None;
             for (player_index, message) in game_over.messages {
                 let envelope =

--- a/forge-harness/src/main/java/forge/harness/common/SnapshotExtractor.java
+++ b/forge-harness/src/main/java/forge/harness/common/SnapshotExtractor.java
@@ -8,6 +8,7 @@ import forge.game.card.CounterEnumType;
 import forge.game.card.CounterType;
 import forge.game.phase.PhaseType;
 import forge.game.player.Player;
+import forge.game.player.RegisteredPlayer;
 import forge.game.spellability.SpellAbilityStackInstance;
 import forge.game.zone.ZoneType;
 
@@ -43,19 +44,7 @@ public final class SnapshotExtractor {
         snapshot.put("priority_player", playerIndex(game, game.getPhaseHandler().getPriorityPlayer()));
         snapshot.put("game_over", game.isGameOver());
 
-        // winner
-        if (game.getOutcome() != null && !game.getOutcome().isDraw() && game.getOutcome().getWinningLobbyPlayer() != null) {
-            String winnerName = game.getOutcome().getWinningLobbyPlayer().getName();
-            for (Player p : game.getPlayers()) {
-                if (p.getName().equals(winnerName)) {
-                    snapshot.put("winner", playerIndex(game, p));
-                    break;
-                }
-            }
-        }
-        if (!snapshot.containsKey("winner")) {
-            snapshot.put("winner", null);
-        }
+        snapshot.put("winner", winnerIndex(game));
 
         // players — use getRegisteredPlayers() to include lost players
         List<Map<String, Object>> players = new ArrayList<>();
@@ -153,6 +142,33 @@ public final class SnapshotExtractor {
         ps.put("library_top", libraryTop);
 
         return ps;
+    }
+
+    private static Integer winnerIndex(Game game) {
+        if (game.getOutcome() != null && !game.getOutcome().isDraw()) {
+            final RegisteredPlayer winner = game.getOutcome().getWinningPlayer();
+            if (winner != null) {
+                for (Player p : game.getRegisteredPlayers()) {
+                    if (p.getRegisteredPlayer().equals(winner)) {
+                        return playerIndex(game, p);
+                    }
+                }
+            }
+        }
+        if (!game.isGameOver()) {
+            return null;
+        }
+        Player winner = null;
+        for (Player p : game.getRegisteredPlayers()) {
+            if (p.hasLost()) {
+                continue;
+            }
+            if (winner != null) {
+                return null;
+            }
+            winner = p;
+        }
+        return winner == null ? null : playerIndex(game, winner);
     }
 
     private static Map<String, Object> snapshotCard(Game game, Card c) {

--- a/src/hooks/useGameEventListeners.ts
+++ b/src/hooks/useGameEventListeners.ts
@@ -1,7 +1,11 @@
 import { useEffect } from "react";
 import { toast } from "sonner";
 import { getPlatform } from "@/platform";
-import { getSelectedGameRuntime } from "@/game";
+import {
+  getSelectedGameRuntime,
+  isRoomRelayProtocol,
+  SELF_HOSTED_NODE_RELAY_PROTOCOL,
+} from "@/game";
 import { useGameStore } from "@/stores/useGameStore";
 import { clearActiveGameSession } from "@/lib/activeGameSession";
 import { normalizeGameLogPayload } from "@/types/gameLog";
@@ -9,7 +13,25 @@ import { normalizeSnapshotPayload } from "@/types/gameSnapshot";
 import { applyDisplay, applyPrompt, applyState } from "@/stores/gameStore.constants";
 import type { Prompt, StateUpdate } from "@/protocol";
 import type { DisplayEvent } from "@/protocol/display";
-import type { AuthResultPayload } from "@/types/server";
+import type { AuthResultPayload, RoomMessagePayload } from "@/types/server";
+
+type SelfHostedNodeRoomPayload = {
+  type?: unknown;
+};
+
+const GAME_OVER_PROMPT: Prompt = { input: { type: "gameOver" } };
+
+function isGameOverPrompt(prompt: Prompt | null): boolean {
+  return prompt?.input.type === "gameOver";
+}
+
+function isSelfHostedNodeGameOverPayload(payload: unknown): boolean {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    (payload as SelfHostedNodeRoomPayload).type === "gameOver"
+  );
+}
 
 function normalizeEnginePrompt(prompt: unknown): Prompt | null {
   return typeof prompt === "object" && prompt !== null && "input" in prompt
@@ -138,10 +160,35 @@ export function useGameEventListeners() {
       );
 
       unsubscribers.push(
+        platform.events.on<RoomMessagePayload<SelfHostedNodeRoomPayload>>(
+          "server:room_message",
+          (payload) => {
+            if (
+              !isRoomRelayProtocol<SelfHostedNodeRoomPayload>(
+                payload.state,
+                SELF_HOSTED_NODE_RELAY_PROTOCOL,
+              )
+            ) {
+              return;
+            }
+            if (!isSelfHostedNodeGameOverPayload(payload.state.payload)) return;
+            const state = getState();
+            if (!state.isMultiplayer || !state.isGameActive) return;
+            if (state.gameView?.gameOver || isGameOverPrompt(state.currentPrompt)) return;
+            setState({
+              currentPrompt: GAME_OVER_PROMPT,
+              isWaitingForResponse: false,
+              debugInfo: "Remote: gameOver",
+            });
+          },
+        ),
+      );
+
+      unsubscribers.push(
         platform.events.on("server:game_aborted", () => {
           const state = getState();
           if (!state.isMultiplayer || !state.isGameActive) return;
-          if (state.gameView?.gameOver) return;
+          if (state.gameView?.gameOver || isGameOverPrompt(state.currentPrompt)) return;
           clearActiveGameSession();
           toast.error("Game aborted — a player did not reconnect.");
           void useGameStore.getState().endGame();

--- a/src/hooks/useMultiplayerInterruption.ts
+++ b/src/hooks/useMultiplayerInterruption.ts
@@ -16,6 +16,7 @@ export function useMultiplayerInterruption(): MultiplayerInterruption {
   const isMultiplayer = useGameStore((s) => s.isMultiplayer);
   const isGameActive = useGameStore((s) => s.isGameActive);
   const gameOver = useGameStore((s) => s.gameView?.gameOver ?? false);
+  const gameOverPrompt = useGameStore((s) => s.currentPrompt?.input.type === "gameOver");
   const reconnectPhase = useServerStore((s) => s.reconnect.phase);
   const currentRoom = useServerStore((s) => s.currentRoom);
   const username = useServerStore((s) => s.username);
@@ -29,6 +30,7 @@ export function useMultiplayerInterruption(): MultiplayerInterruption {
     isMultiplayer &&
     isGameActive &&
     !gameOver &&
+    !gameOverPrompt &&
     (selfDisconnected || disconnectedNames.length > 0);
   const timeoutS = currentRoom?.reconnect_timeout_s ?? DEFAULT_RECONNECT_TIMEOUT_S;
 


### PR DESCRIPTION
## Summary

- forward hosted Java final state and game-over prompt together before ending the room
- preserve the Java snapshot winner by reading the Forge game outcome and registered players
- suppress disconnect/abort overlays once a game-over prompt is already pending

## Why

Hosted Java games could end by broadcasting `EndGame` before the client had received the final Java state and game-over prompt. That made wins and losses look like disconnects or draws, especially when the final snapshot carried the decisive winner state.

### Game-over ordering race

The hosted Java game-over path had two independent outbound streams:

Before:
- Final Java state and the marker-only `gameOver` prompt were sent through `remote_prompt_tx`, then forwarded by `spawn_remote_prompt_forwarder`.
- The room end signal was sent through `game_over_tx`, then forwarded by `spawn_game_over_forwarder`.
- Both forwarders wrote to the same `outbound_tx`, but because they ran on separate threads there was no FIFO guarantee between the final prompt/state and `EndGame`.

That meant `EndGame` could overtake the final state or `gameOver` prompt. When that happened, the relay reset the room first and clients saw the normal game finish as an abort/disconnect instead of a result screen.

After:
- The Java game-over path bundles the final state, marker prompt, room `gameOver` relay message, and `EndGame` into one `HostedGameOver` delivery path.
- One forwarder sends those messages in the required order.
- The client-side guards suppress abort/disconnect UI once a game-over state or prompt is already pending.

This preserves the Java winner snapshot while keeping `EndGame` as the room lifecycle teardown. The native Rust hosted path still uses the older two-channel pattern; hosted AI currently runs through Java-Forge, but we should either unify both paths into one ordered hosted-engine event stream or track that as a follow-up.

## Test plan

- `node scripts/harness.mjs build`
- `cargo check -p self-hosted-node --features java-forge`
- `./node_modules/.bin/eslint src/hooks/useGameEventListeners.ts src/hooks/useMultiplayerInterruption.ts && ./node_modules/.bin/tsc -p tsconfig.app.json --noEmit`
- `yarn lint:all` fails on existing Rust clippy issues unrelated to this change (`forge-card-script`, `forge-protocol`, `forge-foundation`)

## Build artifacts

- [ ] Build macOS .dmg
- [ ] Build Windows .exe
