### PR TITLE
fix(hosted): preserve nonland mana source choices

### DIFF
--- a/forge-engine/crates/forge-agent-interface/src/java_prompt_normalizer.rs
+++ b/forge-engine/crates/forge-agent-interface/src/java_prompt_normalizer.rs
@@ -590,6 +590,7 @@ struct NormalizedAction {
     label: String,
     card_id: Option<String>,
     kind: Option<&'static str>,
+    cost: Option<String>,
 }
 
 fn build_choose_action(
@@ -620,7 +621,7 @@ fn build_choose_action(
                     ability_index: action.index,
                     description: action.label.clone(),
                     is_mana_ability: true,
-                    cost: None,
+                    cost: action.cost.clone(),
                 });
             }
             Some("ability") => {
@@ -967,6 +968,7 @@ fn to_actions(actions: &[JavaRawAction]) -> Vec<NormalizedAction> {
                 label,
                 card_id: action.card_id.clone(),
                 kind: java_action_kind(action.kind.as_deref()),
+                cost: action.cost.clone(),
             })
         })
         .collect()

--- a/forge-engine/crates/forge-agent-interface/src/java_raw.rs
+++ b/forge-engine/crates/forge-agent-interface/src/java_raw.rs
@@ -347,6 +347,7 @@ pub struct JavaRawAction {
     #[serde(rename = "cardId")]
     pub card_id: Option<String>,
     pub kind: Option<String>,
+    pub cost: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]

--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveController.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveController.java
@@ -148,6 +148,13 @@ public final class ManaBrewInteractiveController extends PlayerController implem
             }
             passUntilPhase = choice.untilPhase();
             final SpellAbility selected = choice.action();
+            if (selected != null && selected.isManaAbility() && selected.getManaPart() != null) {
+                if (choice.color() == null) {
+                    selected.getManaPart().clearExpressChoice();
+                } else {
+                    selected.getManaPart().setExpressChoice(shortColorName(choice.color()));
+                }
+            }
             return selected == null ? null : Lists.newArrayList(selected);
         }
     }
@@ -2303,6 +2310,25 @@ public final class ManaBrewInteractiveController extends PlayerController implem
             return Color.GREEN.getColorMask();
         }
         return Color.COLORLESS.getColorMask();
+    }
+
+    private static String shortColorName(final String color) {
+        if ("White".equals(color) || "W".equals(color)) {
+            return "W";
+        }
+        if ("Blue".equals(color) || "U".equals(color)) {
+            return "U";
+        }
+        if ("Black".equals(color) || "B".equals(color)) {
+            return "B";
+        }
+        if ("Red".equals(color) || "R".equals(color)) {
+            return "R";
+        }
+        if ("Green".equals(color) || "G".equals(color)) {
+            return "G";
+        }
+        return "C";
     }
 
     private Map<Card, Integer> fallbackCombatDamage(

--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveSession.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveSession.java
@@ -143,20 +143,23 @@ public final class ManaBrewInteractiveSession {
         private final SpellAbility action;
         private final String untilPhase;
         private final Card untapCard;
+        private final String color;
 
         private PriorityChoice(final PriorityActionKind kind, final SpellAbility action, final String untilPhase) {
-            this(kind, action, untilPhase, null);
+            this(kind, action, untilPhase, null, null);
         }
 
         private PriorityChoice(
                 final PriorityActionKind kind,
                 final SpellAbility action,
                 final String untilPhase,
-                final Card untapCard) {
+                final Card untapCard,
+                final String color) {
             this.kind = kind;
             this.action = action;
             this.untilPhase = untilPhase;
             this.untapCard = untapCard;
+            this.color = color;
         }
 
         PriorityActionKind kind() {
@@ -173,6 +176,10 @@ public final class ManaBrewInteractiveSession {
 
         Card untapCard() {
             return untapCard;
+        }
+
+        String color() {
+            return color;
         }
     }
 
@@ -200,7 +207,7 @@ public final class ManaBrewInteractiveSession {
             }
             if ("untap_land".equals(kind)) {
                 final Card untapCard = resolveUntapCard(action, untappableCards);
-                return new PriorityChoice(PriorityActionKind.UNDO, null, null, untapCard);
+                return new PriorityChoice(PriorityActionKind.UNDO, null, null, untapCard, null);
             }
             if ("choose_action".equals(kind)) {
                 final int index = action.get("index").getAsInt();
@@ -217,7 +224,10 @@ public final class ManaBrewInteractiveSession {
                 if (index < 0 || index >= actionsForPrompt.size()) {
                     throw new IllegalArgumentException("tap_land index out of range: " + index);
                 }
-                return new PriorityChoice(PriorityActionKind.ACTION, actionsForPrompt.get(index), null);
+                final String color = action.has("color") && !action.get("color").isJsonNull()
+                        ? action.get("color").getAsString()
+                        : null;
+                return new PriorityChoice(PriorityActionKind.ACTION, actionsForPrompt.get(index), null, null, color);
             }
             throw new UnsupportedOperationException("unsupported action kind: " + kind);
         }
@@ -1457,6 +1467,9 @@ public final class ManaBrewInteractiveSession {
             final Card host = sa.getHostCard();
             if (host != null) {
                 option.addProperty("cardId", SnapshotExtractor.javaCardId(host));
+            }
+            if (sa.isManaAbility() && sa.getManaPart() != null) {
+                option.addProperty("cost", sa.getManaPart().mana(sa));
             }
             options.add(option);
         }

--- a/src/components/game/manaUtils.ts
+++ b/src/components/game/manaUtils.ts
@@ -9,9 +9,44 @@ export function extractManaLetters(desc: string | undefined): string[] {
 
 export const ANY_COLOR_LETTERS = ["W", "U", "B", "R", "G"];
 
-/**
- * Expand mana abilities by detecting color options in descriptions.
- */
+const MANA_TOKEN_TO_LETTER: Record<string, string> = {
+  WHITE: "W",
+  W: "W",
+  BLUE: "U",
+  U: "U",
+  BLACK: "B",
+  B: "B",
+  RED: "R",
+  R: "R",
+  GREEN: "G",
+  G: "G",
+  COLORLESS: "C",
+  C: "C",
+};
+
+function extractProducedManaTokens(cost: string | undefined): string[] {
+  if (!cost) return [];
+  return cost
+    .replace(/[{}]/g, " ")
+    .split(/[\s,/]+/)
+    .map((token) => token.trim().toUpperCase())
+    .filter(Boolean);
+}
+
+function extractProducedManaLetters(cost: string | undefined): string[] {
+  return extractProducedManaTokens(cost)
+    .map((token) => MANA_TOKEN_TO_LETTER[token])
+    .filter((letter) => letter != null);
+}
+
+function hasAnyColorText(text: string): boolean {
+  return (
+    text.includes("any color") ||
+    text.includes("any one color") ||
+    text.includes("mana of any color")
+  );
+}
+
 export const getExpandedManaAbilities = (
   cardId: string,
   options: ActivatableAbilityInfo[],
@@ -24,14 +59,14 @@ export const getExpandedManaAbilities = (
   for (const ab of cardAbs) {
     const letters = extractManaLetters(ab.description);
     const desc = ab.description.toLowerCase();
+    const producedTokens = extractProducedManaTokens(ab.cost);
+    const cost = producedTokens.join(" ").toLowerCase();
+    const producedLetters = extractProducedManaLetters(ab.cost);
     const isAnyColor =
-      desc.includes("any color") ||
-      desc.includes("any one color") ||
-      desc.includes("mana of any color");
+      hasAnyColorText(desc) || hasAnyColorText(cost) || producedTokens.includes("ANY");
 
     if (letters.length > 1) {
-      // e.g. "Add {W} or {U}"
-      letters.forEach((letter) => {
+      [...new Set(letters)].forEach((letter) => {
         expanded.push({
           ...ab,
           description: `Add {${letter}}`,
@@ -46,6 +81,21 @@ export const getExpandedManaAbilities = (
           description: `Add {${letter}}`,
         });
       });
+    } else if (producedLetters.length > 0) {
+      const uniqueProducedLetters = [...new Set(producedLetters)];
+      if (uniqueProducedLetters.length === 1) {
+        expanded.push({
+          ...ab,
+          description: `Add {${uniqueProducedLetters[0]}}`,
+        });
+      } else {
+        uniqueProducedLetters.forEach((letter) => {
+          expanded.push({
+            ...ab,
+            description: `Add {${letter}}`,
+          });
+        });
+      }
     } else {
       expanded.push(ab);
     }

--- a/src/views/Game.tsx
+++ b/src/views/Game.tsx
@@ -6,7 +6,7 @@ import { useAutoResolvePrompt } from "@/components/game/prompts/useAutoResolvePr
 import { useShallow } from "zustand/react/shallow";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import type { GameCard, Player, StackObject, ActivatableAbilityInfo } from "@/types/manabrew";
+import type { ActivatableAbilityInfo, GameCard, Player, StackObject } from "@/types/manabrew";
 import { Card } from "@/components/game/Card";
 import { GameModals } from "@/components/game/GameModals";
 import { GameOverScreen } from "@/components/game/GameOverScreen";
@@ -21,7 +21,7 @@ import { PixiArrowsCanvas } from "@/pixi/PixiArrowsCanvas";
 import type { PixiGameScene } from "@/pixi/PixiGameScene";
 import { buildArrowSpecs } from "@/components/game/arrowSpecs";
 import { buildPointerSpecs } from "@/components/game/pointerSpecs";
-import { ANY_COLOR_LETTERS } from "@/components/game/manaUtils";
+import { getExpandedManaAbilities } from "@/components/game/manaUtils";
 import { PlayModePicker } from "@/components/game/PlayModePicker";
 import { HAND_CARD_BASES } from "@/components/game/game.styles";
 import { useHandScale } from "@/hooks/useHandScale";
@@ -279,6 +279,11 @@ export default function Game({ exitTo }: GameProps = {}) {
     cost: a.cost,
   });
 
+  const manaColorFromAction = (action: HandActionOption): string | null => {
+    const matches = action.label.match(/\{([WUBRGC])\}/);
+    return matches ? matches[1] : null;
+  };
+
   const castOptionsByCardId = useMemo(() => {
     const map = new Map<string, HandActionOption[]>();
     for (const o of chooseActionInput?.playableOptions ?? []) {
@@ -311,28 +316,7 @@ export default function Game({ exitTo }: GameProps = {}) {
       byCard.set(ab.cardId, arr);
     }
     for (const [cardId, abilities] of byCard) {
-      const expanded: ActivatableAbilityInfo[] = [];
-      for (const ab of abilities) {
-        const desc = ab.description.toLowerCase();
-        const matches = ab.description.matchAll(/\{([WUBRGC])\}/g);
-        const letters = Array.from(matches, (m) => m[1]);
-        const isAnyColor =
-          desc.includes("any color") ||
-          desc.includes("any one color") ||
-          desc.includes("mana of any color");
-        if (letters.length > 1) {
-          letters.forEach((letter) => expanded.push({ ...ab, description: `Add {${letter}}` }));
-        } else if (letters.length === 1) {
-          expanded.push(ab);
-        } else if (isAnyColor) {
-          ANY_COLOR_LETTERS.forEach((letter) =>
-            expanded.push({ ...ab, description: `Add {${letter}}` }),
-          );
-        } else {
-          expanded.push(ab);
-        }
-      }
-      map.set(cardId, expanded.map(toAbilityOption));
+      map.set(cardId, getExpandedManaAbilities(cardId, abilities).map(toAbilityOption));
     }
     return map;
   }, [chooseActionInput?.manaAbilityOptions, payManaCostInput?.manaAbilityOptions]);
@@ -415,9 +399,9 @@ export default function Game({ exitTo }: GameProps = {}) {
 
       const abilities = [...(abilitiesByCardId.get(card.id) ?? [])];
       const manaAbilities = manaAbilitiesByCardId.get(card.id) ?? [];
-      const isLandTappable = tappableLandIdSet.has(card.id) && card.types?.includes("Land");
+      const isManaSource = tappableLandIdSet.has(card.id);
 
-      if (isLandTappable && manaAbilities.length > 0) {
+      if (isManaSource && manaAbilities.length > 0) {
         // Use explicit mana abilities emitted by the engine instead of inventing a generic land tap action.
         abilities.unshift(...manaAbilities);
       }
@@ -586,23 +570,22 @@ export default function Game({ exitTo }: GameProps = {}) {
   // Land tap/untap handler — shows interactive preview for multi-ability lands
   const handleTapLand = (card: GameCard) => {
     if (payManaCostInput) {
-      const manaAbilities = payManaCostInput.manaAbilityOptions
-        .filter((a) => a.cardId === card.id)
-        .map((ability) => ({
-          kind: "ability" as const,
-          cardId: ability.cardId,
-          abilityIndex: ability.abilityIndex,
-          label: ability.description,
-          isManaAbility: true,
-          cost: ability.cost,
-        }));
+      const manaAbilities = getExpandedManaAbilities(
+        card.id,
+        payManaCostInput.manaAbilityOptions,
+      ).map(toAbilityOption);
 
       if (manaAbilities.length > 1) {
         preview.showSticky(card);
         return;
       }
       if (manaAbilities.length === 1) {
-        respond({ type: "tapLand", cardId: card.id, abilityIndex: manaAbilities[0].abilityIndex });
+        respond({
+          type: "tapLand",
+          cardId: card.id,
+          abilityIndex: manaAbilities[0].abilityIndex,
+          color: manaColorFromAction(manaAbilities[0]),
+        });
         return;
       }
       respond({ type: "tapLand", cardId: card.id });
@@ -624,11 +607,12 @@ export default function Game({ exitTo }: GameProps = {}) {
         isManaAbility: ability.isManaAbility,
         cost: ability.cost,
       }));
-    const manaAbilities = (chooseActionInput?.manaAbilityOptions ?? []).filter(
-      (a) => a.cardId === card.id,
-    );
+    const manaAbilities = getExpandedManaAbilities(
+      card.id,
+      chooseActionInput?.manaAbilityOptions ?? [],
+    ).map(toAbilityOption);
     const isManaSource = (chooseActionInput?.tappableLandIds ?? []).includes(card.id);
-    const hasManaAbility = isManaSource && card.types.includes("Land");
+    const hasManaAbility = isManaSource;
 
     // Multiple mana abilities (dual land) — show interactive preview for color choice
     if (manaAbilities.length > 1) {
@@ -637,7 +621,12 @@ export default function Game({ exitTo }: GameProps = {}) {
     }
     // Single mana ability — tap directly with that ability index
     if (manaAbilities.length === 1 && abilities.length === 0) {
-      respond({ type: "tapLand", cardId: card.id, abilityIndex: manaAbilities[0].abilityIndex });
+      respond({
+        type: "tapLand",
+        cardId: card.id,
+        abilityIndex: manaAbilities[0].abilityIndex,
+        color: manaColorFromAction(manaAbilities[0]),
+      });
       return;
     }
 
@@ -843,15 +832,11 @@ export default function Game({ exitTo }: GameProps = {}) {
       });
     } else if (action.abilityIndex != null) {
       if (action.isManaAbility) {
-        // Mana abilities use tapLand (ActivateMana) in both ChooseAction and PayManaCost.
-        // Extract color from label (e.g. "Add {G}") if present.
-        const matches = action.label.match(/\{([WUBRGC])\}/);
-        const color = matches ? matches[1] : undefined;
         respond({
           type: "tapLand",
           cardId: action.cardId,
           abilityIndex: action.abilityIndex,
-          color: color ?? null,
+          color: manaColorFromAction(action),
         });
       } else {
         respond({
@@ -1672,11 +1657,12 @@ export default function Game({ exitTo }: GameProps = {}) {
           } else if (ability.abilityIndex === -1) {
             respond({ type: "tapLand", cardId: abilityPickerState!.cardId });
           } else if (ability.abilityIndex != null) {
-            if (promptType === "payManaCost" && ability.isManaAbility) {
+            if (ability.isManaAbility) {
               respond({
                 type: "tapLand",
                 cardId: abilityPickerState!.cardId,
                 abilityIndex: ability.abilityIndex,
+                color: manaColorFromAction(ability),
               });
             } else {
               respond({


### PR DESCRIPTION
## Summary

- forward hosted Java mana ability produced-mana metadata through the prompt bridge
- preserve chosen mana colors when activating nonland mana sources
- let the client present nonland mana sources through the same tap/action flow as lands

### Black Lotus Before / After
<img width="113" height="158" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/552d7b5a-6e62-471d-9c7c-867a2176f830" />
<img width="109" height="144" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/195570e3-a5a3-47cf-be21-5a1e1a5ac8da" />

### Talisman of Creativity Before / After:
<img width="109" height="144" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/57f871c0-f86f-4e31-a0a5-9106f18e29a9" />
<img width="109" height="144" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/52b6307b-4182-49b9-8312-4c3944059036" />


## Why

Hosted Java mana prompts were treating cards like Black Lotus as generic artifact actions instead of preserving the exact mana ability choice selected by the player. That meant the client could lose which color was chosen, or fail to surface nonland mana sources consistently during payment.

## Test plan

- `node scripts/harness.mjs build`
- `cargo check -p forge-agent-interface && cargo check -p self-hosted-node --features java-forge`
- `./node_modules/.bin/eslint src/views/Game.tsx src/components/game/manaUtils.ts && ./node_modules/.bin/tsc -p tsconfig.app.json --noEmit`
- `yarn lint:all` fails on existing Rust clippy issues unrelated to this change (`forge-card-script`, `forge-protocol`, `forge-foundation`)

## Build artifacts

- [ ] Build macOS .dmg
- [ ] Build Windows .exe
