### PR TITLE
chore: rename java -> forge, rust -> manabrew for engine references

### DIFF
--- a/forge-engine/crates/forge-protocol/src/protocol.rs
+++ b/forge-engine/crates/forge-protocol/src/protocol.rs
@@ -276,6 +276,6 @@ pub enum GameFormat {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub enum EngineKind {
     #[default]
-    Wasm,
-    Java,
+    Manabrew,
+    Forge,
 }

--- a/forge-engine/crates/forge-server/src/room.rs
+++ b/forge-engine/crates/forge-server/src/room.rs
@@ -365,7 +365,7 @@ mod tests {
             "host".into(),
             4,
             GameFormat::Commander,
-            EngineKind::Java,
+            EngineKind::Forge,
             host_plays,
             None,
             None,

--- a/forge-engine/crates/self-hosted-node/Dockerfile
+++ b/forge-engine/crates/self-hosted-node/Dockerfile
@@ -4,7 +4,7 @@
 # subprocess per game (line-delimited JSON-RPC over stdin/stdout, modelled on
 # forge-parity's --server pool). Each game owns its own JVM, so Forge's static
 # counters can't race across games. The Rust backend exists too
-# (SELF_HOSTED_NODE_ENGINE_BACKEND=rust) but this image defaults to java.
+# (SELF_HOSTED_NODE_ENGINE_BACKEND=manabrew) but this image defaults to forge.
 
 # ── Stage 1: Build the Java Forge harness JAR ───────────────────────
 # Mirrors forge-parity/Dockerfile — the harness jar bundles forge-core / game
@@ -91,7 +91,7 @@ COPY public/preset_decks/ /build/public/preset_decks/
 
 WORKDIR /build
 
-ENV SELF_HOSTED_NODE_ENGINE_BACKEND=java
+ENV SELF_HOSTED_NODE_ENGINE_BACKEND=forge
 ENV SELF_HOSTED_NODE_JAVA_HOME=/opt/java/openjdk
 # Default to the in-compose relay; compose overrides as needed.
 ENV FORGE_RELAY_URL=ws://forge-server:9443

--- a/forge-engine/crates/self-hosted-node/src/engine_backend.rs
+++ b/forge-engine/crates/self-hosted-node/src/engine_backend.rs
@@ -10,8 +10,8 @@ pub struct HostedGameOver {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EngineBackendKind {
-    Rust,
-    JavaForge,
+    Manabrew,
+    Forge,
 }
 
 impl EngineBackendKind {
@@ -20,26 +20,26 @@ impl EngineBackendKind {
             .or_else(|_| std::env::var("FORGE_ROOM_ENGINE_BACKEND"))
             .ok()
             .and_then(|value| Self::parse(&value))
-            .unwrap_or(Self::Rust)
+            .unwrap_or(Self::Manabrew)
     }
 
     fn parse(value: &str) -> Option<Self> {
         match value.trim().to_ascii_lowercase().as_str() {
-            "" | "rust" | "rust-engine" => Some(Self::Rust),
-            "java" | "java-forge" | "forge-java" => Some(Self::JavaForge),
+            "" | "manabrew" => Some(Self::Manabrew),
+            "forge" => Some(Self::Forge),
             _ => None,
         }
     }
 
     pub fn is_supported(self) -> bool {
-        matches!(self, Self::Rust)
-            || (matches!(self, Self::JavaForge) && cfg!(feature = "java-forge"))
+        matches!(self, Self::Manabrew)
+            || (matches!(self, Self::Forge) && cfg!(feature = "java-forge"))
     }
 
     pub fn label(self) -> &'static str {
         match self {
-            Self::Rust => "rust",
-            Self::JavaForge => "java-forge",
+            Self::Manabrew => "manabrew",
+            Self::Forge => "forge",
         }
     }
 }

--- a/forge-engine/crates/self-hosted-node/src/main.rs
+++ b/forge-engine/crates/self-hosted-node/src/main.rs
@@ -45,10 +45,10 @@ struct RelayClient {
 }
 
 enum EngineSession {
-    Rust {
+    Manabrew {
         remote_response_txs: HashMap<usize, std_mpsc::Sender<PlayerAction>>,
     },
-    Java {
+    Forge {
         remote_response_txs: HashMap<usize, std_mpsc::Sender<PlayerAction>>,
         cancel: Arc<AtomicBool>,
     },
@@ -197,7 +197,7 @@ async fn run(mut config: Config) -> Result<(), Box<dyn std::error::Error + Send 
     let backend = EngineBackendKind::from_env();
     if config.engine_enabled
         && backend.is_supported()
-        && matches!(backend, EngineBackendKind::JavaForge)
+        && matches!(backend, EngineBackendKind::Forge)
     {
         info!("initializing shared java engine (one JVM for all hosted games)");
         java_backend::init_engine()?;
@@ -267,10 +267,10 @@ async fn host_one_room(
         info!(room_id, "joining configured room");
         room_id.clone()
     } else {
-        let engine = if matches!(EngineBackendKind::from_env(), EngineBackendKind::JavaForge) {
-            EngineKind::Java
+        let engine = if matches!(EngineBackendKind::from_env(), EngineBackendKind::Forge) {
+            EngineKind::Forge
         } else {
-            EngineKind::Wasm
+            EngineKind::Manabrew
         };
         host.send(&ClientMessage::CreateRoom {
             room_name: config.room_name.clone(),
@@ -773,7 +773,7 @@ fn maybe_start_hosted_engine(
     let game_id = format!("room-game-{}", Uuid::new_v4());
 
     match backend {
-        EngineBackendKind::Rust => {
+        EngineBackendKind::Manabrew => {
             let (remote_prompt_tx, remote_prompt_rx) = std_mpsc::channel::<(usize, AgentMessage)>();
             let mut remote_response_txs = HashMap::new();
             let mut remote_response_rxs = Vec::new();
@@ -785,7 +785,7 @@ fn maybe_start_hosted_engine(
                 remote_response_txs.insert(i, response_tx);
                 remote_response_rxs.push((i, response_rx));
             }
-            *guard = Some(EngineSession::Rust {
+            *guard = Some(EngineSession::Manabrew {
                 remote_response_txs,
             });
             drop(guard);
@@ -818,7 +818,7 @@ fn maybe_start_hosted_engine(
                 clear_engine_session(&session_handle);
             });
         }
-        EngineBackendKind::JavaForge => {
+        EngineBackendKind::Forge => {
             let (remote_prompt_tx, remote_prompt_rx) = std_mpsc::channel::<(usize, AgentMessage)>();
             let mut remote_response_txs = HashMap::new();
             let mut remote_response_rxs = Vec::new();
@@ -831,7 +831,7 @@ fn maybe_start_hosted_engine(
                 remote_response_rxs.push((i, response_rx));
             }
             let cancel = Arc::new(AtomicBool::new(false));
-            *guard = Some(EngineSession::Java {
+            *guard = Some(EngineSession::Forge {
                 remote_response_txs,
                 cancel: cancel.clone(),
             });
@@ -920,7 +920,7 @@ fn end_hosted_game_on_abandon(
 ) {
     let cancelled = match engine_session.lock() {
         Ok(guard) => match guard.as_ref() {
-            Some(EngineSession::Java { cancel, .. }) => {
+            Some(EngineSession::Forge { cancel, .. }) => {
                 cancel.store(true, Ordering::Relaxed);
                 true
             }
@@ -986,7 +986,7 @@ fn route_remote_response(engine_session: &SharedEngineSession, state: &Value) {
         return;
     };
     match session {
-        EngineSession::Rust {
+        EngineSession::Manabrew {
             remote_response_txs,
         } => {
             let action: PlayerAction = match serde_json::from_value(action_value) {
@@ -1004,7 +1004,7 @@ fn route_remote_response(engine_session: &SharedEngineSession, state: &Value) {
                 warn!(from_player, %error, "failed to route relay response");
             }
         }
-        EngineSession::Java {
+        EngineSession::Forge {
             remote_response_txs,
             ..
         } => {

--- a/src-tauri/AGENTS.md
+++ b/src-tauri/AGENTS.md
@@ -1,6 +1,6 @@
 # Tauri shell
 
-Native desktop wrapper. Tauri v2, Rust backend, hosts either the native Rust engine or (opt-in) the Java Forge bridge.
+Native desktop wrapper. Tauri v2, Rust backend, hosts either the native ManaBrew engine or (opt-in) the Forge bridge.
 
 Read first: `/AGENTS.md`.
 
@@ -22,7 +22,7 @@ Read first: `/AGENTS.md`.
 ## Conventions
 
 - **Bundled resources** — `scripts/harness.mjs` stages the Java Forge harness JAR and engine Forge assets into generated `src-tauri/resources/forge-runtime/`, with `forge-gui/res/cardsfolder/cardsfolder.zip` matching Forge's packaged-resource lookup. Tauri copies that bundle to `engine/forge/`; `public/preset_decks/` is copied to `preset_decks/` (the same directory the web build serves at `/preset_decks/`). Runtime paths are exposed via env vars (`CARDS_DIR`, `TOKEN_SCRIPTS_DIR`, `MANA_BREW_FORGE_ASSETS_DIR`, `MANA_BREW_FORGE_HARNESS_JAR`, `PRESET_DECKS_DIR`, …) set in `lib.rs::run()` before any command runs. `CARDSET_ARCHIVE` remains the separate Tauri archive resource at bundled `cardset.rkyv`, produced from `src-tauri/resources/cardset.rkyv` by `src-tauri/build.rs`. Don't read paths relative to the source tree at runtime — packaged builds don't have it.
-- **Backend selection.** `MANABREW_ENGINE_BACKEND=java-forge` switches to the Java bridge. Without it, the native Rust engine runs. Confirm the active backend in terminal logs (`backend=java-forge` or `backend=rust`); the UI alone doesn't reveal it.
+- **Backend selection.** `MANA_BREW_ENGINE_BACKEND=forge` switches to the Forge bridge. Without it (or `=manabrew`), the native ManaBrew engine runs. Confirm the active backend in terminal logs (`backend=forge` or `backend=manabrew`); the UI alone doesn't reveal it.
 - **DTO parity.** `engine_backend/rust_backend.rs` and `engine_backend/java_backend.rs` must emit identical DTO shapes. If you add a field to one, add it to the other.
 - **Tauri command surface.** Every UI-facing command is registered in `lib.rs::run()` via `tauri::generate_handler![…]`. Adding a command means: implement, add to the handler list, expose from the appropriate module.
 - **Long-running work runs off the command thread.** Tauri commands are async; spawn into the game/transport runtime, don't block.

--- a/src-tauri/src/engine_backend.rs
+++ b/src-tauri/src/engine_backend.rs
@@ -3,8 +3,8 @@ pub mod rust_backend;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EngineBackendKind {
-    Rust,
-    JavaForge,
+    Manabrew,
+    Forge,
 }
 
 impl EngineBackendKind {
@@ -12,28 +12,28 @@ impl EngineBackendKind {
         std::env::var("MANA_BREW_ENGINE_BACKEND")
             .ok()
             .and_then(|value| Self::parse(&value))
-            .unwrap_or(Self::Rust)
+            .unwrap_or(Self::Manabrew)
     }
 
     fn parse(value: &str) -> Option<Self> {
         match value.trim().to_ascii_lowercase().as_str() {
-            "" | "rust" | "rust-engine" => Some(Self::Rust),
-            "java" | "java-forge" | "forge-java" => Some(Self::JavaForge),
+            "" | "manabrew" => Some(Self::Manabrew),
+            "forge" => Some(Self::Forge),
             _ => None,
         }
     }
 
     pub fn is_supported(self) -> bool {
         match self {
-            Self::Rust => true,
-            Self::JavaForge => cfg!(feature = "java-forge"),
+            Self::Manabrew => true,
+            Self::Forge => cfg!(feature = "java-forge"),
         }
     }
 
     pub fn label(self) -> &'static str {
         match self {
-            Self::Rust => "rust",
-            Self::JavaForge => "java-forge",
+            Self::Manabrew => "manabrew",
+            Self::Forge => "forge",
         }
     }
 }

--- a/src-tauri/src/game_manager.rs
+++ b/src-tauri/src/game_manager.rs
@@ -118,7 +118,7 @@ impl GameManager {
                 );
                 let result =
                     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| match backend {
-                        EngineBackendKind::Rust => rust_backend::run_game(
+                        EngineBackendKind::Manabrew => rust_backend::run_game(
                             game_id_clone.clone(),
                             deck,
                             starting_life,
@@ -130,7 +130,7 @@ impl GameManager {
                             snapshot_tx,
                             abort_signal_for_thread,
                         ),
-                        EngineBackendKind::JavaForge => java_backend::run_game(
+                        EngineBackendKind::Forge => java_backend::run_game(
                             game_id_clone.clone(),
                             deck,
                             starting_life,
@@ -238,7 +238,7 @@ impl GameManager {
         let game_id = format!("game-{}", uuid_simple());
         let game_id_clone = game_id.clone();
         let backend = EngineBackendKind::from_env();
-        if !backend.is_supported() || matches!(backend, EngineBackendKind::JavaForge) {
+        if !backend.is_supported() || matches!(backend, EngineBackendKind::Forge) {
             java_backend::JavaRuntimeConfig::from_env().validate()?;
             return Err("Tauri multiplayer java-forge dispatch is not wired yet".to_string());
         }
@@ -301,7 +301,7 @@ impl GameManager {
                 );
                 let result =
                     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| match backend {
-                        EngineBackendKind::Rust => rust_backend::run_multiplayer_game(
+                        EngineBackendKind::Manabrew => rust_backend::run_multiplayer_game(
                             game_id_clone.clone(),
                             player_name_strs,
                             selected_deck_lists,
@@ -316,7 +316,7 @@ impl GameManager {
                             remote_response_rxs,
                             abort_signal_for_thread,
                         ),
-                        EngineBackendKind::JavaForge => {
+                        EngineBackendKind::Forge => {
                             unreachable!("unsupported backend rejected before thread start")
                         }
                     }));

--- a/src-tauri/src/server_commands.rs
+++ b/src-tauri/src/server_commands.rs
@@ -102,7 +102,7 @@ pub async fn server_create_room(
             "max_players": max_players,
             "format": format,
             "hosted": hosted.unwrap_or(false),
-            "engine": engine.unwrap_or_else(|| "Wasm".to_string()),
+            "engine": engine.unwrap_or_else(|| "Manabrew".to_string()),
             "draft_config": draft_config,
             "sealed_config": sealed_config,
             "reconnect_timeout_s": reconnect_timeout_s,

--- a/src/components/lobby/CreateRoomDialog.tsx
+++ b/src/components/lobby/CreateRoomDialog.tsx
@@ -321,7 +321,7 @@ export function CreateRoomDialog({ open, onOpenChange }: CreateRoomDialogProps) 
         roomName.trim() || defaultName,
         maxPlayers,
         submittedFormat,
-        "Wasm",
+        "Manabrew",
         draftConfig,
         sealedConfig,
         reconnectTimeoutS,

--- a/src/components/lobby/EngineChoiceModal.tsx
+++ b/src/components/lobby/EngineChoiceModal.tsx
@@ -30,12 +30,12 @@ export function EngineChoiceModal({ onChoose, onCancel, hostedAvailable }: Engin
         </DialogHeader>
         <div className="grid gap-3 sm:grid-cols-2">
           <button
-            onClick={() => onChoose("Wasm")}
+            onClick={() => onChoose("Manabrew")}
             className="text-left rounded-lg border p-4 transition-colors hover:border-primary/40 hover:bg-muted/30"
           >
             <div className="flex items-center gap-2 mb-1.5">
               <Cpu className="h-4 w-4 text-primary" />
-              <span className="font-semibold text-sm">Rust</span>
+              <span className="font-semibold text-sm">ManaBrew</span>
               <Badge variant="outline" className="text-[9px]">
                 in-browser
               </Badge>
@@ -46,7 +46,7 @@ export function EngineChoiceModal({ onChoose, onCancel, hostedAvailable }: Engin
             </p>
           </button>
           <button
-            onClick={() => onChoose("Java")}
+            onClick={() => onChoose("Forge")}
             disabled={!hostedAvailable}
             className="text-left rounded-lg border p-4 transition-colors enabled:hover:border-primary/40 enabled:hover:bg-muted/30 disabled:cursor-not-allowed disabled:opacity-50"
           >
@@ -59,8 +59,8 @@ export function EngineChoiceModal({ onChoose, onCancel, hostedAvailable }: Engin
             </div>
             <p className="text-xs text-muted-foreground leading-snug">
               {hostedAvailable
-                ? "Java Forge on a ManaBrew-hosted node — full card support, but adds a little network latency."
-                : "Java Forge on a ManaBrew-hosted node — full card support. Not available in this build."}
+                ? "Forge on a ManaBrew-hosted node — full card support, but adds a little network latency."
+                : "Forge on a ManaBrew-hosted node — full card support. Not available in this build."}
             </p>
           </button>
         </div>

--- a/src/components/lobby/TablesList.tsx
+++ b/src/components/lobby/TablesList.tsx
@@ -573,13 +573,13 @@ export function TablesList({
 
                     <span className="font-medium text-sm truncate min-w-0">{room.room_name}</span>
 
-                    <LobbyTag tone={room.engine === "Java" ? "blue" : "sky"} className="shrink-0">
-                      {room.engine === "Java" ? (
+                    <LobbyTag tone={room.engine === "Forge" ? "blue" : "sky"} className="shrink-0">
+                      {room.engine === "Forge" ? (
                         <Anvil className="h-3 w-3" />
                       ) : (
                         <Cpu className="h-3 w-3" />
                       )}
-                      {room.engine === "Java" ? "Forge" : "ManaBrew"}
+                      {room.engine === "Forge" ? "Forge" : "ManaBrew"}
                     </LobbyTag>
                     {room.format !== "Any" && (
                       <LobbyTag tone={modeTone} className="shrink-0">

--- a/src/game/runtime.types.ts
+++ b/src/game/runtime.types.ts
@@ -1,7 +1,7 @@
 import type { IGameApi } from "@/platform";
 import type { GameCard, GameView } from "@/types/manabrew";
 
-export type GameRuntimeKind = "rust-engine" | "forge-java" | "manual-tabletop";
+export type GameRuntimeKind = "manabrew" | "forge" | "manual-tabletop";
 
 export type SeatControllerKind =
   | "local-human"

--- a/src/game/runtimeRegistry.ts
+++ b/src/game/runtimeRegistry.ts
@@ -3,7 +3,7 @@ import { ManualTabletopGameApi } from "./manualTabletopApi";
 import type { GameRuntime, GameRuntimeCapabilities, GameRuntimeKind } from "./runtime.types";
 
 const manualTabletopApi = new ManualTabletopGameApi();
-let selectedRuntimeKind: GameRuntimeKind = "rust-engine";
+let selectedRuntimeKind: GameRuntimeKind = "manabrew";
 
 function getPlatformGameCapabilities(): GameRuntimeCapabilities {
   const platform = getPlatform();
@@ -16,8 +16,8 @@ function getPlatformGameCapabilities(): GameRuntimeCapabilities {
   };
 }
 
-const rustRuntime: GameRuntime = {
-  kind: "rust-engine",
+const manabrewRuntime: GameRuntime = {
+  kind: "manabrew",
   label: "Rust engine",
   get capabilities() {
     return getPlatformGameCapabilities();
@@ -41,9 +41,9 @@ const manualTabletopRuntime: GameRuntime = {
 };
 
 const runtimes: Record<GameRuntimeKind, GameRuntime | null> = {
-  "rust-engine": rustRuntime,
+  manabrew: manabrewRuntime,
   "manual-tabletop": manualTabletopRuntime,
-  "forge-java": null,
+  forge: null,
 };
 
 export function getAvailableGameRuntimes(): GameRuntime[] {
@@ -51,7 +51,7 @@ export function getAvailableGameRuntimes(): GameRuntime[] {
 }
 
 export function getSelectedGameRuntime(): GameRuntime {
-  return runtimes[selectedRuntimeKind] ?? rustRuntime;
+  return runtimes[selectedRuntimeKind] ?? manabrewRuntime;
 }
 
 export function getSelectedGameRuntimeKind(): GameRuntimeKind {
@@ -68,9 +68,9 @@ export function selectGameRuntime(kind: GameRuntimeKind): GameRuntime {
 }
 
 export function resetSelectedGameRuntime(): GameRuntime {
-  return selectGameRuntime("rust-engine");
+  return selectGameRuntime("manabrew");
 }
 
 export function getDefaultGameRuntime(): GameRuntime {
-  return rustRuntime;
+  return manabrewRuntime;
 }

--- a/src/lib/decks.ts
+++ b/src/lib/decks.ts
@@ -37,7 +37,7 @@ export function asDeckCard(deck: Deck | undefined, gameCard: GameCard): DeckCard
       `Token archive has no entry for ${gameCard.name} (${gameCard.setCode}#${gameCard.cardNumber})`,
     );
   }
-  // The engine may not carry the printing through — the hosted Java backend
+  // The engine may not carry the printing through — the hosted Forge backend
   // emits empty setCode/cardNumber for every card — so the exact match misses
   // deck cards pinned to a specific printing (e.g. a commander). Fall back to
   // a name match; the singleton deck makes this unambiguous for non-basics.

--- a/src/platform/tauri.ts
+++ b/src/platform/tauri.ts
@@ -112,7 +112,7 @@ class TauriServerApi implements IServerApi {
       maxPlayers: params.maxPlayers,
       format: params.format,
       hosted: params.hosted ?? false,
-      engine: params.engine ?? "Wasm",
+      engine: params.engine ?? "Manabrew",
       draftConfig: params.draftConfig ?? null,
       sealedConfig: params.sealedConfig ?? null,
       reconnectTimeoutS: params.reconnectTimeoutS ?? null,

--- a/src/platform/web.ts
+++ b/src/platform/web.ts
@@ -800,7 +800,7 @@ class WebServerApi implements IServerApi {
       max_players: params.maxPlayers,
       format: params.format,
       hosted: params.hosted ?? false,
-      engine: params.engine ?? "Wasm",
+      engine: params.engine ?? "Manabrew",
       draft_config: params.draftConfig ?? null,
       sealed_config: params.sealedConfig ?? null,
       reconnect_timeout_s: params.reconnectTimeoutS ?? null,

--- a/src/stores/useGameStore.ts
+++ b/src/stores/useGameStore.ts
@@ -106,7 +106,7 @@ async function initializeGame({
   if (
     getPlatform().type === "web" &&
     isHostedEngineAvailable() &&
-    engine === "Java" &&
+    engine === "Forge" &&
     opponentDeck
   ) {
     set({

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -47,7 +47,7 @@ export interface RoomInfo {
   sealed_config?: SealedConfig;
 }
 
-export type EngineKind = "Wasm" | "Java";
+export type EngineKind = "Manabrew" | "Forge";
 
 export interface SealedConfig {
   set_code: string;

--- a/src/views/Play.tsx
+++ b/src/views/Play.tsx
@@ -109,7 +109,7 @@ export default function Play() {
             if (getPlatform().type === "web") {
               setPendingAiStart({ playerDeck, opponentDeck, formatId, commanderName });
             } else {
-              startGame(playerDeck, formatId, commanderName, opponentDeck, "Wasm");
+              startGame(playerDeck, formatId, commanderName, opponentDeck, "Manabrew");
             }
           }}
         />

--- a/website/src-landing/pages/index.astro
+++ b/website/src-landing/pages/index.astro
@@ -100,7 +100,7 @@ const mana = preset.gameColors;
           <h2>Forge-faithful rules</h2>
           <p>
             The engine is a Rust port of Forge, not a reinterpretation — and it's
-            swappable: games can run on the original Java Forge engine itself,
+            swappable: games can run on the original Forge engine itself,
             with full rules coverage, through the same client.
           </p>
         </article>

--- a/website/src/content/docs/faq.md
+++ b/website/src/content/docs/faq.md
@@ -21,7 +21,7 @@ rules keep working without images.
 
 ## A card did the wrong thing
 
-Probably a gap in the Rust engine — these reports are the project's
+Probably a gap in the ManaBrew engine — these reports are the project's
 lifeblood. Post on [Discord](https://discord.gg/NqrKpbhtcd) or open a
 [GitHub issue](https://github.com/witchesofthehill/manabrew/issues) with:
 
@@ -32,7 +32,7 @@ lifeblood. Post on [Discord](https://discord.gg/NqrKpbhtcd) or open a
 
 ## Why is a card marked "unsupported"?
 
-The Rust engine doesn't implement everything that card's script needs yet.
+The ManaBrew engine doesn't implement everything that card's script needs yet.
 The deck still saves; the card just won't behave correctly in-game. See
 [Formats & limitations](/formats/).
 

--- a/website/src/content/docs/formats.md
+++ b/website/src/content/docs/formats.md
@@ -20,27 +20,27 @@ data.
 ## Card coverage
 
 The card database parses Forge's full library of 32,000+ card scripts, but
-the Rust engine does not implement every mechanic those scripts use yet.
+the ManaBrew engine does not implement every mechanic those scripts use yet.
 What that means in practice:
 
 - The deck editor checks every card against the engine and flags ones it
   can't run with an **unsupported** badge — check your deck before a game,
   not during one.
-- Coverage grows parity-first: each fix is verified against Java Forge's
+- Coverage grows parity-first: each fix is verified against Forge's
   behavior with identical seeds and choices, and locked in by a regression
   suite.
-- The engine is swappable: rooms hosted on the original Java Forge engine via
+- The engine is swappable: rooms hosted on the original Forge engine via
   a [self-hosted node](/self-hosting/) are fully supported and give you
   Forge's complete card coverage today.
 
 ## Web vs desktop
 
-|                  | Web (play.manabrew.app)                 | Desktop (Tauri)                                          |
-| ---------------- | --------------------------------------- | -------------------------------------------------------- |
-| Rules engine     | Rust engine compiled to WASM            | Same Rust engine, native                                 |
-| Java Forge games | Join rooms hosted by a self-hosted node | Same                                                     |
-| Offline play     | No                                      | Engine runs locally, but card images still need internet |
-| Install          | None                                    | `.dmg` / `.exe` from releases                            |
+|              | Web (play.manabrew.app)                 | Desktop (Tauri)                                          |
+| ------------ | --------------------------------------- | -------------------------------------------------------- |
+| Rules engine | ManaBrew engine compiled to WASM        | Same ManaBrew engine, native                             |
+| Forge games  | Join rooms hosted by a self-hosted node | Same                                                     |
+| Offline play | No                                      | Engine runs locally, but card images still need internet |
+| Install      | None                                    | `.dmg` / `.exe` from releases                            |
 
 The web client additionally requires a cross-origin-isolated host (see
 [hosting the web client](/self-hosting/#hosting-the-web-client)) — this

--- a/website/src/content/docs/getting-started.md
+++ b/website/src/content/docs/getting-started.md
@@ -6,7 +6,7 @@ description: Play ManaBrew in the browser, install the desktop app, or build fro
 ## Play in the browser
 
 The fastest way to try ManaBrew is the web client at
-[manabrew.app](https://play.manabrew.app). It runs the Rust engine compiled to
+[manabrew.app](https://play.manabrew.app). It runs the ManaBrew engine compiled to
 WebAssembly — nothing to install.
 
 ## Desktop app
@@ -28,14 +28,14 @@ connection even in the desktop app.
 You need [Node.js](https://nodejs.org) 22+, [Yarn v1](https://classic.yarnpkg.com),
 and a [Rust](https://rustup.rs) toolchain. Desktop builds also need the
 [Tauri platform prerequisites](https://tauri.app/start/prerequisites/); Java
-(18+) and Maven are only required for Java Forge-backed games and parity runs.
+(18+) and Maven are only required for Forge-backed games and parity runs.
 
 ```bash
 git clone --recurse-submodules https://github.com/witchesofthehill/manabrew.git
 cd manabrew
 yarn install
 
-# Web client (Rust engine compiled to WASM)
+# Web client (ManaBrew engine compiled to WASM)
 yarn dev:web
 
 # Desktop client (Tauri)

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -20,8 +20,8 @@ so it can run anywhere — including directly in your browser via WebAssembly.
     releases](https://github.com/witchesofthehill/manabrew/releases).
   </Card>
   <Card title="Swappable engine" icon="setting">
-    A Rust port of Forge's game engine, verified card-by-card against Java Forge — or swap in the
-    original Java Forge engine itself and play with full rules coverage today.
+    A Rust port of Forge's game engine, verified card-by-card against Forge — or swap in the
+    original Forge engine itself and play with full rules coverage today.
   </Card>
   <Card title="Multiplayer" icon="seti:pipeline">
     A relay server powers online lobbies, with reconnection support for in-progress games.
@@ -39,10 +39,10 @@ not shipped by this project.
 ManaBrew is pre-release software, and its game engine is **swappable**. Two
 backends drive the same client today:
 
-- **Rust engine** — the Forge port that runs everywhere, including in your
+- **ManaBrew engine** — the Forge port that runs everywhere, including in your
   browser. It plays a growing set of matchups, with card coverage expanding
-  through parity testing against Java Forge.
-- **Java Forge engine** — fully supported as a first-class way to play. Rooms
+  through parity testing against Forge.
+- **Forge engine** — fully supported as a first-class way to play. Rooms
   hosted on a [self-hosted node](/self-hosting/) run games on the
   original, battle-tested Forge rules engine with its complete card coverage.
 
@@ -59,8 +59,8 @@ backends drive the same client today:
   href="/playing/"
 />
 <LinkCard
-  title="Self-hosting a Java room"
-  description="Run your own game room on the Java Forge engine, or host a full relay."
+  title="Self-hosting a Forge room"
+  description="Run your own game room on the Forge engine, or host a full relay."
   href="/self-hosting/"
 />
 <LinkCard

--- a/website/src/content/docs/playing.md
+++ b/website/src/content/docs/playing.md
@@ -17,7 +17,7 @@ is checked live:
 
 - **Legality badges** mark cards that are banned or restricted in the deck's
   format.
-- An **unsupported** badge marks cards the Rust engine can't run yet — the
+- An **unsupported** badge marks cards the ManaBrew engine can't run yet — the
   deck still saves, but those cards won't behave correctly in a game.
 - For Commander decks, the editor shows detected **combos** (via Commander
   Spellbook), **Game Changers**, and an estimated **bracket**: brackets 2–4

--- a/website/src/content/docs/self-hosting.md
+++ b/website/src/content/docs/self-hosting.md
@@ -1,12 +1,12 @@
 ---
-title: Self-hosting a Java room
-description: Run your own headless game room backed by the Java Forge engine, via Docker Compose or from source.
+title: Self-hosting a Forge room
+description: Run your own headless game room backed by the Forge engine, via Docker Compose or from source.
 ---
 
 A **self-hosted node** is a headless room host. It connects to a relay server,
 opens a lobby room, and runs the games for everyone who joins — players only
-need the web or desktop client. With the `java-forge` backend the node spawns
-one Java Forge process per game, so games are played on the original Forge
+need the web or desktop client. With the `forge` backend the node spawns
+one Forge process per game, so games are played on the original Forge
 rules engine rather than the Rust port.
 
 Both options below start from a full checkout:
@@ -21,7 +21,7 @@ The node authenticates to the relay with the relay's server key. Set it via
 
 ## Option 1: Docker Compose
 
-The image bundles everything: the node binary, the Java Forge harness, and a
+The image bundles everything: the node binary, the Forge harness, and a
 JRE. Create a `compose.yml`:
 
 ```yaml
@@ -38,7 +38,7 @@ services:
     restart: unless-stopped
 ```
 
-The image defaults to the Java backend, so no extra configuration is needed:
+The image defaults to the Forge backend, so no extra configuration is needed:
 
 ```bash
 SELF_HOSTED_NODE_SERVER_KEY=… docker compose up --build
@@ -48,7 +48,7 @@ SELF_HOSTED_NODE_SERVER_KEY=… docker compose up --build
 
 You need a Rust toolchain, a JDK (17+), and Maven.
 
-Build the Java Forge harness jar and the cardset archive once:
+Build the Forge harness jar and the cardset archive once:
 
 ```bash
 mvn -pl forge-harness -am package -DskipTests
@@ -60,7 +60,7 @@ Then run the node:
 ```bash
 SELF_HOSTED_NODE_ROOM_NAME=my-room \
 SELF_HOSTED_NODE_SERVER_KEY=<your-server-key> \
-SELF_HOSTED_NODE_ENGINE_BACKEND=java-forge \
+SELF_HOSTED_NODE_ENGINE_BACKEND=forge \
 SELF_HOSTED_NODE_RELAY_URL=wss://relay.manabrew.app \
 JAVA_HOME="$(/usr/libexec/java_home)" \
 cargo run --release -p self-hosted-node --features java-forge
@@ -74,18 +74,18 @@ cargo run --release -p self-hosted-node --features java-forge
 
 All settings are environment variables:
 
-| Variable                          | Default               | Purpose                                              |
-| --------------------------------- | --------------------- | ---------------------------------------------------- |
-| `SELF_HOSTED_NODE_RELAY_URL`      | `ws://127.0.0.1:9443` | Relay server to connect to                           |
-| `SELF_HOSTED_NODE_SERVER_KEY`     | —                     | Relay server key (must match the relay's)            |
-| `SELF_HOSTED_NODE_ROOM_NAME`      | `Self-Hosted Node`    | Lobby name shown to players                          |
-| `SELF_HOSTED_NODE_ROOM_PASSWORD`  | none                  | Require a password to join                           |
-| `SELF_HOSTED_NODE_FORMAT`         | `any`                 | Game format (e.g. `commander`)                       |
-| `SELF_HOSTED_NODE_MAX_PLAYERS`    | `4`                   | Seats in the room                                    |
-| `SELF_HOSTED_NODE_MAX_GAMES`      | `1`                   | Concurrent games the node will run                   |
-| `SELF_HOSTED_NODE_ENGINE_BACKEND` | `rust`                | `java-forge` for the Java engine (`java` also works) |
-| `SELF_HOSTED_NODE_BOT_ENABLED`    | `false`               | Seat an AI bot in the room                           |
-| `SELF_HOSTED_NODE_AUTO_START`     | `false`               | Start as soon as the room fills                      |
+| Variable                          | Default               | Purpose                                                          |
+| --------------------------------- | --------------------- | ---------------------------------------------------------------- |
+| `SELF_HOSTED_NODE_RELAY_URL`      | `ws://127.0.0.1:9443` | Relay server to connect to                                       |
+| `SELF_HOSTED_NODE_SERVER_KEY`     | —                     | Relay server key (must match the relay's)                        |
+| `SELF_HOSTED_NODE_ROOM_NAME`      | `Self-Hosted Node`    | Lobby name shown to players                                      |
+| `SELF_HOSTED_NODE_ROOM_PASSWORD`  | none                  | Require a password to join                                       |
+| `SELF_HOSTED_NODE_FORMAT`         | `any`                 | Game format (e.g. `commander`)                                   |
+| `SELF_HOSTED_NODE_MAX_PLAYERS`    | `4`                   | Seats in the room                                                |
+| `SELF_HOSTED_NODE_MAX_GAMES`      | `1`                   | Concurrent games the node will run                               |
+| `SELF_HOSTED_NODE_ENGINE_BACKEND` | `manabrew`            | `forge` for the Forge engine, `manabrew` for the ManaBrew engine |
+| `SELF_HOSTED_NODE_BOT_ENABLED`    | `false`               | Seat an AI bot in the room                                       |
+| `SELF_HOSTED_NODE_AUTO_START`     | `false`               | Start as soon as the room fills                                  |
 
 ## Hosting your own relay
 


### PR DESCRIPTION
## Summary
* Repo wide ranames, on contracts, args, and docs for better readibility

## Build artifacts
<!--
  Check the boxes below to build the corresponding installer on merge to main
  (uploaded to the Actions run, 30-day retention).
  Leave unchecked to skip — faster CI, no binaries produced.
  Tag pushes (v*) always build both and publish a GitHub Release regardless.
-->
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
