### PR TITLE
fix(ui): fix card scale of battlegrounds

### DIFF
--- a/src/components/game/AGENTS.md
+++ b/src/components/game/AGENTS.md
@@ -48,14 +48,14 @@ Don't roll your own symbol parsing.
 
 Use the standard size constants. Don't invent pixel values.
 
-| Constant             | Usage                                                                              |
-| -------------------- | ---------------------------------------------------------------------------------- |
-| `BATTLEFIELD_CARD`   | `w-[70px] h-[98px]` — battlefield (where React is involved)                        |
-| `HAND_CARD`          | `w-[80px] h-[112px]` — hand / zone viewer                                          |
-| `HAND_CARD_BASES`    | Per-size pixel dims (`small`/`medium`/`large`) scaled at runtime by `useHandScale` |
-| `MODAL_CARD_SIZE`    | `w-[100px] h-[140px]` — cards inside modal grids                                   |
-| `MULLIGAN_CARD_SIZE` | `w-[160px] h-[222px]` — cards inside mulligan modals                               |
-| `FLASH_CARD_SIZE`    | `{ w: 310, h: 434 }` (numeric — for Pixi-rendered preview, not a Tailwind class)   |
+| Constant             | Usage                                                                                                                                       |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BATTLEFIELD_CARD`   | `w-[70px] h-[98px]` — battlefield (where React is involved)                                                                                 |
+| `HAND_CARD`          | `w-[80px] h-[112px]` — hand / zone viewer                                                                                                   |
+| `HAND_CARD_BASE`     | Hand-card base pixel dims, scaled at runtime by `useHandScale` (`HAND_FAN_PARAMS` in `pixi/HandLayout.ts` holds the fan spread/lift params) |
+| `MODAL_CARD_SIZE`    | `w-[100px] h-[140px]` — cards inside modal grids                                                                                            |
+| `MULLIGAN_CARD_SIZE` | `w-[160px] h-[222px]` — cards inside mulligan modals                                                                                        |
+| `FLASH_CARD_SIZE`    | `{ w: 310, h: 434 }` (numeric — for Pixi-rendered preview, not a Tailwind class)                                                            |
 
 ## Prompt routing
 

--- a/src/components/game/GameBoard.tsx
+++ b/src/components/game/GameBoard.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useCallback, useMemo, useRef, useState } from "react";
 import type { GameCard, Player } from "@/types/manabrew";
 import type { Prompt } from "@/protocol";
-import { usePreferencesStore, type ZonePanelItem } from "@/stores/usePreferencesStore";
+import { type ZonePanelItem } from "@/stores/usePreferencesStore";
 import { PixiGameCanvas } from "@/pixi/PixiGameCanvas";
 import { PixiPhaseStripCanvas } from "@/pixi/PixiPhaseStripCanvas";
 import type { BattlefieldState, GameCanvasCallbacks, ScreenBounds } from "@/pixi/types";
@@ -11,8 +11,8 @@ import type { PromptType } from "@/protocol";
 import { OpponentHalf, PlayerPanel } from "@/components/game/panels";
 import type { PlacementGhost } from "@/components/game/game.types";
 import { useHandScale } from "@/hooks/useHandScale";
-import { HAND_CARD_BASES } from "@/components/game/game.styles";
-import { computeBaseLayout, SIZE_PARAMS } from "@/pixi/HandLayout";
+import { HAND_CARD_BASE } from "@/components/game/game.styles";
+import { computeBaseLayout, HAND_FAN_PARAMS } from "@/pixi/HandLayout";
 import type { HandActionOption } from "@/stores/useGameUIStore";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { cn } from "@/lib/utils";
@@ -203,29 +203,26 @@ export function GameBoard({
   const selfStops = usePhaseStopStore((s) => s.selfStops);
   const toggleSelfStop = usePhaseStopStore((s) => s.toggleSelfStop);
 
-  const handSize = usePreferencesStore((s) => s.handSize);
   const vScale = useHandScale();
   // Reserve the visible portion of the hand for drag clamping. The hand
   // now sits lower (45% of card clipped below zone), so the reserved
   // strip is thinner — roughly 35% of the container height.
-  const handBottomReserved = Math.round(HAND_CARD_BASES[handSize].containerH * vScale * 0.35);
+  const handBottomReserved = Math.round(HAND_CARD_BASE.containerH * vScale * 0.35);
 
   const handWidth = useMemo(() => {
     if (myHand.length === 0) return 0;
-    const base = HAND_CARD_BASES[handSize];
-    const params = SIZE_PARAMS[handSize];
-    const cardW = Math.round(base.cardW * vScale);
+    const cardW = Math.round(HAND_CARD_BASE.cardW * vScale);
     const layout = computeBaseLayout(
       myHand.length,
       cardW,
-      Math.round(params.maxSpread * vScale),
-      Math.round(params.minSpread * vScale),
-      Math.round(params.spreadWidth * vScale),
+      Math.round(HAND_FAN_PARAMS.maxSpread * vScale),
+      Math.round(HAND_FAN_PARAMS.minSpread * vScale),
+      Math.round(HAND_FAN_PARAMS.spreadWidth * vScale),
     );
     if (layout.length === 0) return 0;
     const xs = layout.map((slot) => slot.x);
     return Math.max(...xs) - Math.min(...xs) + cardW;
-  }, [handSize, myHand.length, vScale]);
+  }, [myHand.length, vScale]);
 
   const CLUSTER_GAP_FROM_HAND_PX = 12;
   const CLUSTER_MIN_WIDTH_PX = 120;
@@ -361,35 +358,9 @@ export function GameBoard({
           ? onBattlefieldClick
           : undefined,
       onHoverCard: (card, bounds) => {
-        if (!card) {
-          onHoverCard(null);
-          return;
-        }
-        if (bounds) {
-          const syntheticEvent = {
-            clientX: bounds.x + bounds.width / 2,
-            clientY: bounds.y,
-            buttons: 0,
-            currentTarget: document.createElement("div"),
-            shiftKey: false,
-            altKey: false,
-            ctrlKey: false,
-            metaKey: false,
-          } as unknown as React.MouseEvent;
-          onHoverCard(card, syntheticEvent, {
-            useAnchor: true,
-            anchorOverride: {
-              left: bounds.x,
-              right: bounds.x + bounds.width,
-              top: bounds.y,
-              bottom: bounds.y + bounds.height,
-              width: bounds.width,
-              height: bounds.height,
-              x: bounds.x,
-              y: bounds.y,
-              toJSON: () => ({}),
-            } as DOMRect,
-          });
+        if (card && bounds) {
+          const rect = new DOMRect(bounds.x, bounds.y, bounds.width, bounds.height);
+          onHoverCard(card, undefined, { useAnchor: true, anchorOverride: rect });
         } else {
           onHoverCard(null);
         }
@@ -711,6 +682,7 @@ export function GameBoard({
               </div>
               <div className="absolute inset-0 z-10 overflow-hidden">
                 <PixiGameCanvas
+                  boardId="self"
                   battlefield={pixiBattlefield}
                   hand={pixiHand}
                   sceneRef={pixiSceneRef}

--- a/src/components/game/game.styles.ts
+++ b/src/components/game/game.styles.ts
@@ -22,11 +22,7 @@ export const BATTLEFIELD_CARD = "w-[70px] h-[98px] shrink-0" as const;
 export const HAND_CARD = "w-[80px] h-[112px]" as const;
 
 /** Base hand card sizes at 1920px reference width (scaled at runtime by useHandScale). */
-export const HAND_CARD_BASES = {
-  small: { cardW: 80, cardH: 112, containerH: 140 },
-  medium: { cardW: 130, cardH: 182, containerH: 220 },
-  large: { cardW: 170, cardH: 238, containerH: 280 },
-} as const;
+export const HAND_CARD_BASE = { cardW: 130, cardH: 182, containerH: 220 } as const;
 /** Cards inside modal grids (e.g., LibraryPeekModal, SpellStackModal, ZoneTargetSelector) */
 export const MODAL_CARD_SIZE = "w-[100px] h-[140px]" as const;
 /** Large preview card (e.g., CardPreview floating overlay) */

--- a/src/components/game/panels/OpponentHalf.tsx
+++ b/src/components/game/panels/OpponentHalf.tsx
@@ -14,7 +14,6 @@ const OPPONENT_SCENE_OPTIONS = {
 } as const;
 
 const OPPONENT_PANEL_SCALE = 0.72;
-const OPPONENT_MIN_ROWS = 3;
 const PANEL_EDGE_OFFSET_PX = 8;
 const PANEL_GAP_PX = 8;
 const PANEL_BOX_FALLBACK = { width: 260, height: 120 } as const;
@@ -179,11 +178,11 @@ export function OpponentHalf({
           </div>
           <div className="absolute inset-0 z-10 rounded-lg overflow-hidden">
             <PixiGameCanvas
+              boardId={player.id}
               battlefield={pixiBattlefield}
               sceneRef={pixiSceneRef}
               callbacks={pixiCallbacks}
               topLeftReserved={panelBox}
-              minRows={OPPONENT_MIN_ROWS}
               bottomReserved={0}
               externalBlockers={[]}
               sceneOptions={OPPONENT_SCENE_OPTIONS}

--- a/src/hooks/useBattlefieldCardScale.ts
+++ b/src/hooks/useBattlefieldCardScale.ts
@@ -1,0 +1,18 @@
+import { usePreferencesStore } from "@/stores/usePreferencesStore";
+import { useBattlefieldScaleStore } from "@/stores/useBattlefieldScaleStore";
+import { battlefieldScaleForFraction } from "@/pixi/GridLayout";
+import { BATTLEFIELD_CARD_SCALE_DEFAULT } from "@/pixi/constants";
+
+export function useBattlefieldCardScale() {
+  const fraction = usePreferencesStore((s) => s.battlefieldCardScale);
+  const setFraction = usePreferencesStore((s) => s.setBattlefieldCardScale);
+  return { fraction, setFraction };
+}
+
+export function useResolvedBattlefieldScale(): number {
+  const fraction = usePreferencesStore((s) => s.battlefieldCardScale);
+  const usableHeights = useBattlefieldScaleStore((s) => s.usableHeights);
+  const heights = Object.values(usableHeights);
+  if (heights.length === 0) return BATTLEFIELD_CARD_SCALE_DEFAULT;
+  return battlefieldScaleForFraction(Math.min(...heights), fraction);
+}

--- a/src/hooks/useCardPreview.ts
+++ b/src/hooks/useCardPreview.ts
@@ -91,15 +91,15 @@ export function useCardPreview(dismissDeps: unknown[] = []) {
 
       if (e) {
         setMousePos({ x: e.clientX, y: e.clientY });
-        if (options.anchorOverride) {
-          setAnchorRect(options.anchorOverride);
-        } else if (options.useAnchor) {
-          setAnchorRect((e.currentTarget as HTMLElement).getBoundingClientRect());
-        } else {
-          setAnchorRect(null);
-        }
-        setPlacement(options.placement ?? "auto");
       }
+      if (options.anchorOverride) {
+        setAnchorRect(options.anchorOverride);
+      } else if (options.useAnchor && e) {
+        setAnchorRect((e.currentTarget as HTMLElement).getBoundingClientRect());
+      } else {
+        setAnchorRect(null);
+      }
+      setPlacement(options.placement ?? "auto");
 
       const delay = options.useDelay ? cardHoverDelayMs : 0;
 

--- a/src/pixi/GridLayout.ts
+++ b/src/pixi/GridLayout.ts
@@ -6,7 +6,12 @@
  */
 
 import { CARD_W, CARD_H } from "@/components/game/game.constants";
-import { GAP } from "./constants";
+import {
+  GAP,
+  BATTLEFIELD_MIN_ROWS,
+  BATTLEFIELD_MAX_ROWS,
+  BATTLEFIELD_CARD_SCALE_FLOOR,
+} from "./constants";
 import type { PlayZoneRect } from "./types";
 
 export interface GridBlocker {
@@ -50,6 +55,17 @@ export const cellKey = (col: number, row: number): string => `${col},${row}`;
 export const maxScaleForRows = (usableH: number, rows: number): number => {
   const cellH = (usableH + GAP) / rows - 0.5;
   return (cellH - GAP) / (CARD_H * (1 + CELL_BREATHING_FRAC));
+};
+
+export const battlefieldScaleForFraction = (usableH: number, fraction: number): number => {
+  const f = Math.min(1, Math.max(0, fraction));
+  const floor = BATTLEFIELD_CARD_SCALE_FLOOR;
+  const maxScale = Math.max(floor, maxScaleForRows(usableH, BATTLEFIELD_MIN_ROWS));
+  const minScale = Math.max(
+    floor,
+    Math.min(maxScale, maxScaleForRows(usableH, BATTLEFIELD_MAX_ROWS)),
+  );
+  return minScale + f * (maxScale - minScale);
 };
 
 /**

--- a/src/pixi/HandLayout.ts
+++ b/src/pixi/HandLayout.ts
@@ -3,28 +3,12 @@ const MAX_ARC_DEG = 30;
 
 export const HOVER_SCALE = 1.8;
 
-export const SIZE_PARAMS = {
-  small: {
-    hoverLift: 40,
-    neighborPush: 30,
-    maxSpread: 56,
-    minSpread: 24,
-    spreadWidth: 560,
-  },
-  medium: {
-    hoverLift: 70,
-    neighborPush: 48,
-    maxSpread: 90,
-    minSpread: 38,
-    spreadWidth: 900,
-  },
-  large: {
-    hoverLift: 90,
-    neighborPush: 62,
-    maxSpread: 118,
-    minSpread: 50,
-    spreadWidth: 1180,
-  },
+export const HAND_FAN_PARAMS = {
+  hoverLift: 70,
+  neighborPush: 78,
+  maxSpread: 90,
+  minSpread: 38,
+  spreadWidth: 900,
 } as const;
 
 export interface BaseCardLayout {

--- a/src/pixi/PixiGameCanvas.tsx
+++ b/src/pixi/PixiGameCanvas.tsx
@@ -17,6 +17,8 @@ import type {
   PlayZoneRect,
 } from "./types";
 import { useHandScale } from "@/hooks/useHandScale";
+import { useResolvedBattlefieldScale } from "@/hooks/useBattlefieldCardScale";
+import { useBattlefieldScaleStore } from "@/stores/useBattlefieldScaleStore";
 import { HandCardActions } from "@/components/game/zones/HandCardActions";
 import type { HandActionOption } from "@/stores/useGameUIStore";
 import type { GameCard } from "@/types/manabrew";
@@ -53,8 +55,9 @@ interface PixiGameCanvasProps {
   leftReserved?: number;
   /** Keep-out box at the top-left for the opponent panel cluster. */
   topLeftReserved?: { width: number; height: number } | null;
-  /** Auto-fit the card scale so at least this many rows always render. */
-  minRows?: number;
+  /** Unique id for this board, used to report its usable height into the
+   *  shared cross-board scale calculation. */
+  boardId: string;
   /** Keep-out size anchored to the bottom-left of the canvas — the player
    *  panel cluster (avatar + zones + mana). */
   bottomLeftReserved?: { width: number; height: number } | null;
@@ -93,7 +96,7 @@ export function PixiGameCanvas({
   bottomReserved = 0,
   leftReserved = 0,
   topLeftReserved,
-  minRows,
+  boardId,
   bottomLeftReserved,
   externalBlockers,
   bottomRightReserved,
@@ -108,6 +111,7 @@ export function PixiGameCanvas({
   const [scene, setScene] = useState<PixiGameScene | null>(null);
   const sceneRef = useRef<PixiGameScene | null>(null);
   const callbacksRef = useRef(callbacks);
+  const reportUsableHeightRef = useRef<(height: number) => void>(() => {});
   // Scene construction options are read once when the scene is built.
   // Store them in a ref so the init callback's dependency list stays
   // stable (the `initApp` useCallback would otherwise rebuild the scene
@@ -126,6 +130,13 @@ export function PixiGameCanvas({
   useEffect(() => {
     callbacksRef.current = callbacks;
   }, [callbacks]);
+
+  const reportUsableHeight = useBattlefieldScaleStore((s) => s.reportUsableHeight);
+  const clearBoard = useBattlefieldScaleStore((s) => s.clearBoard);
+  useEffect(() => {
+    reportUsableHeightRef.current = (height: number) => reportUsableHeight(boardId, height);
+  }, [reportUsableHeight, boardId]);
+  useEffect(() => () => clearBoard(boardId), [clearBoard, boardId]);
 
   const cancelHandHoverClear = useCallback(() => {
     if (clearTimerRef.current != null) {
@@ -197,6 +208,7 @@ export function PixiGameCanvas({
         onClickCard_Hand: (...args) => callbacksRef.current.onClickCard_Hand?.(...args),
         onCastSpell: (...args) => callbacksRef.current.onCastSpell?.(...args),
         onDismissHoverPreview: () => callbacksRef.current.onDismissHoverPreview?.(),
+        onUsableHeightChange: (height) => reportUsableHeightRef.current(height),
         onHoverHandCard: (card, bounds) => {
           if (card && bounds) {
             cancelHandHoverClear();
@@ -273,39 +285,29 @@ export function PixiGameCanvas({
     return unsub;
   }, [scene]);
 
-  const handSize = usePreferencesStore((s) => s.handSize);
-  const battlefieldCardScale = usePreferencesStore((s) => s.battlefieldCardScale);
+  const resolvedCardScale = useResolvedBattlefieldScale();
   const vScale = useHandScale();
 
   useEffect(() => {
     if (!scene) return;
-    scene.setBattlefieldCardScale(battlefieldCardScale);
-  }, [scene, battlefieldCardScale]);
+    scene.setCardScale(resolvedCardScale);
+  }, [scene, resolvedCardScale]);
 
   useEffect(() => {
     if (!scene) return;
     scene.setReserved(bottomReserved, leftReserved);
     scene.setBottomLeftReserved(bottomLeftReserved ?? null);
     scene.setTopLeftReserved(topLeftReserved ?? null);
-    scene.setMinRows(minRows ?? null);
     scene.updateBattlefield(battlefield);
-  }, [
-    scene,
-    battlefield,
-    bottomReserved,
-    leftReserved,
-    topLeftReserved,
-    minRows,
-    bottomLeftReserved,
-  ]);
+  }, [scene, battlefield, bottomReserved, leftReserved, topLeftReserved, bottomLeftReserved]);
 
   useEffect(() => {
     if (!scene) return;
-    scene.setHandPreferences(handSize, vScale);
+    scene.setHandScale(vScale);
     scene.updateHand(hand ?? { cards: [] });
     // Hand dimensions changed → blocker rect changed → re-layout battlefield
     scene.updateBattlefield(battlefield);
-  }, [scene, hand, handSize, vScale, battlefield]);
+  }, [scene, hand, vScale, battlefield]);
 
   useEffect(() => {
     if (!scene) return;

--- a/src/pixi/PixiGameScene.ts
+++ b/src/pixi/PixiGameScene.ts
@@ -15,7 +15,6 @@ import type {
   GameCanvasCallbacks,
   BattlefieldState,
   HandState,
-  HandSize,
   PlayZoneRect,
   ScreenPos,
   ScreenBounds,
@@ -38,13 +37,12 @@ import {
   cellFromPoint,
   cellsByDistance,
   cellKey,
-  maxScaleForRows,
   type GridCell,
   type GridLayoutInfo,
 } from "./GridLayout";
-import { computeBaseLayout, computeHandLayout, SIZE_PARAMS } from "./HandLayout";
+import { computeBaseLayout, computeHandLayout, HAND_FAN_PARAMS } from "./HandLayout";
 import { ArrowLayer, type ArrowDef } from "./ArrowLayer";
-import { HAND_CARD_BASES } from "@/components/game/game.styles";
+import { HAND_CARD_BASE } from "@/components/game/game.styles";
 import { extractManaLetters, getExpandedManaAbilities } from "@/components/game/manaUtils";
 import {
   getManaSymbolTextureSync,
@@ -54,9 +52,7 @@ import {
 import { manaColorFor } from "./manaColors";
 import {
   ATTACH_OFFSET_Y,
-  BATTLEFIELD_CARD_SCALE_AUTOFIT_MIN,
   BATTLEFIELD_CARD_SCALE_DEFAULT,
-  BATTLEFIELD_CARD_SCALE_MAX,
   OPPONENT_PANEL_FULLWIDTH_FRAC,
   BATTLEFIELD_HOVER_HOLD_MS,
   BATTLEFIELD_LERP,
@@ -238,7 +234,7 @@ export class PixiGameScene {
    *  panel's footprint is reserved, so the lands row still fills the rest of
    *  the top edge. */
   private topLeftReserved: { width: number; height: number } | null = null;
-  private minRows: number | null = null;
+  private lastReportedHeight = 0;
   /**
    * Set in `destroy()` so any late-firing effects (React unmount races) that
    * still hold a reference to this instance short-circuit instead of touching
@@ -288,7 +284,6 @@ export class PixiGameScene {
   private handHoverHoldTimer: number | null = null;
   private pendingHandHoverLeaveIndex: number | null = null;
   private lastHandState: HandState | null = null;
-  private handSize: HandSize = "medium";
   private vScale = 1;
   private arrowLayer: ArrowLayer;
   /** Current arrow specs. Resolved to canvas-local ArrowDefs every tick so
@@ -476,6 +471,7 @@ export class PixiGameScene {
   setBottomRightReserved(size: { width: number; height: number } | null): void {
     if (this.destroyed) return;
     this.bottomRightReserved = size;
+    this.reportUsableHeight();
     this.syncDragBlockers();
     if (this.lastState) this.updateBattlefield(this.lastState);
   }
@@ -487,6 +483,7 @@ export class PixiGameScene {
   setBottomLeftReserved(size: { width: number; height: number } | null): void {
     if (this.destroyed) return;
     this.bottomLeftReserved = size;
+    this.reportUsableHeight();
     this.syncDragBlockers();
     if (this.lastState) this.updateBattlefield(this.lastState);
   }
@@ -494,7 +491,7 @@ export class PixiGameScene {
   setTopLeftReserved(size: { width: number; height: number } | null): void {
     if (this.destroyed) return;
     this.topLeftReserved = size;
-    this.recomputeAutoFitScale();
+    this.reportUsableHeight();
     this.syncDragBlockers();
     if (this.lastState) this.updateBattlefield(this.lastState);
   }
@@ -508,24 +505,6 @@ export class PixiGameScene {
 
   private topReserveInset(): number {
     return this.topReserveIsFullWidth() ? this.topLeftReserved!.height : 0;
-  }
-
-  setMinRows(rows: number | null): void {
-    if (this.destroyed) return;
-    if (rows === this.minRows) return;
-    this.minRows = rows;
-    this.recomputeAutoFitScale();
-    if (this.lastState) this.updateBattlefield(this.lastState);
-  }
-
-  private recomputeAutoFitScale(): void {
-    if (this.minRows == null) return;
-    const fit = maxScaleForRows(this.getPlayZone().height, this.minRows);
-    this.cardScale = Math.max(
-      BATTLEFIELD_CARD_SCALE_AUTOFIT_MIN,
-      Math.min(BATTLEFIELD_CARD_SCALE_MAX, fit),
-    );
-    this.dragHandler.setCardScale(this.cardScale);
   }
 
   private syncDragBlockers(): void {
@@ -552,26 +531,38 @@ export class PixiGameScene {
     return rects;
   }
 
-  setHandPreferences(size: HandSize, scale: number): void {
+  setHandScale(scale: number): void {
     if (this.destroyed) return;
-    this.handSize = size;
     this.vScale = scale;
+    this.reportUsableHeight();
   }
 
-  /**
-   * Resize all battlefield cards (and the grid cells they snap to). Accepts
-   * a uniform multiplier; the caller is responsible for clamping to a sane
-   * range. Triggers a relayout so existing sprites reflow into the resized
-   * grid immediately.
-   */
-  setBattlefieldCardScale(scale: number): void {
-    if (this.destroyed) return;
-    if (this.minRows != null) return;
-    if (!Number.isFinite(scale) || scale <= 0) return;
+  setCardScale(scale: number): void {
+    if (this.destroyed || !Number.isFinite(scale) || scale <= 0) return;
     if (scale === this.cardScale) return;
     this.cardScale = scale;
     this.dragHandler.setCardScale(scale);
     if (this.lastState) this.updateBattlefield(this.lastState);
+  }
+
+  private reportUsableHeight(): void {
+    const height = this.usableGridHeight();
+    if (height === this.lastReportedHeight) return;
+    this.lastReportedHeight = height;
+    this.callbacks.onUsableHeightChange?.(height);
+  }
+
+  private usableGridHeight(): number {
+    const zone = this.getPlayZone();
+    const handBlockerTop = this.showHand
+      ? this.handBottomY() - this.computeHandDimensions().cardH - GAP
+      : zone.y + zone.height;
+    const panelStrip = Math.max(
+      this.bottomLeftReserved?.height ?? 0,
+      this.bottomRightReserved?.height ?? 0,
+    );
+    const usableBottom = Math.min(handBlockerTop, zone.y + zone.height - panelStrip);
+    return Math.max(CARD_H, usableBottom - zone.y);
   }
 
   resize(width: number, height: number): void {
@@ -582,7 +573,7 @@ export class PixiGameScene {
     this.emptyText.y = this.zoneCenterY();
     // dragHandler clamps into the play-zone rect when one is set; otherwise
     // the full canvas.
-    this.recomputeAutoFitScale();
+    this.reportUsableHeight();
     const zone = this.getPlayZone();
     this.dragHandler.setContainerSize(zone.width, zone.height);
     // Bottom-right reserved rect is anchored to canvas size — re-resolve
@@ -2338,19 +2329,21 @@ export class PixiGameScene {
   }
 
   private computeHandDimensions() {
-    const base = HAND_CARD_BASES[this.handSize];
-    const params = SIZE_PARAMS[this.handSize];
+    const base = HAND_CARD_BASE;
+    const params = HAND_FAN_PARAMS;
     // `vScale` comes from the `useHandScale` hook. Using it directly
     // keeps the Pixi hand consistent across mulligan and normal play.
     const scale = this.vScale;
+    const cardW = Math.round(base.cardW * scale);
+    const available = Math.max(cardW, this.getPlayZone().width - cardW);
     return {
-      cardW: Math.round(base.cardW * scale),
+      cardW,
       cardH: Math.round(base.cardH * scale),
       hoverLift: Math.round(params.hoverLift * scale),
       neighborPush: Math.round(params.neighborPush * scale),
       maxSpread: Math.round(params.maxSpread * scale),
       minSpread: Math.round(params.minSpread * scale),
-      spreadWidth: Math.round(params.spreadWidth * scale),
+      spreadWidth: Math.min(Math.round(params.spreadWidth * scale), available),
     };
   }
 

--- a/src/pixi/constants.ts
+++ b/src/pixi/constants.ts
@@ -16,12 +16,11 @@ export const MAX_GRID_SLOTS = 200;
 
 // ── Battlefield card scale ─────────────────────────────────────────────────
 // Multiplier applied to battlefield sprites (and their grid cell footprint).
-// 1.0 is the baseline size; default is slightly bigger. User-adjustable via
-// the Settings page.
 export const BATTLEFIELD_CARD_SCALE_DEFAULT = 1.15;
-export const BATTLEFIELD_CARD_SCALE_MIN = 0.8;
-export const BATTLEFIELD_CARD_SCALE_MAX = 1.8;
-export const BATTLEFIELD_CARD_SCALE_AUTOFIT_MIN = 0.5;
+// Absolute floor so cards never go microscopic on very short displays.
+export const BATTLEFIELD_CARD_SCALE_FLOOR = 0.5;
+export const BATTLEFIELD_MIN_ROWS = 3;
+export const BATTLEFIELD_MAX_ROWS = 4;
 // Panel wider than this fraction of the canvas reserves the whole top row.
 export const OPPONENT_PANEL_FULLWIDTH_FRAC = 0.4;
 

--- a/src/pixi/types.ts
+++ b/src/pixi/types.ts
@@ -1,7 +1,4 @@
 import type { GameCard, ActivatableAbilityInfo } from "@/types/manabrew";
-import type { HAND_CARD_BASES } from "@/components/game/game.styles";
-
-export type HandSize = keyof typeof HAND_CARD_BASES;
 
 export interface ScreenBounds {
   x: number;
@@ -100,6 +97,7 @@ export interface GameCanvasCallbacks {
    * the scene begins a drag so the preview doesn't linger on the cursor.
    */
   onDismissHoverPreview?: () => void;
+  onUsableHeightChange?: (height: number) => void;
 }
 
 export interface BattlefieldState {

--- a/src/stores/useBattlefieldScaleStore.ts
+++ b/src/stores/useBattlefieldScaleStore.ts
@@ -1,0 +1,24 @@
+import { create } from "zustand";
+
+interface BattlefieldScaleState {
+  usableHeights: Record<string, number>;
+  reportUsableHeight: (boardId: string, height: number) => void;
+  clearBoard: (boardId: string) => void;
+}
+
+export const useBattlefieldScaleStore = create<BattlefieldScaleState>((set) => ({
+  usableHeights: {},
+  reportUsableHeight: (boardId, height) =>
+    set((state) =>
+      state.usableHeights[boardId] === height
+        ? state
+        : { usableHeights: { ...state.usableHeights, [boardId]: height } },
+    ),
+  clearBoard: (boardId) =>
+    set((state) => {
+      if (!(boardId in state.usableHeights)) return state;
+      const next = { ...state.usableHeights };
+      delete next[boardId];
+      return { usableHeights: next };
+    }),
+}));

--- a/src/stores/usePreferencesStore.ts
+++ b/src/stores/usePreferencesStore.ts
@@ -4,7 +4,6 @@ import { getServerConnectionDefaults } from "@/config/webRuntimeConfig";
 import { STORAGE_KEYS } from "@/lib/constants";
 
 export type ZonePanelItem = "library" | "graveyard" | "exile";
-export type HandSize = "small" | "medium" | "large";
 export type CardPreviewMode = "hover" | "shift" | "alt" | "ctrl";
 
 interface PreferencesState {
@@ -30,13 +29,8 @@ interface PreferencesState {
   zonePanelOrder: ZonePanelItem[];
   setZonePanelOrder: (order: ZonePanelItem[]) => void;
 
-  /** Hand card size */
-  handSize: HandSize;
-  setHandSize: (size: HandSize) => void;
-
-  /** Multiplier applied to battlefield card sprites and the grid cells they snap into. */
   battlefieldCardScale: number;
-  setBattlefieldCardScale: (scale: number) => void;
+  setBattlefieldCardScale: (fraction: number) => void;
 
   /** Card preview trigger mode */
   cardPreviewMode: CardPreviewMode;
@@ -65,7 +59,6 @@ const PERSISTED_PREFERENCE_KEYS = [
   "serverUsername",
   "serverPassword",
   "zonePanelOrder",
-  "handSize",
   "battlefieldCardScale",
   "cardPreviewMode",
   "cardHoverDelayMs",
@@ -117,12 +110,9 @@ export const usePreferencesStore = create<PreferencesState>()(
           zonePanelOrder: ["library", "graveyard", "exile"],
           setZonePanelOrder: (zonePanelOrder) => set({ zonePanelOrder }),
 
-          handSize: "medium",
-          setHandSize: (handSize) => set({ handSize }),
-
-          battlefieldCardScale: 1.15,
+          battlefieldCardScale: 0.5,
           setBattlefieldCardScale: (battlefieldCardScale) =>
-            set({ battlefieldCardScale: Math.max(0.8, Math.min(1.8, battlefieldCardScale)) }),
+            set({ battlefieldCardScale: Math.max(0, Math.min(1, battlefieldCardScale)) }),
 
           cardPreviewMode: "hover",
           setCardPreviewMode: (cardPreviewMode) => set({ cardPreviewMode }),

--- a/src/views/Game.tsx
+++ b/src/views/Game.tsx
@@ -23,7 +23,7 @@ import { buildArrowSpecs } from "@/components/game/arrowSpecs";
 import { buildPointerSpecs } from "@/components/game/pointerSpecs";
 import { ANY_COLOR_LETTERS } from "@/components/game/manaUtils";
 import { PlayModePicker } from "@/components/game/PlayModePicker";
-import { HAND_CARD_BASES } from "@/components/game/game.styles";
+import { HAND_CARD_BASE } from "@/components/game/game.styles";
 import { useHandScale } from "@/hooks/useHandScale";
 import { useFlashQueue } from "@/hooks/useFlashQueue";
 import { useHandDrag } from "@/hooks/useHandDrag";
@@ -133,10 +133,9 @@ export default function Game({ exitTo }: GameProps = {}) {
   );
   const flashDurationMs = usePreferencesStore((s) => s.flashDurationMs);
   const zonePanelOrder = usePreferencesStore((s) => s.zonePanelOrder);
-  const handSize = usePreferencesStore((s) => s.handSize);
   const vScale = useHandScale();
-  const ghostCardW = Math.round(HAND_CARD_BASES[handSize].cardW * vScale);
-  const ghostCardH = Math.round(HAND_CARD_BASES[handSize].cardH * vScale);
+  const ghostCardW = Math.round(HAND_CARD_BASE.cardW * vScale);
+  const ghostCardH = Math.round(HAND_CARD_BASE.cardH * vScale);
   const themeColors = useTheme().gameTheme;
   const location = useLocation();
   const devExtraOpponents =
@@ -835,7 +834,7 @@ export default function Game({ exitTo }: GameProps = {}) {
   const battlefieldContainerRef = useRef<HTMLDivElement>(null);
   const { draggingHandCard, ghostPos, isOverBattlefield, startHandCardDrag } = useHandDrag({
     battlefieldContainerRef,
-    handDropExclusionPx: Math.round(HAND_CARD_BASES[handSize].containerH * vScale * 0.35),
+    handDropExclusionPx: Math.round(HAND_CARD_BASE.containerH * vScale * 0.35),
     onCastSpell: handleCastSpell,
     dismissHover: preview.dismiss,
   });

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -7,6 +7,7 @@ import { PromptPreferencesPanel } from "@/components/game/prompts/PromptPreferen
 import { toPickerHexColor } from "@/themes/gameTheme";
 import type { GameThemeColors } from "@/themes/gameTheme";
 import { getDefaultGameThemeColorMap } from "@/hooks/useTheme";
+import { useBattlefieldCardScale } from "@/hooks/useBattlefieldCardScale";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
@@ -343,6 +344,8 @@ const HOVER_DELAY_STEP = 50;
 export default function Settings() {
   const isGameActive = useGameStore((s) => s.isGameActive);
   const prefs = usePreferencesStore();
+  const { fraction: battlefieldSizeFraction, setFraction: setBattlefieldSizeFraction } =
+    useBattlefieldCardScale();
   const { flashDurationMs, setFlashDurationMs } = prefs;
   const server = useServerStore();
   const { theme, setTheme, resolvedTheme } = useColorMode();
@@ -578,71 +581,30 @@ export default function Settings() {
             </div>
 
             <div className="rounded-lg border bg-card/40 p-4 space-y-2">
-              <Label>Hand Card Size</Label>
-              <div className="flex items-center gap-2">
-                <Button
-                  variant={prefs.handSize === "small" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => prefs.setHandSize("small")}
-                >
-                  Small
-                </Button>
-                <Button
-                  variant={prefs.handSize === "medium" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => prefs.setHandSize("medium")}
-                >
-                  Medium
-                </Button>
-                <Button
-                  variant={prefs.handSize === "large" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => prefs.setHandSize("large")}
-                >
-                  Large
-                </Button>
-              </div>
-              <p className="text-xs text-muted-foreground">
-                Controls the size of cards displayed in your hand.
-              </p>
-            </div>
-
-            <div className="rounded-lg border bg-card/40 p-4 space-y-2">
-              <Label>Battlefield Card Size ({Math.round(prefs.battlefieldCardScale * 100)}%)</Label>
+              <Label>Battlefield Card Size ({Math.round(battlefieldSizeFraction * 100)}%)</Label>
               <input
                 type="range"
-                min={80}
-                max={180}
+                min={0}
+                max={100}
                 step={5}
-                value={Math.round(prefs.battlefieldCardScale * 100)}
-                onChange={(e) => prefs.setBattlefieldCardScale(Number(e.target.value) / 100)}
+                value={Math.round(battlefieldSizeFraction * 100)}
+                onChange={(e) => setBattlefieldSizeFraction(Number(e.target.value) / 100)}
                 className="w-full accent-primary"
               />
               <div className="flex items-center gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => prefs.setBattlefieldCardScale(1.0)}
-                >
-                  100%
+                <Button variant="outline" size="sm" onClick={() => setBattlefieldSizeFraction(0)}>
+                  Smallest
                 </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => prefs.setBattlefieldCardScale(1.15)}
-                >
+                <Button variant="outline" size="sm" onClick={() => setBattlefieldSizeFraction(0.5)}>
                   Default
                 </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => prefs.setBattlefieldCardScale(1.4)}
-                >
-                  Large
+                <Button variant="outline" size="sm" onClick={() => setBattlefieldSizeFraction(1)}>
+                  Largest
                 </Button>
               </div>
               <p className="text-xs text-muted-foreground">
-                Controls the size of cards (and the grid they snap into) on the battlefield.
+                Controls the size of cards on the battlefield. The largest setting still keeps at
+                least 3 rows visible on any display.
               </p>
             </div>
 


### PR DESCRIPTION
## Summary
* Adjust setting card scale so that theres always at least 3 visible rows
* Adjust scaling so that all battlegrounds render cards of the same size
* Fix battleground card preview being missplaced when hovering on an opponent's card

## Build artifacts
<!--
  Check the boxes below to build the corresponding installer on merge to main
  (uploaded to the Actions run, 30-day retention).
  Leave unchecked to skip — faster CI, no binaries produced.
  Tag pushes (v*) always build both and publish a GitHub Release regardless.
-->
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
