### PR TITLE
docs: tweak on contribution guidelines and download flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to ManaBrew
 
-Thanks for helping. The easiest contributions to review are small,
+First things first, thanks so much for helping. The easiest contributions to review are small,
 issue-backed, reproducible, and checked locally before the PR is opened.
 
 ## Contribution flow
@@ -8,7 +8,7 @@ issue-backed, reproducible, and checked locally before the PR is opened.
 Use this path for most contributions:
 
 1. **Pick up an issue.** Start from an existing issue, or open one before doing
-   larger work.
+   larger work. Make sure you assign the issue to yourself, and put it as "InProgress" so other people don't pick up the same issue as you
 2. **Fork the repository.** Create your own fork and make changes on a branch in
    that fork.
 3. **Implement the change.** Keep the patch focused on the issue. Avoid
@@ -23,8 +23,6 @@ Use this path for most contributions:
 ## Start with an issue
 
 For anything larger than a typo, start from an existing issue or open one first.
-Comment on the issue if you plan to work on it, so maintainers and other
-contributors can avoid duplicate effort.
 
 Good issue reports include:
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ The repository includes:
 > Java Forge-backed sessions, which gives the project a usable path while Rust
 > parity work continues.
 
+## Start playing online now - for free
+
+To get started visit our [landing page](https://manabrew.app)
+
 ## Current Status
 
 `ManaBrew` is pre-release software.
@@ -272,45 +276,13 @@ Before opening a PR, read [CONTRIBUTING.md](./CONTRIBUTING.md). In short:
 - run `yarn lint:all` before asking for review;
 - do not bundle card images or secrets.
 
-### Preview Deploys
-
-A PR can be deployed to a shared preview environment at
-[staging.manabrew.app](https://staging.manabrew.app) by adding the
-`deploy-preview` label to it.
-
-**Why.** Some classes of bug only show up against a real deployment — TLS,
-cross-origin isolation (`SharedArrayBuffer` needs the right COOP/COEP
-headers), the Scryfall image proxy, and live WebSocket multiplayer. None of
-those are exercised by a local `yarn dev`. The preview gives reviewers a
-working URL to click through before merge instead of building the branch
-themselves.
-
-**How.** Labelling a PR `deploy-preview` triggers the `preview-deploy`
-workflow, which SSHes to the deploy host, checks out the PR's HEAD into a
-separate `/opt/manabrew-staging` working tree (kept apart from the live
-`/opt/manabrew` so a preview build can't disturb prod), and brings up a
-self-contained staging stack:
-
-- `staging.manabrew.app` — the PR's web client
-- `relay-staging.manabrew.app` — a dedicated `forge-server` relay, so a
-  PR that changes the backend is previewed end-to-end without touching the
-  production relay
-
-The workflow comments the preview URL back on the PR. There is a **single**
-preview slot: the most recently labelled PR occupies it, and labelling a
-different PR takes it over. Every push to a labelled PR redeploys
-automatically.
-
-Merging (or closing) the PR, or removing the label, tears the staging stack
-down and frees the slot — a merged PR cleans up after itself, so no stale
-preview lingers.
-
 ### AI-Assisted Development
 
-This repository uses AI assistance for mechanical porting, parity
+This repository welcomes the use of AI assistance for mechanical porting, parity
 investigation, trace analysis, documentation, and large-scale inventory work. AI
-output is treated as code written by a contributor: it must be reviewed, tested,
-and grounded in Forge's Java behavior.
+output is treated as code written by a contributor: it must be well thought of, reviewed, and properly tested.
+
+Do not push code you don't understand.
 
 See [AI Usage](./docs/AI_USAGE.md).
 

--- a/website/astro.config.docs.mjs
+++ b/website/astro.config.docs.mjs
@@ -33,7 +33,12 @@ export default defineConfig({
       sidebar: [
         {
           label: "Start here",
-          items: [{ label: "What is ManaBrew?", link: "/" }, "getting-started"],
+          items: [
+            { label: "What is ManaBrew?", link: "/" },
+            "getting-started",
+            "download-windows",
+            "download-macos",
+          ],
         },
         { label: "Playing", items: ["playing", "formats", "faq"] },
         { label: "Hosting", items: ["self-hosting"] },

--- a/website/src-landing/pages/index.astro
+++ b/website/src-landing/pages/index.astro
@@ -14,7 +14,8 @@ import vsSelection from "../../../images/vsSelection.jpeg";
 
 const GITHUB = "https://github.com/witchesofthehill/manabrew";
 const DISCORD = "https://discord.gg/NqrKpbhtcd";
-const RELEASES = `${GITHUB}/releases`;
+const WINDOWS_DOWNLOAD = "https://docs.manabrew.app/download-windows/";
+const MACOS_DOWNLOAD = "https://docs.manabrew.app/download-macos/";
 const DESCRIPTION =
   "An open-source Magic: The Gathering client and rules engine, built around Forge compatibility. Play in your browser or on the desktop.";
 
@@ -69,7 +70,22 @@ const mana = preset.gameColors;
           </p>
           <div class="cta-row reveal">
             <a class="btn btn-primary" href="https://play.manabrew.app">Play in your browser</a>
-            <a class="btn btn-ghost" href={RELEASES}>Download for desktop</a>
+            <a class="btn btn-ghost" href={WINDOWS_DOWNLOAD}>
+              <svg class="btn-icon" aria-hidden="true" viewBox="0 0 24 24" width="16" height="16">
+                <path d="M3 4.9 10.5 3.9v7.4H3V4.9Z"></path>
+                <path d="M11.5 3.8 21 2.5v8.8h-9.5V3.8Z"></path>
+                <path d="M3 12.3h7.5v7.5L3 18.8v-6.5Z"></path>
+                <path d="M11.5 12.3H21v9.2l-9.5-1.3v-7.9Z"></path>
+              </svg>
+              Download for Windows
+            </a>
+            <a class="btn btn-ghost" href={MACOS_DOWNLOAD}>
+              <svg class="btn-icon" aria-hidden="true" viewBox="0 0 24 24" width="16" height="16">
+                <path d="M16.4 2c.1 1.1-.3 2.2-1 3-.8.9-1.9 1.5-3 1.4-.1-1 .3-2.1 1-2.9.8-.9 2-1.5 3-1.5Z"></path>
+                <path d="M20.5 17.4c-.4.9-.7 1.3-1.2 2.1-.8 1.2-1.9 2.7-3.3 2.7-1.2 0-1.6-.8-3.3-.8s-2.1.8-3.4.8c-1.4 0-2.5-1.4-3.3-2.6-2.3-3.5-2.6-7.6-1.1-9.8 1-1.5 2.6-2.4 4.2-2.4 1.6 0 2.6.8 3.9.8 1.2 0 2-.8 3.8-.8 1.3 0 2.7.7 3.7 1.9-3.2 1.8-2.7 6.4.4 8.1Z"></path>
+              </svg>
+              Download for macOS
+            </a>
             <a class="btn btn-bare" href="https://docs.manabrew.app/">Read the docs →</a>
           </div>
         </div>
@@ -310,7 +326,10 @@ const mana = preset.gameColors;
   }
 
   .btn {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
     padding: 0.78rem 1.5rem;
     border-radius: 4px;
     font-weight: 700;
@@ -320,6 +339,14 @@ const mana = preset.gameColors;
       transform 140ms ease,
       box-shadow 140ms ease,
       background-color 140ms ease;
+  }
+
+  .btn-icon {
+    width: 1rem;
+    height: 1rem;
+    flex: 0 0 auto;
+    display: block;
+    fill: var(--foreground);
   }
 
   .btn-primary {

--- a/website/src/content/docs/download-macos.mdx
+++ b/website/src/content/docs/download-macos.mdx
@@ -1,0 +1,45 @@
+---
+title: Download for macOS
+description: Install the latest ManaBrew desktop build on macOS.
+---
+
+## 1. Download
+
+Download the latest macOS `.dmg` from
+[GitHub releases](https://github.com/witchesofthehill/manabrew/releases/latest).
+Open the disk image and drag `ManaBrew.app` into `/Applications`.
+:::note
+We currently only support Apple silicon devices
+:::
+
+## 2. Install into Applications
+
+Double click on the downloaded `.dmg` file, after that, drag the Manabrew app into the `Applications/` folder.
+
+## 3. macOS warning
+
+ManaBrew's CI builds are not currently Developer ID signed and notarized.
+After downloading from the internet, macOS may say the app is damaged or cannot
+be opened.
+
+After dragging the app to `/Applications`:
+
+1. Open the `terminal` (search for "terminal" in the macOS search tool)
+2. Run the following commands
+
+```bash
+# 1. Remove the quarantine and provenance attributes from the whole bundle
+xattr -dr com.apple.quarantine /Applications/ManaBrew.app
+xattr -dr com.apple.provenance /Applications/ManaBrew.app
+
+# 2. Re-seal with an ad-hoc signature, regenerating _CodeSignature/CodeResources
+codesign --force --deep --sign - /Applications/ManaBrew.app
+
+# 3. Verify the seal is now valid
+codesign --verify --deep --strict --verbose=2 /Applications/ManaBrew.app
+```
+
+3. Then open ManaBrew from `/Applications`.
+
+Only install builds from the official
+[ManaBrew releases page](https://github.com/witchesofthehill/manabrew/releases/latest).

--- a/website/src/content/docs/download-windows.mdx
+++ b/website/src/content/docs/download-windows.mdx
@@ -1,0 +1,26 @@
+---
+title: Download for Windows
+description: Install the latest ManaBrew desktop build on Windows.
+---
+
+## 1. Download
+
+Download the latest Windows installer from
+[GitHub releases](https://github.com/witchesofthehill/manabrew/releases/latest).
+Use the `.exe` installer when available; the `.msi` is also attached for users
+who prefer Windows Installer packages.
+
+## 2. Windows warning
+
+ManaBrew is pre-release open-source software and its Windows installer is not
+yet broadly trusted by Microsoft SmartScreen. Windows may warn that the app is
+unrecognized or unsafe.
+
+To run it anyway:
+
+1. Open the downloaded installer.
+2. Click **More info** if Windows Defender SmartScreen blocks it.
+3. Click **Run anyway**.
+
+Only install builds from the official
+[ManaBrew releases page](https://github.com/witchesofthehill/manabrew/releases/latest).

--- a/website/src/content/docs/getting-started.md
+++ b/website/src/content/docs/getting-started.md
@@ -11,8 +11,11 @@ WebAssembly — nothing to install.
 
 ## Desktop app
 
-Native installers for macOS (`.dmg`) and Windows (`.exe`) are published on the
-[GitHub releases page](https://github.com/witchesofthehill/manabrew/releases).
+Native installers are published on GitHub releases. Follow the platform
+instructions:
+
+- [Download for Windows](/download-windows/)
+- [Download for macOS](/download-macos/)
 
 ## Card images
 


### PR DESCRIPTION
## Build artifacts
<!--
  Check the boxes below to build the corresponding installer on merge to main
  (uploaded to the Actions run, 30-day retention).
  Leave unchecked to skip — faster CI, no binaries produced.
  Tag pushes (v*) always build both and publish a GitHub Release regardless.
-->
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
