### PR TITLE
chore(card-script): polish parser/lsp and prep crates for publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ exclude = [
 
 [workspace.package]
 license = "GPL-3.0-or-later"
+repository = "https://github.com/witchesofthehill/manabrew"
 
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/forge-engine/crates/forge-card-script-lsp/Cargo.toml
+++ b/forge-engine/crates/forge-card-script-lsp/Cargo.toml
@@ -2,14 +2,19 @@
 name = "forge-card-script-lsp"
 version = "0.1.0"
 edition = "2021"
-description = "Language Server Protocol implementation for the Forge card script DSL"
+description = "Language Server Protocol implementation for the Forge card-script DSL"
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+keywords = ["mtg", "magic", "forge", "lsp", "dsl"]
+categories = ["development-tools"]
 
 [[bin]]
 name = "forge-card-script-lsp"
 path = "src/main.rs"
 
 [dependencies]
-forge-card-script = { path = "../forge-card-script" }
+forge-card-script = { path = "../forge-card-script", version = "0.1.0" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 ropey = "1"

--- a/forge-engine/crates/forge-card-script-lsp/README.md
+++ b/forge-engine/crates/forge-card-script-lsp/README.md
@@ -1,0 +1,46 @@
+# forge-card-script-lsp
+
+A [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) server for the
+**Forge card-script DSL** (Magic: The Gathering card definitions). It is built on
+[`forge-card-script`](https://crates.io/crates/forge-card-script) and is part of the
+[ManaBrew](https://github.com/witchesofthehill/manabrew) project.
+
+## Features
+
+- **Diagnostics** — missing `:` / `$` delimiters, empty keys, missing ability record type,
+  missing SVar name, and duplicate parameters (last-wins), published as you type.
+- **Hover** — over a parameter shows its inferred semantic type and raw value; over an SVar
+  reference shows the SVar's definition (or a warning if it is not defined on the card).
+- **Go to definition** — from an SVar reference (`Execute$`, `SubAbility$`, …) to its `SVar:` line.
+
+Positions are reported in UTF-16 code units per the LSP spec, so ranges stay correct for cards
+with non-ASCII text (accented names, em-dashes in oracle text).
+
+## Build & run
+
+```bash
+cargo build --release -p forge-card-script-lsp
+# binary: target/release/forge-card-script-lsp  (speaks LSP over stdio)
+```
+
+### Neovim example
+
+```lua
+vim.lsp.start({
+  name = "forge-card-script",
+  cmd = { "forge-card-script-lsp" },
+  root_dir = vim.fn.getcwd(),
+})
+```
+
+Pair it with the [`tree-sitter-forge-card-script`](https://crates.io/crates/tree-sitter-forge-card-script)
+grammar for syntax highlighting.
+
+## Scope
+
+This is a focused server: diagnostics, hover, and SVar go-to-definition. There is no completion,
+document-symbol, or semantic-tokens support yet.
+
+## License
+
+GPL-3.0-or-later. See the repository for details.

--- a/forge-engine/crates/forge-card-script-lsp/src/main.rs
+++ b/forge-engine/crates/forge-card-script-lsp/src/main.rs
@@ -17,9 +17,7 @@ struct Document {
     svars: HashMap<String, SvarInfo>,
 }
 
-#[allow(dead_code)]
 struct SvarInfo {
-    line: u32,
     name_start: u32,
     name_end: u32,
     value_start: u32,
@@ -42,7 +40,6 @@ impl Document {
                 svars.insert(
                     svar.name.to_string(),
                     SvarInfo {
-                        line: (line.line_no - 1) as u32,
                         name_start: svar.name_span.start as u32,
                         name_end: svar.name_span.end as u32,
                         value_start: svar.value_span.start as u32,
@@ -83,23 +80,18 @@ impl Backend {
     }
 
     fn compute_diagnostics(&self, text: &str) -> Vec<Diagnostic> {
+        let rope = Rope::from_str(text);
         let parsed = ParsedCardScript::parse(text);
         parsed
             .diagnostics()
             .iter()
-            .filter_map(|d| self.to_lsp_diagnostic(text, d))
+            .filter_map(|d| self.to_lsp_diagnostic(&rope, d))
             .collect()
     }
 
-    fn to_lsp_diagnostic(&self, text: &str, d: &ScriptDiagnostic<'_>) -> Option<Diagnostic> {
-        let line = (d.line_no.saturating_sub(1)) as u32;
-        let line_start = text
-            .lines()
-            .take(d.line_no.saturating_sub(1))
-            .map(|l| l.len() + 1)
-            .sum::<usize>();
-        let col_start = d.span.start.saturating_sub(line_start) as u32;
-        let col_end = d.span.end.saturating_sub(line_start) as u32;
+    fn to_lsp_diagnostic(&self, rope: &Rope, d: &ScriptDiagnostic<'_>) -> Option<Diagnostic> {
+        let start = byte_to_position(rope, d.span.start);
+        let end = byte_to_position(rope, d.span.end);
 
         let (severity, message) = match d.kind {
             ScriptDiagnosticKind::MissingColon => (
@@ -146,10 +138,7 @@ impl Backend {
         };
 
         Some(Diagnostic {
-            range: Range {
-                start: Position::new(line, col_start),
-                end: Position::new(line, col_end),
-            },
+            range: Range { start, end },
             severity: Some(severity),
             source: Some("forge-card-script".to_string()),
             message,
@@ -157,11 +146,8 @@ impl Backend {
         })
     }
 
-    /// Find the SVar name at a cursor position (for go-to-def and hover).
-    fn svar_ref_at_position<'a>(&self, text: &'a str, pos: Position) -> Option<&'a str> {
-        let line_text = text.lines().nth(pos.line as usize)?;
-        let col = pos.character as usize;
-
+    /// Find the SVar name at a byte column within a line (for go-to-def and hover).
+    fn svar_ref_at_position<'a>(&self, line_text: &'a str, col: usize) -> Option<&'a str> {
         // Look for patterns like Execute$ Name, SubAbility$ Name, etc.
         // Find the $ before cursor or the value after $
         for segment in line_text.split('|') {
@@ -208,6 +194,24 @@ fn is_svar_ref_key(key: &str) -> bool {
         || key.ends_with("Subs")
         || key.starts_with("AddTrigger")
         || key.starts_with("AddStaticAbility")
+}
+
+/// Convert an absolute byte offset into an LSP position (line + UTF-16 column).
+fn byte_to_position(rope: &Rope, byte: usize) -> Position {
+    let byte = byte.min(rope.len_bytes());
+    let line = rope.byte_to_line(byte);
+    let line_start = rope.char_to_utf16_cu(rope.line_to_char(line));
+    let col = rope.char_to_utf16_cu(rope.byte_to_char(byte)) - line_start;
+    Position::new(line as u32, col as u32)
+}
+
+/// Convert an LSP position (line + UTF-16 column) into an absolute byte offset.
+fn position_to_byte(rope: &Rope, pos: Position) -> usize {
+    let line = (pos.line as usize).min(rope.len_lines().saturating_sub(1));
+    let line_start = rope.char_to_utf16_cu(rope.line_to_char(line));
+    let max = rope.char_to_utf16_cu(rope.len_chars());
+    let target = (line_start + pos.character as usize).min(max);
+    rope.char_to_byte(rope.utf16_cu_to_char(target))
 }
 
 // ── LanguageServer trait ────────────────────────────────────────
@@ -275,15 +279,18 @@ impl LanguageServer for Backend {
         };
 
         let text = doc.rope.to_string();
+        let cursor = position_to_byte(&doc.rope, pos);
+        let line_idx = doc.rope.byte_to_line(cursor);
+        let line_start = doc.rope.line_to_byte(line_idx);
+        let line_text = doc.rope.line(line_idx).to_string();
 
         // Check if cursor is on an SVar reference
-        if let Some(svar_name) = self.svar_ref_at_position(&text, pos) {
+        if let Some(svar_name) = self.svar_ref_at_position(&line_text, cursor - line_start) {
             if let Some(info) = doc.svars.get(svar_name) {
-                let svar_line = text.lines().nth(info.line as usize).unwrap_or("");
-                let value = &svar_line[info.value_start as usize..];
-                // Truncate at newline
-                let value = value.lines().next().unwrap_or(value);
-                let hover_text = format!("**SVar** `{}`\n\n```\n{}\n```", svar_name, value);
+                let value = text
+                    .get(info.value_start as usize..info.value_end as usize)
+                    .unwrap_or("");
+                let hover_text = format!("**SVar** `{svar_name}`\n\n```\n{value}\n```");
                 return Ok(Some(Hover {
                     contents: HoverContents::Markup(MarkupContent {
                         kind: MarkupKind::Markdown,
@@ -295,7 +302,7 @@ impl LanguageServer for Backend {
                 return Ok(Some(Hover {
                     contents: HoverContents::Markup(MarkupContent {
                         kind: MarkupKind::Markdown,
-                        value: format!("**SVar** `{}` — ⚠️ not defined on this card", svar_name),
+                        value: format!("**SVar** `{svar_name}` — ⚠️ not defined on this card"),
                     }),
                     range: None,
                 }));
@@ -303,22 +310,15 @@ impl LanguageServer for Backend {
         }
 
         // Check if cursor is on a param key — show semantic type
-        let _line_text = match text.lines().nth(pos.line as usize) {
-            Some(l) => l,
-            None => return Ok(None),
-        };
-
         let parsed = ParsedCardScript::parse(&text);
         for line in parsed.lines() {
-            if line.line_no != (pos.line as usize + 1) {
+            if line.line_no != line_idx + 1 {
                 continue;
             }
             match &line.kind {
                 ScriptLineKind::Ability(ability) => {
                     for entry in ability.params.entries() {
-                        if pos.character as usize >= entry.key_span.start - line.span.start
-                            && pos.character as usize <= entry.value_span.end - line.span.start
-                        {
+                        if cursor >= entry.key_span.start && cursor <= entry.value_span.end {
                             let sem = entry.semantic();
                             return Ok(Some(Hover {
                                 contents: HoverContents::Markup(MarkupContent {
@@ -339,9 +339,7 @@ impl LanguageServer for Backend {
                 | ScriptLineKind::StaticAbility(rec)
                 | ScriptLineKind::Replacement(rec) => {
                     for entry in rec.params.entries() {
-                        if pos.character as usize >= entry.key_span.start - line.span.start
-                            && pos.character as usize <= entry.value_span.end - line.span.start
-                        {
+                        if cursor >= entry.key_span.start && cursor <= entry.value_span.end {
                             let sem = entry.semantic();
                             return Ok(Some(Hover {
                                 contents: HoverContents::Markup(MarkupContent {
@@ -377,22 +375,18 @@ impl LanguageServer for Backend {
             None => return Ok(None),
         };
 
-        let text = doc.rope.to_string();
+        let cursor = position_to_byte(&doc.rope, pos);
+        let line_idx = doc.rope.byte_to_line(cursor);
+        let line_start = doc.rope.line_to_byte(line_idx);
+        let line_text = doc.rope.line(line_idx).to_string();
 
-        if let Some(svar_name) = self.svar_ref_at_position(&text, pos) {
+        if let Some(svar_name) = self.svar_ref_at_position(&line_text, cursor - line_start) {
             if let Some(info) = doc.svars.get(svar_name) {
-                let line_start = text
-                    .lines()
-                    .take(info.line as usize)
-                    .map(|l| l.len() + 1)
-                    .sum::<usize>();
-                let col = info.name_start as usize - line_start;
-
                 return Ok(Some(GotoDefinitionResponse::Scalar(Location {
                     uri: uri.clone(),
                     range: Range {
-                        start: Position::new(info.line, col as u32),
-                        end: Position::new(info.line, (col + svar_name.len()) as u32),
+                        start: byte_to_position(&doc.rope, info.name_start as usize),
+                        end: byte_to_position(&doc.rope, info.name_end as usize),
                     },
                 })));
             }

--- a/forge-engine/crates/forge-card-script/Cargo.toml
+++ b/forge-engine/crates/forge-card-script/Cargo.toml
@@ -2,6 +2,12 @@
 name = "forge-card-script"
 version = "0.1.0"
 edition = "2021"
+description = "Parser and intermediate representation for the Forge card-script DSL used by Magic: The Gathering rules engines"
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+keywords = ["mtg", "magic", "forge", "parser", "dsl"]
+categories = ["parser-implementations"]
 
 [dependencies]
 smallvec = "1"

--- a/forge-engine/crates/forge-card-script/README.md
+++ b/forge-engine/crates/forge-card-script/README.md
@@ -1,0 +1,50 @@
+# forge-card-script
+
+A parser and intermediate representation for the **Forge card-script DSL** — the line-oriented
+text format used to describe Magic: The Gathering cards in the
+[Forge](https://github.com/Card-Forge/forge) rules engine (`A:`, `T:`, `S:`, `R:`, `SVar:`,
+`K:` lines, `$`-delimited parameter records, faces, and so on).
+
+It is the shared front-end used by the [ManaBrew](https://github.com/witchesofthehill/manabrew)
+engine and by [`forge-card-script-lsp`](https://crates.io/crates/forge-card-script-lsp).
+
+## What it does
+
+- **Line classification** — splits a card script into typed lines (`Field`, `Ability`,
+  `Trigger`, `StaticAbility`, `Replacement`, `SVar`, `Keyword`, faces, …) with byte spans
+  preserved for every key and value.
+- **Parameter records** — parses `Key$ Value | Key$ Value` records, including SVar values that
+  nest abilities, parameter records, or numeric expressions (`Count$`, `Remembered$`, …).
+- **Diagnostics** — reports recoverable problems (missing `:`/`$`, empty keys, missing ability
+  record, duplicate parameters) with spans, without ever failing to parse.
+- **Semantic value typing** — `ParamEntry::semantic()` classifies a raw value into a
+  `SemanticParamValue` (amount, selector, zone list, cost, comparison, produced mana, …).
+
+```rust
+use forge_card_script::{ParsedCardScript, ScriptLineKind};
+
+let script = "Name:Lightning Bolt\n\
+              ManaCost:R\n\
+              Types:Instant\n\
+              A:SP$ DealDamage | ValidTgts$ Any | NumDmg$ 3\n";
+
+let parsed = ParsedCardScript::parse(script);
+assert!(parsed.diagnostics().is_empty());
+
+for ability in parsed.abilities() {
+    for param in ability.params.semantic_entries() {
+        println!("{} => {:?}", param.key, param.value);
+    }
+}
+```
+
+## A note on semantic typing
+
+`SemanticParamValue` classification is **heuristic** — it is driven by parameter-key name
+patterns, not by an authoritative schema of the DSL. It is intended to power editor affordances
+(hover, highlighting) and convenience accessors, not to be a complete or normative interpretation
+of every Forge parameter. Treat `Raw` as the always-correct fallback.
+
+## License
+
+GPL-3.0-or-later. See the repository for details.

--- a/forge-engine/crates/forge-card-script/src/lib.rs
+++ b/forge-engine/crates/forge-card-script/src/lib.rs
@@ -352,11 +352,15 @@ impl<'a> ParsedCardScript<'a> {
         let mut diagnostics = SmallVec::new();
         let mut offset = 0;
 
-        for (idx, line) in raw.lines().enumerate() {
+        for (idx, segment) in raw.split_inclusive('\n').enumerate() {
+            let line = segment
+                .strip_suffix('\n')
+                .map(|s| s.strip_suffix('\r').unwrap_or(s))
+                .unwrap_or(segment);
             let line_no = idx + 1;
             let parsed = parse_script_line(line, line_no, offset, &mut diagnostics);
             lines.push(parsed);
-            offset += line.len() + 1;
+            offset += segment.len();
         }
 
         Self {

--- a/tree-sitter-forge-card-script/Cargo.toml
+++ b/tree-sitter-forge-card-script/Cargo.toml
@@ -3,6 +3,12 @@ name = "tree-sitter-forge-card-script"
 version = "0.1.0"
 edition = "2021"
 build = "bindings/rust/build.rs"
+description = "Tree-sitter grammar for the Forge card-script DSL used by Magic: The Gathering rules engines"
+license = "MIT"
+repository.workspace = true
+readme = "README.md"
+keywords = ["tree-sitter", "mtg", "magic", "forge", "parser"]
+categories = ["parser-implementations"]
 
 [lib]
 path = "bindings/rust/lib.rs"

--- a/tree-sitter-forge-card-script/LICENSE
+++ b/tree-sitter-forge-card-script/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 khaliostr
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tree-sitter-forge-card-script/README.md
+++ b/tree-sitter-forge-card-script/README.md
@@ -1,0 +1,50 @@
+# tree-sitter-forge-card-script
+
+A [tree-sitter](https://tree-sitter.github.io/tree-sitter/) grammar for the **Forge card-script
+DSL** — the text format used to describe Magic: The Gathering cards in the
+[Forge](https://github.com/Card-Forge/forge) rules engine. Part of the
+[ManaBrew](https://github.com/witchesofthehill/manabrew) project.
+
+It parses the line-oriented card format: field lines (`Name:`, `ManaCost:`, …), ability/trigger/
+static/replacement lines (`A:`, `T:`, `S:`, `R:`), `SVar:` definitions, keyword (`K:`) lines,
+`$`-delimited parameter records, comments, and multi-face cards (`ALTERNATE`, `SPECIALIZE`,
+`AlternateMode`).
+
+## Usage
+
+The grammar is authored in `grammar.ts` (TypeScript DSL). Regenerate and test with the
+[tree-sitter CLI](https://github.com/tree-sitter/tree-sitter):
+
+```bash
+yarn install
+yarn generate      # tree-sitter generate
+yarn test          # runs the corpus tests under test/corpus/
+yarn parse <file>  # parse a card script and print its tree
+```
+
+Syntax-highlighting queries live in `queries/highlights.scm`.
+
+### Rust binding
+
+```toml
+[dependencies]
+tree-sitter = "0.24"
+tree-sitter-forge-card-script = "0.1"
+```
+
+```rust
+let mut parser = tree_sitter::Parser::new();
+parser.set_language(&tree_sitter_forge_card_script::language()).unwrap();
+let tree = parser.parse("Name:Grizzly Bears\nPT:2/2\n", None).unwrap();
+```
+
+## Coverage note
+
+The grammar recognises the common Forge field keys explicitly; an unrecognised `Key:` line will
+produce an error node. The companion [`forge-card-script`](https://crates.io/crates/forge-card-script)
+crate is more permissive and degrades unknown fields gracefully, so the two can disagree on
+unusual input.
+
+## License
+
+MIT. See [LICENSE](./LICENSE).

--- a/tree-sitter-forge-card-script/package.json
+++ b/tree-sitter-forge-card-script/package.json
@@ -4,6 +4,13 @@
   "description": "Tree-sitter grammar for the Forge Card Script DSL",
   "main": "bindings/node",
   "types": "bindings/node",
+  "license": "MIT",
+  "author": "khaliostr",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/witchesofthehill/manabrew.git",
+    "directory": "tree-sitter-forge-card-script"
+  },
   "keywords": [
     "tree-sitter",
     "parser",

--- a/tree-sitter-forge-card-script/tree-sitter.json
+++ b/tree-sitter-forge-card-script/tree-sitter.json
@@ -14,7 +14,7 @@
     "license": "MIT",
     "description": "Tree-sitter grammar for the Forge Card Script DSL",
     "links": {
-      "repository": "https://github.com/tree-sitter/tree-sitter-forge-card-script"
+      "repository": "https://github.com/witchesofthehill/manabrew"
     }
   },
   "bindings": {


### PR DESCRIPTION
## Summary
Polish + publish-prep for the three card-script modules (parser, LSP, tree-sitter grammar).

Correctness fixes:
- LSP positions are now UTF-16- and CRLF-correct (ropey-based byte↔position helpers), so diagnostics/hover/goto land correctly on cards with non-ASCII text (accented names, em-dashes).
- Fixed a latent panic in hover that sliced a single line with an absolute document byte offset (broke for any SVar past line 1).
- Fixed CRLF span drift in the core parser (`offset += line.len() + 1` terminator assumption → `split_inclusive`).

Polish: removed dead `SvarInfo.line` field + `#[allow(dead_code)]`, inlined format args, fixed the placeholder repo URL in `tree-sitter.json`.

Publish-readiness: descriptions / license / repository / readme / keywords / categories on all three crates, READMEs added, registry version on the lsp→parser dep. Grammar licensed **MIT** (parser/lsp stay **GPL-3.0-or-later**); npm metadata (author/license/repository) added for the grammar.

## Why
Sharing these to the Forge Discord and claiming the crate names. The position bugs would misalign editor highlights on real cards; the hover slice could panic the LSP.

## Test plan
- `cargo clippy -p forge-card-script -p forge-card-script-lsp -- -D warnings` — clean
- `cargo fmt --check` — clean
- `tree-sitter test` — 13/13 corpus tests pass
- `cargo publish --dry-run` — parser + grammar package and verify
- Runtime check: CRLF + Unicode spans land on correct bytes

## Build artifacts
- [ ] Build macOS .dmg
- [ ] Build Windows .exe
