### PR TITLE
fix(hosted): honor optional any-target bounds

### DIFF
--- a/forge-engine/crates/forge-agent-interface/src/agent_impl/targeting.rs
+++ b/forge-engine/crates/forge-agent-interface/src/agent_impl/targeting.rs
@@ -24,6 +24,9 @@ pub(super) fn choose_target_player<T: Responder>(
             valid_player_ids,
             hostile,
             intent,
+            min_targets: 1,
+            max_targets: 1,
+            chosen_targets: 0,
         },
         source,
     );
@@ -162,6 +165,9 @@ pub(super) fn choose_target_spell<T: Responder>(
         AgentPromptInner::ChooseTargetSpell {
             valid_spell_ids,
             intent: TargetingIntent::Counter,
+            min_targets: 1,
+            max_targets: 1,
+            chosen_targets: 0,
         },
         source,
     );

--- a/forge-engine/crates/forge-agent-interface/src/agent_impl/targeting.rs
+++ b/forge-engine/crates/forge-agent-interface/src/agent_impl/targeting.rs
@@ -123,6 +123,9 @@ pub(super) fn choose_target_any<T: Responder>(
             valid_card_ids,
             hostile,
             intent,
+            min_targets: 1,
+            max_targets: 1,
+            chosen_targets: 0,
         },
         source,
     );

--- a/forge-engine/crates/forge-agent-interface/src/bin/emit_prompt_fixtures.rs
+++ b/forge-engine/crates/forge-agent-interface/src/bin/emit_prompt_fixtures.rs
@@ -44,6 +44,9 @@ fn main() {
             valid_player_ids: vec![],
             hostile: false,
             intent: TargetingIntent::default(),
+            min_targets: 0,
+            max_targets: 3,
+            chosen_targets: 1,
         },
         ChooseTargetCard {
             valid_card_ids: vec![],
@@ -99,6 +102,9 @@ fn main() {
         ChooseTargetSpell {
             valid_spell_ids: vec![],
             intent: TargetingIntent::default(),
+            min_targets: 0,
+            max_targets: 3,
+            chosen_targets: 1,
         },
         ChooseOptionalTrigger {
             description: String::new(),

--- a/forge-engine/crates/forge-agent-interface/src/bin/emit_prompt_fixtures.rs
+++ b/forge-engine/crates/forge-agent-interface/src/bin/emit_prompt_fixtures.rs
@@ -58,6 +58,9 @@ fn main() {
             valid_card_ids: vec![],
             hostile: false,
             intent: TargetingIntent::default(),
+            min_targets: 0,
+            max_targets: 3,
+            chosen_targets: 1,
         },
         ChooseTargetCardFromZone {
             valid_card_ids: vec![],

--- a/forge-engine/crates/forge-agent-interface/src/java_prompt_normalizer.rs
+++ b/forge-engine/crates/forge-agent-interface/src/java_prompt_normalizer.rs
@@ -323,6 +323,9 @@ pub fn normalize_java_prompt(prompt: JavaRawPrompt) -> AgentPrompt {
             api,
             destination,
             counter_type,
+            min_targets,
+            max_targets,
+            chosen_targets,
         } => {
             source_card_id = source;
             let intent = intent_from_api(&api, &destination, &counter_type);
@@ -331,6 +334,9 @@ pub fn normalize_java_prompt(prompt: JavaRawPrompt) -> AgentPrompt {
                 valid_card_ids: target_ids(&cards),
                 hostile: intent.is_hostile(),
                 intent,
+                min_targets,
+                max_targets,
+                chosen_targets,
             }
         }
         JavaRawPromptBody::ChooseTargetSpell {

--- a/forge-engine/crates/forge-agent-interface/src/java_prompt_normalizer.rs
+++ b/forge-engine/crates/forge-agent-interface/src/java_prompt_normalizer.rs
@@ -274,6 +274,9 @@ pub fn normalize_java_prompt(prompt: JavaRawPrompt) -> AgentPrompt {
             api,
             destination,
             counter_type,
+            min_targets,
+            max_targets,
+            chosen_targets,
         } => {
             source_card_id = source;
             let intent = intent_from_api(&api, &destination, &counter_type);
@@ -281,6 +284,9 @@ pub fn normalize_java_prompt(prompt: JavaRawPrompt) -> AgentPrompt {
                 valid_player_ids: target_ids(&players),
                 hostile: intent.is_hostile(),
                 intent,
+                min_targets,
+                max_targets,
+                chosen_targets,
             }
         }
         JavaRawPromptBody::ChooseTargetCard {
@@ -345,11 +351,17 @@ pub fn normalize_java_prompt(prompt: JavaRawPrompt) -> AgentPrompt {
             api,
             destination,
             counter_type,
+            min_targets,
+            max_targets,
+            chosen_targets,
         } => {
             source_card_id = source;
             AgentPromptInner::ChooseTargetSpell {
                 valid_spell_ids: target_ids(&spells),
                 intent: intent_from_api(&api, &destination, &counter_type),
+                min_targets,
+                max_targets,
+                chosen_targets,
             }
         }
         JavaRawPromptBody::PayManaCost {

--- a/forge-engine/crates/forge-agent-interface/src/java_raw.rs
+++ b/forge-engine/crates/forge-agent-interface/src/java_raw.rs
@@ -220,6 +220,12 @@ pub enum JavaRawPromptBody {
         destination: Option<String>,
         #[serde(rename = "counterType")]
         counter_type: Option<String>,
+        #[serde(rename = "minTargets", default)]
+        min_targets: i32,
+        #[serde(rename = "maxTargets", default)]
+        max_targets: i32,
+        #[serde(rename = "chosenTargets", default)]
+        chosen_targets: i32,
     },
     ChooseTargetCard {
         #[serde(default)]
@@ -265,6 +271,12 @@ pub enum JavaRawPromptBody {
         destination: Option<String>,
         #[serde(rename = "counterType")]
         counter_type: Option<String>,
+        #[serde(rename = "minTargets", default)]
+        min_targets: i32,
+        #[serde(rename = "maxTargets", default)]
+        max_targets: i32,
+        #[serde(rename = "chosenTargets", default)]
+        chosen_targets: i32,
     },
     PayManaCost {
         #[serde(rename = "cardId")]

--- a/forge-engine/crates/forge-agent-interface/src/java_raw.rs
+++ b/forge-engine/crates/forge-agent-interface/src/java_raw.rs
@@ -249,6 +249,12 @@ pub enum JavaRawPromptBody {
         destination: Option<String>,
         #[serde(rename = "counterType")]
         counter_type: Option<String>,
+        #[serde(rename = "minTargets", default)]
+        min_targets: i32,
+        #[serde(rename = "maxTargets", default)]
+        max_targets: i32,
+        #[serde(rename = "chosenTargets", default)]
+        chosen_targets: i32,
     },
     ChooseTargetSpell {
         #[serde(default)]

--- a/forge-engine/crates/forge-agent-interface/src/prompt.rs
+++ b/forge-engine/crates/forge-agent-interface/src/prompt.rs
@@ -138,6 +138,12 @@ pub enum AgentPromptInner {
         /// Semantic classification used by the UI to pick a pointer icon / glow color.
         #[serde(default = "default_intent")]
         intent: TargetingIntent,
+        #[serde(rename = "minTargets", default)]
+        min_targets: i32,
+        #[serde(rename = "maxTargets", default)]
+        max_targets: i32,
+        #[serde(rename = "chosenTargets", default)]
+        chosen_targets: i32,
     },
     ChooseTargetCard {
         #[serde(rename = "validCardIds")]
@@ -234,6 +240,12 @@ pub enum AgentPromptInner {
         valid_spell_ids: Vec<String>,
         #[serde(default = "default_intent")]
         intent: TargetingIntent,
+        #[serde(rename = "minTargets", default)]
+        min_targets: i32,
+        #[serde(rename = "maxTargets", default)]
+        max_targets: i32,
+        #[serde(rename = "chosenTargets", default)]
+        chosen_targets: i32,
     },
     /// Choose whether an optional triggered ability fires.
     ChooseOptionalTrigger {

--- a/forge-engine/crates/forge-agent-interface/src/prompt.rs
+++ b/forge-engine/crates/forge-agent-interface/src/prompt.rs
@@ -162,6 +162,12 @@ pub enum AgentPromptInner {
         hostile: bool,
         #[serde(default = "default_intent")]
         intent: TargetingIntent,
+        #[serde(rename = "minTargets", default)]
+        min_targets: i32,
+        #[serde(rename = "maxTargets", default)]
+        max_targets: i32,
+        #[serde(rename = "chosenTargets", default)]
+        chosen_targets: i32,
     },
     ChooseTargetCardFromZone {
         #[serde(rename = "validCardIds")]

--- a/src/components/game/game.types.ts
+++ b/src/components/game/game.types.ts
@@ -108,6 +108,8 @@ export interface MainActionOverlayProps {
   blockAssignments: CombatAssignment[];
   onDeclareBlockers: (assignments: CombatAssignment[]) => void;
   onOpenStack: () => void;
+  targetCompletionLabel?: string | null;
+  onCompleteTargets?: (() => void) | null;
   onConcede: () => void;
   resolveCardName: (cardId: string) => string;
   resolveCard: (cardId: string) => GameCard | undefined;

--- a/src/components/game/panels/MainActionOverlay.tsx
+++ b/src/components/game/panels/MainActionOverlay.tsx
@@ -30,6 +30,8 @@ export function MainActionOverlay({
   blockAssignments,
   onDeclareBlockers,
   onOpenStack,
+  targetCompletionLabel,
+  onCompleteTargets,
   onConcede,
   resolveCardName,
   resolveCard,
@@ -100,6 +102,8 @@ export function MainActionOverlay({
               blockAssignments={blockAssignments}
               onDeclareBlockers={onDeclareBlockers}
               onOpenStack={onOpenStack}
+              targetCompletionLabel={targetCompletionLabel}
+              onCompleteTargets={onCompleteTargets}
               buttonLayout={buttonLayout}
               payManaCostInfo={payManaCostInfo}
               onPayManaCost={onPayManaCost}

--- a/src/components/game/panels/PromptActionController.tsx
+++ b/src/components/game/panels/PromptActionController.tsx
@@ -64,6 +64,8 @@ interface PromptActionControllerProps {
   blockAssignments: CombatAssignment[];
   onDeclareBlockers: (assignments: CombatAssignment[]) => void;
   onOpenStack: () => void;
+  targetCompletionLabel?: string | null;
+  onCompleteTargets?: (() => void) | null;
   buttonLayout?: PromptButtonLayout;
   // Pay mana cost
   payManaCostInfo?: {
@@ -105,6 +107,8 @@ export function PromptActionController({
   blockAssignments,
   onDeclareBlockers,
   onOpenStack,
+  targetCompletionLabel,
+  onCompleteTargets,
   buttonLayout = "full",
   payManaCostInfo,
   onPayManaCost,
@@ -197,6 +201,9 @@ export function PromptActionController({
         <PromptLabel
           buttonLayout={buttonLayout}
           label={(promptType && labels[promptType]) || "Waiting..."}
+          isWaitingForResponse={isWaitingForResponse}
+          completionLabel={targetCompletionLabel ?? undefined}
+          onCompleteTargets={onCompleteTargets ?? undefined}
         />
       );
     },

--- a/src/components/game/panels/PromptActionController.tsx
+++ b/src/components/game/panels/PromptActionController.tsx
@@ -162,6 +162,8 @@ export function PromptActionController({
         buttonLayout={buttonLayout}
         isWaitingForResponse={isWaitingForResponse}
         onOpenStack={onOpenStack}
+        completionLabel={targetCompletionLabel ?? undefined}
+        onCompleteTargets={onCompleteTargets ?? undefined}
       />
     ),
     payManaCost: () => (

--- a/src/components/game/panels/prompt-actions/ChooseTargetSpell.tsx
+++ b/src/components/game/panels/prompt-actions/ChooseTargetSpell.tsx
@@ -1,4 +1,4 @@
-import { Layers } from "lucide-react";
+import { Check, Layers } from "lucide-react";
 import { PromptActionButton } from "@/components/game/panels/PromptActionButton";
 import type { ChooseTargetSpellProps } from "./types";
 
@@ -6,15 +6,28 @@ export function ChooseTargetSpell({
   buttonLayout,
   isWaitingForResponse,
   onOpenStack,
+  completionLabel,
+  onCompleteTargets,
 }: ChooseTargetSpellProps) {
   return (
-    <PromptActionButton
-      layout={buttonLayout}
-      label="View Stack"
-      title="Click a glowing spell on the stack to counter it"
-      icon={<Layers className="h-3.5 w-3.5" />}
-      onClick={onOpenStack}
-      disabled={isWaitingForResponse}
-    />
+    <div className="flex items-center gap-1.5">
+      <PromptActionButton
+        layout={buttonLayout}
+        label="View Stack"
+        title="Click a glowing spell on the stack to counter it"
+        icon={<Layers className="h-3.5 w-3.5" />}
+        onClick={onOpenStack}
+        disabled={isWaitingForResponse}
+      />
+      {onCompleteTargets && (
+        <PromptActionButton
+          layout={buttonLayout}
+          label={completionLabel ?? "Done"}
+          icon={<Check className="h-3.5 w-3.5" />}
+          onClick={onCompleteTargets}
+          disabled={isWaitingForResponse}
+        />
+      )}
+    </div>
   );
 }

--- a/src/components/game/panels/prompt-actions/PromptLabel.tsx
+++ b/src/components/game/panels/prompt-actions/PromptLabel.tsx
@@ -1,19 +1,42 @@
-import { Crosshair } from "lucide-react";
-import type { PromptButtonLayout } from "@/components/game/panels/PromptActionButton";
+import { Check, Crosshair } from "lucide-react";
+import {
+  PromptActionButton,
+  type PromptButtonLayout,
+} from "@/components/game/panels/PromptActionButton";
 
 interface PromptLabelProps {
   buttonLayout: PromptButtonLayout;
   label: string;
+  isWaitingForResponse?: boolean;
+  completionLabel?: string;
+  onCompleteTargets?: () => void;
 }
 
-export function PromptLabel({ buttonLayout, label }: PromptLabelProps) {
+export function PromptLabel({
+  buttonLayout,
+  label,
+  isWaitingForResponse,
+  completionLabel,
+  onCompleteTargets,
+}: PromptLabelProps) {
+  const completionButton = onCompleteTargets ? (
+    <PromptActionButton
+      layout={buttonLayout}
+      label={completionLabel ?? "Done"}
+      icon={<Check className="h-3.5 w-3.5" />}
+      onClick={onCompleteTargets}
+      disabled={isWaitingForResponse}
+    />
+  ) : null;
+
   if (buttonLayout === "modern") {
     return (
-      <div className="flex w-3/5 flex-col gap-1.5">
-        <div className="flex items-center gap-2 h-9 px-3 rounded-lg border border-white/20 bg-white/5 text-white/80">
+      <div className="flex w-3/5 items-center gap-1.5">
+        <div className="flex min-w-0 flex-1 items-center gap-2 h-9 px-3 rounded-lg border border-white/20 bg-white/5 text-white/80">
           <Crosshair className="h-3.5 w-3.5 shrink-0 animate-pulse" />
           <span className="text-xs font-semibold tracking-wide truncate">{label}</span>
         </div>
+        {completionButton}
       </div>
     );
   }
@@ -22,6 +45,7 @@ export function PromptLabel({ buttonLayout, label }: PromptLabelProps) {
     <div className="flex items-center gap-2 px-2 py-1 text-sm text-muted-foreground">
       <Crosshair className="h-4 w-4 shrink-0 animate-pulse" />
       <span className="font-medium">{label}</span>
+      {completionButton}
     </div>
   );
 }

--- a/src/components/game/panels/prompt-actions/types.ts
+++ b/src/components/game/panels/prompt-actions/types.ts
@@ -41,6 +41,8 @@ export interface ChooseBlockersProps extends PromptActionLayoutProps {
 
 export interface ChooseTargetSpellProps extends PromptActionLayoutProps {
   onOpenStack: () => void;
+  completionLabel?: string;
+  onCompleteTargets?: () => void;
 }
 
 export interface PayManaCostProps extends PromptActionLayoutProps {

--- a/src/components/game/prompts/resolvers/forced.ts
+++ b/src/components/game/prompts/resolvers/forced.ts
@@ -40,10 +40,21 @@ function consumeIntentForSpell(
   return intent.id;
 }
 
+function canFinishTargeting(input: {
+  minTargets: number;
+  maxTargets: number;
+  chosenTargets: number;
+}): boolean {
+  return input.maxTargets > input.minTargets && input.chosenTargets >= input.minTargets;
+}
+
 export const singleLegalCard: PromptResolver<"chooseTargetCard" | "chooseTargetCardFromZone"> = (
   prompt,
   ctx,
 ) => {
+  if (prompt.input.type === "chooseTargetCard" && canFinishTargeting(prompt.input)) {
+    return { kind: "force-show" };
+  }
   const preselected = consumeIntentForCard(prompt, ctx);
   if (preselected) {
     return {
@@ -204,6 +215,7 @@ export const singleAssigneeDamage: PromptResolver<"chooseCombatDamageAssignment"
 };
 
 export const singleLegalAny: PromptResolver<"chooseTargetAny"> = (prompt, ctx) => {
+  if (canFinishTargeting(prompt.input)) return { kind: "force-show" };
   const preCard = consumeIntentForCard(prompt, ctx);
   if (preCard) {
     return {

--- a/src/components/game/prompts/resolvers/forced.ts
+++ b/src/components/game/prompts/resolvers/forced.ts
@@ -73,6 +73,7 @@ export const singleLegalCard: PromptResolver<"chooseTargetCard" | "chooseTargetC
 };
 
 export const singleLegalPlayer: PromptResolver<"chooseTargetPlayer"> = (prompt, ctx) => {
+  if (canFinishTargeting(prompt.input)) return { kind: "force-show" };
   const preselected = consumeIntentForPlayer(prompt, ctx);
   if (preselected) {
     return {
@@ -91,6 +92,7 @@ export const singleLegalPlayer: PromptResolver<"chooseTargetPlayer"> = (prompt, 
 };
 
 export const singleLegalSpell: PromptResolver<"chooseTargetSpell"> = (prompt, ctx) => {
+  if (canFinishTargeting(prompt.input)) return { kind: "force-show" };
   const preselected = consumeIntentForSpell(prompt, ctx);
   if (preselected) {
     return {

--- a/src/protocol/prompts/chooseTargetAny.ts
+++ b/src/protocol/prompts/chooseTargetAny.ts
@@ -11,5 +11,8 @@ export type Input = {
   validCardIds: string[];
   hostile?: boolean;
   intent: TargetingIntent;
+  minTargets: number;
+  maxTargets: number;
+  chosenTargets: number;
 };
 export type Output = { type: "targetAny"; target: TargetChoice };

--- a/src/protocol/prompts/chooseTargetPlayer.ts
+++ b/src/protocol/prompts/chooseTargetPlayer.ts
@@ -6,5 +6,8 @@ export type Input = {
   validPlayerIds: string[];
   hostile?: boolean;
   intent: TargetingIntent;
+  minTargets: number;
+  maxTargets: number;
+  chosenTargets: number;
 };
 export type Output = { type: "targetPlayer"; playerId: string | null };

--- a/src/protocol/prompts/chooseTargetSpell.ts
+++ b/src/protocol/prompts/chooseTargetSpell.ts
@@ -5,5 +5,8 @@ export type Input = {
   type: Type;
   validSpellIds: string[];
   intent: TargetingIntent;
+  minTargets: number;
+  maxTargets: number;
+  chosenTargets: number;
 };
 export type Output = { type: "targetSpell"; spellId: string | null };

--- a/src/views/Game.tsx
+++ b/src/views/Game.tsx
@@ -540,7 +540,14 @@ export default function Game({ exitTo }: GameProps = {}) {
   const targetCompletion = useMemo(() => {
     if (!activePrompt) return null;
     const input = activePrompt.input;
-    if (input.type !== "chooseTargetAny" && input.type !== "chooseTargetCard") return null;
+    if (
+      input.type !== "chooseTargetAny" &&
+      input.type !== "chooseTargetCard" &&
+      input.type !== "chooseTargetPlayer" &&
+      input.type !== "chooseTargetSpell"
+    ) {
+      return null;
+    }
     if (input.maxTargets <= input.minTargets || input.chosenTargets < input.minTargets) {
       return null;
     }
@@ -549,9 +556,13 @@ export default function Game({ exitTo }: GameProps = {}) {
       onComplete:
         input.type === "chooseTargetAny"
           ? () => wrappedTargetAny({ kind: "none" })
-          : () => wrappedTargetCard(null),
+          : input.type === "chooseTargetCard"
+            ? () => wrappedTargetCard(null)
+            : input.type === "chooseTargetPlayer"
+              ? () => respond({ type: "targetPlayer", playerId: null })
+              : () => respond({ type: "targetSpell", spellId: null }),
     };
-  }, [activePrompt, wrappedTargetAny, wrappedTargetCard]);
+  }, [activePrompt, respond, wrappedTargetAny, wrappedTargetCard]);
 
   // Zone viewer helpers (wrap store actions)
   function openZone(

--- a/src/views/Game.tsx
+++ b/src/views/Game.tsx
@@ -536,6 +536,22 @@ export default function Game({ exitTo }: GameProps = {}) {
   const selectedAttackDefender = chooseAttackersInput?.possibleDefenderIds.find(
     (defender) => defender.id === attackDefenderId,
   );
+  const { wrappedTargetAny, wrappedTargetCard } = casting;
+  const targetCompletion = useMemo(() => {
+    if (!activePrompt) return null;
+    const input = activePrompt.input;
+    if (input.type !== "chooseTargetAny" && input.type !== "chooseTargetCard") return null;
+    if (input.maxTargets <= input.minTargets || input.chosenTargets < input.minTargets) {
+      return null;
+    }
+    return {
+      label: input.chosenTargets === 0 ? "Skip" : "Done",
+      onComplete:
+        input.type === "chooseTargetAny"
+          ? () => wrappedTargetAny({ kind: "none" })
+          : () => wrappedTargetCard(null),
+    };
+  }, [activePrompt, wrappedTargetAny, wrappedTargetCard]);
 
   // Zone viewer helpers (wrap store actions)
   function openZone(
@@ -1541,6 +1557,8 @@ export default function Game({ exitTo }: GameProps = {}) {
           blockAssignments={blockAssignments}
           onDeclareBlockers={(assignments) => respond({ type: "declareBlockers", assignments })}
           onOpenStack={() => setSpellStackModalOpen(true)}
+          targetCompletionLabel={targetCompletion?.label}
+          onCompleteTargets={targetCompletion?.onComplete}
           onConcede={concede}
           resolveCardName={(cardId) => cardNameById.get(cardId) ?? cardId}
           resolveCard={(cardId) => visibleCardsById.get(cardId)}


### PR DESCRIPTION
## Summary
- Preserve Forge target count bounds on hosted target prompts: player, card, any, zone-card, and spell target variants.
- Stop auto-resolving extra targets once an up-to target prompt may legally finish.
- Add a Skip/Done target-completion action for optional board and stack target prompts.

## Why
Addresses (amongst others) https://github.com/witchesofthehill/manabrew/issues/128
Jaya's Immolating Inferno is scripted as `ValidTgts$ Any | TargetMin$ 0 | TargetMax$ 3`, but hosted target prompts did not consistently carry `minTargets`, `maxTargets`, and `chosenTargets` through the bridge. The client could therefore treat repeated "up to" target prompts as ordinary required target prompts and force the player toward the maximum number of targets. Forge can also narrow later Jaya prompts from any-target to player-only prompts, so the bounds need to be preserved across the target prompt family instead of only `chooseTargetAny`.

## Test plan
- `cargo check -p forge-agent-interface`
- `cargo test -p forge-agent-interface`
- `yarn eslint src/protocol/prompts/chooseTargetPlayer.ts src/protocol/prompts/chooseTargetAny.ts src/protocol/prompts/chooseTargetSpell.ts src/components/game/prompts/resolvers/forced.ts src/components/game/panels/prompt-actions/PromptLabel.tsx src/components/game/panels/prompt-actions/ChooseTargetSpell.tsx src/components/game/panels/prompt-actions/types.ts src/components/game/panels/PromptActionController.tsx src/components/game/panels/MainActionOverlay.tsx src/components/game/game.types.ts src/views/Game.tsx`
- `yarn tsc -p tsconfig.app.json --noEmit`
- `yarn test src/stores/gameStore.constants.test.ts`
- `yarn lint:all` currently fails in unrelated Rust clippy checks already present on `main`: `forge-card-script/src/lib.rs` unnecessary lazy evaluations, `forge-protocol/src/protocol.rs` large enum variant, `forge-foundation/src/phase.rs` unused mut, and `forge-foundation/src/card_split.rs` derivable impls. It also reports an existing warning in `src/components/game/GameBoard.tsx` about `selectableBattlefieldCardIds` dependencies.

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
