### PR TITLE
fix(hosted): label cast options by alternative cost

### DIFF
--- a/forge-engine/crates/forge-agent-interface/src/java_prompt_normalizer.rs
+++ b/forge-engine/crates/forge-agent-interface/src/java_prompt_normalizer.rs
@@ -1060,16 +1060,21 @@ fn java_action_kind(kind: Option<&str>) -> Option<&'static str> {
 
 fn format_action_label(label: &str) -> String {
     let normalized = strip_action_suffix(label);
-    let Some((kind, card_name)) = normalized.split_once(':') else {
+    let Some((kind, rest)) = normalized.split_once(':') else {
         return normalized;
     };
+    let (card_name, alt_cost) = match rest.split_once('#') {
+        Some((name, alt)) => (name, Some(alt)),
+        None => (rest, None),
+    };
     let display_name = action_display_name(card_name);
+    let alt_suffix = alt_cost.map(|alt| format!(" ({alt})")).unwrap_or_default();
     match kind {
-        "LAND" => format!("Play {display_name}"),
-        "SPELL" => format!("Cast {display_name}"),
-        "CYCLE" => format!("Cycle {display_name}"),
-        "MANA" => format!("Activate mana: {display_name}"),
-        "AB" => format!("Activate {display_name}"),
+        "LAND" => format!("Play {display_name}{alt_suffix}"),
+        "SPELL" => format!("Cast {display_name}{alt_suffix}"),
+        "CYCLE" => format!("Cycle {display_name}{alt_suffix}"),
+        "MANA" => format!("Activate mana: {display_name}{alt_suffix}"),
+        "AB" => format!("Activate {display_name}{alt_suffix}"),
         _ => normalized,
     }
 }

--- a/forge-harness/src/main/java/forge/harness/common/ActionSpace.java
+++ b/forge-harness/src/main/java/forge/harness/common/ActionSpace.java
@@ -14,6 +14,7 @@ import forge.game.card.CardLists;
 import forge.game.card.CardPredicates;
 import forge.game.player.Player;
 import forge.game.spellability.AbilityManaPart;
+import forge.game.spellability.AlternativeCost;
 import forge.game.spellability.SpellAbility;
 import forge.game.spellability.SpellAbilityStackInstance;
 import forge.game.spellability.TargetRestrictions;
@@ -39,13 +40,14 @@ public final class ActionSpace {
         final String kind = sa.isCycling() ? "CYCLE"
                 : (sa.isLandAbility() ? "LAND"
                 : (sa.isSpell() ? "SPELL" : (sa.isManaAbility() ? "MANA" : "AB")));
-        final String fbTag = sa.isFlashback() ? "[FB]" : "";
+        final AlternativeCost altCost = sa.getAlternativeCost();
+        final String altTag = altCost == null ? "" : "#" + altCost.name();
         final String hostName = sa.getHostCard().getName();
         final String faceName = sa.getCardState() == null ? hostName : sa.getCardState().getName();
         final String name = faceName == null || faceName.isBlank() || faceName.equals(hostName)
                 ? hostName
                 : hostName + "|" + faceName;
-        return kind + ":" + name + fbTag;
+        return kind + ":" + name + altTag;
     }
 
     public static List<String> buildMainActionLabels(final List<SpellAbility> actions) {


### PR DESCRIPTION
## Summary
- In hosted (Java-backed) games, a card castable both normally and via an alternative cost (Evoke, Flashback, Dash, Spectacle, …) rendered two identical "Cast <name>" rows in the action box — no way to tell which is which.
- Generalize `ActionSpace`'s flashback-only `[FB]` label tag into an alternative-cost tag covering all 26 alt-cost types, and render it in the Java prompt normalizer as e.g. `Cast Flamebraider (Evoke)`.

## Why
The native Rust engine path already disambiguates these (`play_option_to_dto` → "Cast normally" / "Cast with Evoke"), but the Java→UI normalizer built the label from the card name alone, dropping the alternative-cost identity. The fix mirrors the existing general rule on the hosted path rather than special-casing any card. Reported in-game with Flamebraider granted Evoke by Ashling, the Limitless.

## Test plan
- `cargo check -p forge-agent-interface` — clean.
- `cargo fmt -p forge-agent-interface --check` — clean.
- `javac` compile-check of `ActionSpace.java` against the harness fat jar — clean.
- Parity safety: the parity-ordering tag lives in the separate `ParityOrder.actionBaseLabel` (kept in sync with `deterministic_agent.rs`) and is **not** touched; `buildMainActionLabels` is host-only, so parity traces are unaffected.
- Manual: hosted game, cast a card with a granted alternative cost — the two rows now read `Cast <name>` and `Cast <name> (Evoke)`.

Note: the Java change requires a harness jar rebuild (`node scripts/harness.mjs ensure`) to take effect.

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main