### PR TITLE
feat(ui): add card-name filter to card-list modals

### DIFF
--- a/src/components/game/AGENTS.md
+++ b/src/components/game/AGENTS.md
@@ -34,6 +34,8 @@ All game modals use the `Modal` compound:
 
 Use `MODAL_CARD_THUMBNAIL` / `MODAL_CARD_IMAGE` / `MODAL_FOOTER_BETWEEN` constants. Use `useModalKeyboard` for Enter/Escape handling. Use `CardImageThumbnail` for header art.
 
+For a modal that renders a list/grid of cards the user searches through (zone viewers, tutors, choose-from-zone), gate a name filter with `useCardNameFilter(cards)` (shows only past ~10 cards) and render `<ModalCardFilter>` between the header/instructions and `Modal.Body`, mapping its `filtered` instead of the raw `cards`. Pass `autoFocus` only when the modal has no Space/Enter-to-confirm (otherwise the focused input swallows the shortcut).
+
 ## Mana text
 
 Any text that may contain `{W}`, `{2}{R}`, etc. renders through `TextWithMana`:

--- a/src/components/game/ZoneTargetSelector.tsx
+++ b/src/components/game/ZoneTargetSelector.tsx
@@ -5,6 +5,8 @@ import { Modal } from "@/components/game/modals/Modal";
 import { cn } from "@/lib/utils";
 import { useCardPreview } from "@/hooks/useCardPreview";
 import { MODAL_CARD_SIZE } from "./game.styles";
+import { ModalCardFilter } from "@/components/game/modals/ModalCardFilter";
+import { useCardNameFilter } from "@/components/game/modals/useCardNameFilter";
 
 interface ZoneTargetSelectorProps {
   title: string;
@@ -24,6 +26,7 @@ export function ZoneTargetSelector({
   const preview = useCardPreview();
 
   const validCards = cards.filter((card) => validCardIds.includes(card.id));
+  const { query, setQuery, filtered, showFilter } = useCardNameFilter(validCards);
 
   return (
     <Modal onClose={onCancel} maxWidth="max-w-4xl" maxHeight="max-h-[85vh]">
@@ -33,12 +36,16 @@ export function ZoneTargetSelector({
 
       <Modal.Instructions>Choose a target card</Modal.Instructions>
 
+      {showFilter && <ModalCardFilter value={query} onChange={setQuery} autoFocus />}
+
       <Modal.Body>
         {validCards.length === 0 ? (
           <Modal.EmptyState message="No valid targets in this zone" />
+        ) : filtered.length === 0 ? (
+          <Modal.EmptyState message="No matching cards" />
         ) : (
           <div className="flex flex-wrap gap-3 content-start justify-center">
-            {validCards.map((card) => (
+            {filtered.map((card) => (
               <div
                 key={card.id}
                 className="shrink-0 cursor-pointer group"

--- a/src/components/game/modals/ChooseCardsModal.tsx
+++ b/src/components/game/modals/ChooseCardsModal.tsx
@@ -7,6 +7,8 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import type { GameCard } from "@/types/manabrew";
 import { useModalKeyboard } from "@/hooks/useModalKeyboard";
 import { MODAL_FOOTER_BETWEEN } from "../game.styles";
+import { ModalCardFilter } from "./ModalCardFilter";
+import { useCardNameFilter } from "./useCardNameFilter";
 
 interface ChooseCardsModalProps {
   cards: GameCard[];
@@ -36,6 +38,7 @@ export function ChooseCardsModal({
     (optional && selected.size === 0);
 
   const dialogRef = useRef<HTMLDivElement>(null);
+  const { query, setQuery, filtered, showFilter } = useCardNameFilter(cards);
 
   useEffect(() => {
     dialogRef.current?.focus();
@@ -107,12 +110,16 @@ export function ChooseCardsModal({
             : "Select the cards you want, then confirm."}
         </Modal.Instructions>
 
+        {showFilter && <ModalCardFilter value={query} onChange={setQuery} />}
+
         <div className="p-4 overflow-y-auto max-h-[50vh]">
           {cards.length === 0 ? (
             <Modal.EmptyState message="No valid cards" />
+          ) : filtered.length === 0 ? (
+            <Modal.EmptyState message="No matching cards" />
           ) : (
             <div className="flex flex-wrap gap-2 justify-center">
-              {cards.map((card) => {
+              {filtered.map((card) => {
                 const isSelected = selected.has(card.id);
                 return (
                   <div

--- a/src/components/game/modals/LibraryPeekModal.tsx
+++ b/src/components/game/modals/LibraryPeekModal.tsx
@@ -9,6 +9,8 @@ import { cn } from "@/lib/utils";
 import { useState } from "react";
 import { useModalKeyboard } from "@/hooks/useModalKeyboard";
 import { MODAL_CARD_SIZE } from "../game.styles";
+import { ModalCardFilter } from "./ModalCardFilter";
+import { useCardNameFilter } from "./useCardNameFilter";
 import { useTheme } from "@/hooks/useTheme";
 import type { CSSProperties } from "react";
 
@@ -84,6 +86,7 @@ export function LibraryPeekModal({
 }: LibraryPeekModalProps) {
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const preview = useCardPreview();
+  const { query, setQuery, filtered, showFilter } = useCardNameFilter(cards);
 
   const themeColors = useTheme().gameTheme;
   const ringColor = themeColors.cardRing;
@@ -149,12 +152,16 @@ export function LibraryPeekModal({
 
       <Modal.Instructions>{config.instructions}</Modal.Instructions>
 
+      {showFilter && <ModalCardFilter value={query} onChange={setQuery} />}
+
       <Modal.Body>
         {cards.length === 0 ? (
           <Modal.EmptyState message="No cards to choose from" />
+        ) : filtered.length === 0 ? (
+          <Modal.EmptyState message="No matching cards" />
         ) : (
           <div className="flex flex-wrap gap-4 content-start justify-center">
-            {cards.map((card) => {
+            {filtered.map((card) => {
               const isSelected = selected.has(card.id);
               return (
                 <div

--- a/src/components/game/modals/ModalCardFilter.tsx
+++ b/src/components/game/modals/ModalCardFilter.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from "react";
+import { MODAL_INPUT } from "../game.styles";
+
+interface ModalCardFilterProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  autoFocus?: boolean;
+}
+
+export function ModalCardFilter({
+  value,
+  onChange,
+  placeholder = "Filter cards...",
+  autoFocus = false,
+}: ModalCardFilterProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (autoFocus) inputRef.current?.focus();
+  }, [autoFocus]);
+
+  return (
+    <div className="px-4 pb-2">
+      <input
+        ref={inputRef}
+        type="text"
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className={MODAL_INPUT}
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
+      />
+    </div>
+  );
+}

--- a/src/components/game/modals/ZoneViewer.tsx
+++ b/src/components/game/modals/ZoneViewer.tsx
@@ -7,6 +7,8 @@ import { useCardPreview } from "@/hooks/useCardPreview";
 import { HoverCardPreview } from "@/components/game/HoverCardPreview";
 import { useTheme } from "@/hooks/useTheme";
 import { Modal } from "./Modal";
+import { ModalCardFilter } from "./ModalCardFilter";
+import { useCardNameFilter } from "./useCardNameFilter";
 import type { CSSProperties } from "react";
 
 interface ZoneViewerProps {
@@ -29,6 +31,7 @@ export function ZoneViewer({
   const themeColors = useTheme().gameTheme;
   const ringColor = themeColors.cardRing;
   const clickableIdSet = clickableCardIds ? new Set(clickableCardIds) : null;
+  const { query, setQuery, filtered, showFilter } = useCardNameFilter(cards);
 
   return (
     <Modal onClose={onClose}>
@@ -36,12 +39,16 @@ export function ZoneViewer({
         <h2 className="font-semibold text-base">{title}</h2>
       </Modal.Header>
 
+      {showFilter && <ModalCardFilter value={query} onChange={setQuery} autoFocus />}
+
       <Modal.Body>
         {cards.length === 0 ? (
           <Modal.EmptyState />
+        ) : filtered.length === 0 ? (
+          <Modal.EmptyState message="No matching cards" />
         ) : (
           <div className="flex flex-wrap gap-2 content-start">
-            {cards.map((card) => {
+            {filtered.map((card) => {
               const clickable =
                 !!onClickCard && (clickableIdSet == null || clickableIdSet.has(card.id));
               return (

--- a/src/components/game/modals/useCardNameFilter.ts
+++ b/src/components/game/modals/useCardNameFilter.ts
@@ -1,0 +1,19 @@
+import { useMemo, useState } from "react";
+
+const DEFAULT_THRESHOLD = 10;
+
+export function useCardNameFilter<T extends { name: string }>(
+  cards: T[],
+  threshold: number = DEFAULT_THRESHOLD,
+) {
+  const [query, setQuery] = useState("");
+  const showFilter = cards.length > threshold;
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!showFilter || !q) return cards;
+    return cards.filter((card) => card.name.toLowerCase().includes(q));
+  }, [cards, query, showFilter]);
+
+  return { query, setQuery, filtered, showFilter };
+}


### PR DESCRIPTION
## Summary
- Add a name/search filter to the game modals that can render a whole zone or deck, so the user can narrow a long card list instead of scanning it all.
- Covered: `ZoneViewer` (graveyard/exile/library viewer), `ZoneTargetSelector` (choose a card in target zone), `ChooseCardsModal` (delve / convoke / improvise / choose-for-effect), `LibraryPeekModal` (scry / surveil / dig / discard).
- New shared `useCardNameFilter` hook + `ModalCardFilter` input, gated to lists over ~10 cards — mirroring the existing `ChooseCardName` / `ChooseType` filter convention rather than inventing a new one.

## Why
These modals frequently show a full zone (a graveyard or library can be 50+ cards) with no way to find a specific card. A simple name filter makes tutors, graveyard recursion, and zone browsing much faster. Follow-up to the modal survey requested in-game.

## Test plan
- `tsc --noEmit`, `eslint`, `prettier --check` — clean on all six changed files + two new files.
- Manual review of each modal: filter input appears only past ~10 cards; mapping uses the filtered list; a "No matching cards" empty state shows when the filter excludes everything; selection state is keyed by card id so a selected card stays selected even when filtered out of view.
- `autoFocus` is passed only to the two modals without a Space/Enter-to-confirm shortcut (`ZoneViewer`, `ZoneTargetSelector`); the two that confirm via keyboard (`ChooseCardsModal`, `LibraryPeekModal`) leave the input unfocused so the shortcut still works.

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main