### PR TITLE
feat(ui): card preview improvements (p/t badge, loading, loyalty, hints)

### DIFF
--- a/src/components/game/CardPreview.tsx
+++ b/src/components/game/CardPreview.tsx
@@ -511,7 +511,10 @@ export function CardPreview({
                     alt={currentCardName}
                     title=""
                     onLoad={() => setLoadedSrc(currentImageUrl)}
-                    className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rotate-90 origin-center h-[calc(100%*7/5)] aspect-[5/7]"
+                    className={cn(
+                      "absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rotate-90 origin-center h-[calc(100%*7/5)] aspect-[5/7] transition-opacity duration-200",
+                      imgLoaded ? "opacity-100" : "opacity-0",
+                    )}
                   />
                 ) : (
                   <ScryfallImg
@@ -519,7 +522,10 @@ export function CardPreview({
                     alt={currentCardName}
                     title=""
                     onLoad={() => setLoadedSrc(currentImageUrl)}
-                    className="w-full h-full object-cover"
+                    className={cn(
+                      "w-full h-full object-cover transition-opacity duration-200",
+                      imgLoaded ? "opacity-100" : "opacity-0",
+                    )}
                   />
                 )}
                 {!imgLoaded && !currentLowResUrl && (

--- a/src/components/game/CardPreview.tsx
+++ b/src/components/game/CardPreview.tsx
@@ -10,7 +10,7 @@ import { CARD_BADGES } from "./game.constants";
 import { withAlpha } from "@/themes/gameTheme";
 import { useTheme } from "@/hooks/useTheme";
 import { isCreature, isLethalDamage } from "./game.utils";
-import { isHorizontalCard } from "@/lib/cardLayout";
+import { isHorizontalCard, isTwoHalfLayout } from "@/lib/cardLayout";
 import { cn } from "@/lib/utils";
 import type { HandActionOption } from "@/stores/useGameUIStore";
 import { useEffect, useMemo, useState } from "react";
@@ -289,6 +289,7 @@ export function CardPreview({
   const facesHaveImages =
     !!faces &&
     faces.length >= 2 &&
+    !isTwoHalfLayout(card.layout) &&
     !!faces[0].image_uris?.[imageSize] &&
     !!faces[1].image_uris?.[imageSize];
   const derivedBackImageUrl =

--- a/src/components/game/CardPreview.tsx
+++ b/src/components/game/CardPreview.tsx
@@ -90,17 +90,24 @@ function CardDetailOverlay({ card, horizontal }: { card: GameCard; horizontal: b
 
   const ptStyle = useMemo<CSSProperties>(() => {
     const fg = themeColors.textOnTinted;
-    switch (ptState) {
-      case "lethal":
-        return { backgroundColor: themeColors.pt.lethal, color: fg };
-      case "buffed":
-        return { backgroundColor: themeColors.pt.buffed, color: fg };
-      case "debuffed":
-        return { backgroundColor: themeColors.pt.debuffed, color: fg };
-      default:
-        return { backgroundColor: themeColors.pt.neutral, color: fg };
+    const base: CSSProperties = {
+      color: fg,
+      backgroundColor:
+        ptState === "lethal"
+          ? themeColors.pt.lethal
+          : ptState === "buffed"
+            ? themeColors.pt.buffed
+            : ptState === "debuffed"
+              ? themeColors.pt.debuffed
+              : themeColors.pt.neutral,
+    };
+    const toughness = parseInt(card.toughness ?? "0", 10);
+    if (ptState !== "lethal" && damage > 0 && toughness > 0) {
+      const tint = withAlpha(themeColors.pt.lethal, Math.min(0.85, damage / toughness));
+      base.backgroundImage = `linear-gradient(${tint}, ${tint})`;
     }
-  }, [ptState, themeColors]);
+    return base;
+  }, [ptState, damage, card.toughness, themeColors]);
 
   const ptModified = ptState !== "neutral" && ptState !== "unknown";
   const isPlaneswalker = card.types?.some((t) => t.toLowerCase() === "planeswalker") ?? false;

--- a/src/components/game/CardPreview.tsx
+++ b/src/components/game/CardPreview.tsx
@@ -44,6 +44,7 @@ interface CardPreviewProps {
 
 const { w: CARD_W, h: CARD_H } = FLASH_CARD_SIZE;
 const ACTIONS_PANEL_W = 220;
+const MAX_PREVIEW_KEYWORDS = 8;
 
 function CardDetailOverlay({ card, horizontal }: { card: GameCard; horizontal: boolean }) {
   const themeColors = useTheme().gameTheme;
@@ -75,6 +76,8 @@ function CardDetailOverlay({ card, horizontal }: { card: GameCard; horizontal: b
   ]);
 
   const keywords = card.keywords ?? [];
+  const visibleKeywords = keywords.slice(0, MAX_PREVIEW_KEYWORDS);
+  const hiddenKeywordCount = keywords.length - visibleKeywords.length;
 
   const damage = card.damage ?? 0;
 
@@ -146,7 +149,7 @@ function CardDetailOverlay({ card, horizontal }: { card: GameCard; horizontal: b
           )}
           {keywords.length > 0 && (
             <div className="flex flex-wrap gap-1 justify-center">
-              {keywords.map((kw, i) => {
+              {visibleKeywords.map((kw, i) => {
                 const colonIdx = kw.indexOf(":");
                 const label = colonIdx === -1 ? kw : kw.slice(0, colonIdx);
                 const cost = colonIdx === -1 ? null : kw.slice(colonIdx + 1);
@@ -160,6 +163,11 @@ function CardDetailOverlay({ card, horizontal }: { card: GameCard; horizontal: b
                   </span>
                 );
               })}
+              {hiddenKeywordCount > 0 && (
+                <span className="inline-flex items-center text-[11px] font-bold uppercase tracking-wide bg-black/75 text-white px-2 py-0.5 rounded shadow-md">
+                  +{hiddenKeywordCount}
+                </span>
+              )}
             </div>
           )}
         </div>

--- a/src/components/game/CardPreview.tsx
+++ b/src/components/game/CardPreview.tsx
@@ -45,7 +45,7 @@ interface CardPreviewProps {
 const { w: CARD_W, h: CARD_H } = FLASH_CARD_SIZE;
 const ACTIONS_PANEL_W = 220;
 
-function CardDetailOverlay({ card }: { card: GameCard }) {
+function CardDetailOverlay({ card, horizontal }: { card: GameCard; horizontal: boolean }) {
   const themeColors = useTheme().gameTheme;
   const creature = isCreature(card);
   const lethal = isLethalDamage(card);
@@ -105,9 +105,10 @@ function CardDetailOverlay({ card }: { card: GameCard }) {
   const ptModified = ptState !== "neutral" && ptState !== "unknown";
   const isPlaneswalker = card.types?.some((t) => t.toLowerCase() === "planeswalker") ?? false;
   const loyalty = card.counters?.Loyalty;
-  const showLoyalty = isPlaneswalker && loyalty != null;
+  const showLoyalty = isPlaneswalker && loyalty != null && !horizontal;
   const showTopStrip = statusBadges.length > 0 || keywords.length > 0;
-  const showPT = creature && !!card.power && !!card.toughness && (ptModified || damage > 0);
+  const showPT =
+    creature && !horizontal && !!card.power && !!card.toughness && (ptModified || damage > 0);
 
   const overlayCounters = useMemo(() => {
     if (!card.counters) return null;
@@ -473,7 +474,7 @@ export function CardPreview({
                     </span>
                   </div>
                 )}
-                <CardDetailOverlay card={card} />
+                <CardDetailOverlay card={card} horizontal={horizontal} />
                 {hasDoubleFace && onFlip && (
                   <button
                     type="button"

--- a/src/components/game/CardPreview.tsx
+++ b/src/components/game/CardPreview.tsx
@@ -103,8 +103,19 @@ function CardDetailOverlay({ card }: { card: GameCard }) {
   }, [ptState, themeColors]);
 
   const ptModified = ptState !== "neutral" && ptState !== "unknown";
+  const isPlaneswalker = card.types?.some((t) => t.toLowerCase() === "planeswalker") ?? false;
+  const loyalty = card.counters?.Loyalty;
+  const showLoyalty = isPlaneswalker && loyalty != null;
   const showTopStrip = statusBadges.length > 0 || keywords.length > 0;
   const showPT = creature && !!card.power && !!card.toughness && (ptModified || damage > 0);
+
+  const overlayCounters = useMemo(() => {
+    if (!card.counters) return null;
+    const entries = Object.entries(card.counters).filter(
+      ([type, n]) => n > 0 && !(showLoyalty && type === "Loyalty"),
+    );
+    return entries.length ? Object.fromEntries(entries) : null;
+  }, [card.counters, showLoyalty]);
 
   return (
     <>
@@ -168,15 +179,29 @@ function CardDetailOverlay({ card }: { card: GameCard }) {
         </div>
       )}
 
-      {card.counters && Object.values(card.counters).some((n) => n > 0) && (
+      {showLoyalty && (
+        <div className="absolute bottom-[5.5%] right-[5.5%] z-10 pointer-events-none">
+          <span
+            className="text-lg font-bold px-3 py-1 rounded-md shadow-md leading-none"
+            style={{
+              backgroundColor: themeColors.counter.loyalty,
+              color: themeColors.textOnTinted,
+            }}
+          >
+            {loyalty}
+          </span>
+        </div>
+      )}
+
+      {overlayCounters && (
         <div
           className={cn(
             "absolute bottom-1 left-1 z-10 max-w-[70%]",
             "flex flex-wrap gap-0.5 pointer-events-none",
-            showPT ? "pr-12" : "right-1",
+            showPT || showLoyalty ? "pr-12" : "right-1",
           )}
         >
-          <CounterDisplay counters={card.counters} size="sm" />
+          <CounterDisplay counters={overlayCounters} size="sm" />
         </div>
       )}
 

--- a/src/components/game/CardPreview.tsx
+++ b/src/components/game/CardPreview.tsx
@@ -13,7 +13,7 @@ import { isCreature, isLethalDamage } from "./game.utils";
 import { isHorizontalCard } from "@/lib/cardLayout";
 import { cn } from "@/lib/utils";
 import type { HandActionOption } from "@/stores/useGameUIStore";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { CSSProperties } from "react";
 import { useGameStore } from "@/stores/useGameStore";
 import { asDeckCard } from "@/lib/decks";
@@ -230,7 +230,7 @@ export function CardPreview({
   // undefined and the hovered object is a `DeckCard` (uris already on it).
   // Fall back to that case instead of going through `asDeckCard`.
   const deckCard: DeckCard = deck ? asDeckCard(deck, card) : (card as unknown as DeckCard);
-  const isLoading = false;
+  const [loadedSrc, setLoadedSrc] = useState<string | null>(null);
   const imageUrl = deckCard.uris[imageSize];
   const scryfallEntry = useCard({
     name: card.name,
@@ -376,6 +376,7 @@ export function CardPreview({
   const hasDoubleFace = !!doubleFacedData;
   const currentImageUrl = hasDoubleFace && showBackFace ? doubleFacedData.backImageUrl : imageUrl;
   const currentCardName = hasDoubleFace && showBackFace ? doubleFacedData.backName : card.name;
+  const imgLoaded = loadedSrc === currentImageUrl;
 
   return createPortal(
     <>
@@ -420,18 +421,14 @@ export function CardPreview({
                 : undefined
             }
           >
-            {isLoading && !currentImageUrl ? (
-              <div className="w-full h-full flex flex-col items-center justify-center gap-2 p-4">
-                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-                <span className="text-xs text-muted-foreground text-center">{currentCardName}</span>
-              </div>
-            ) : currentImageUrl ? (
+            {currentImageUrl ? (
               <>
                 {horizontal ? (
                   <ScryfallImg
                     src={currentImageUrl}
                     alt={currentCardName}
                     title=""
+                    onLoad={() => setLoadedSrc(currentImageUrl)}
                     className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rotate-90 origin-center h-[calc(100%*7/5)] aspect-[5/7]"
                   />
                 ) : (
@@ -439,8 +436,17 @@ export function CardPreview({
                     src={currentImageUrl}
                     alt={currentCardName}
                     title=""
+                    onLoad={() => setLoadedSrc(currentImageUrl)}
                     className="w-full h-full object-cover"
                   />
+                )}
+                {!imgLoaded && (
+                  <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 p-4 bg-black">
+                    <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                    <span className="text-xs text-muted-foreground text-center">
+                      {currentCardName}
+                    </span>
+                  </div>
                 )}
                 <CardDetailOverlay card={card} />
                 {hasDoubleFace && onFlip && (

--- a/src/components/game/CardPreview.tsx
+++ b/src/components/game/CardPreview.tsx
@@ -108,13 +108,11 @@ function CardDetailOverlay({ card, horizontal }: { card: GameCard; horizontal: b
     ptStyle.backgroundImage = `linear-gradient(${tint}, ${tint})`;
   }
 
-  const ptModified = ptState !== "neutral" && ptState !== "unknown";
   const isPlaneswalker = card.types?.some((t) => t.toLowerCase() === "planeswalker") ?? false;
   const loyalty = card.counters?.Loyalty;
   const showLoyalty = isPlaneswalker && loyalty != null && !horizontal;
   const showTopStrip = statusBadges.length > 0 || keywords.length > 0;
-  const showPT =
-    creature && !horizontal && !!card.power && !!card.toughness && (ptModified || damage > 0);
+  const showPT = creature && !horizontal && !!card.power && !!card.toughness;
 
   const overlayCounters = useMemo(() => {
     if (!card.counters) return null;

--- a/src/components/game/CardPreview.tsx
+++ b/src/components/game/CardPreview.tsx
@@ -76,24 +76,35 @@ function CardDetailOverlay({ card }: { card: GameCard }) {
 
   const keywords = card.keywords ?? [];
 
-  const ptStyle = useMemo<CSSProperties>(() => {
-    const fg = themeColors.textOnTinted;
-    if (lethal) return { backgroundColor: themeColors.pt.lethal, color: fg };
-    if (card.basePower == null || card.power == null) {
-      return { backgroundColor: themeColors.pt.neutral, color: fg };
-    }
+  const damage = card.damage ?? 0;
+
+  const ptState = useMemo(() => {
+    if (lethal) return "lethal" as const;
+    if (card.basePower == null || card.power == null) return "unknown" as const;
     const curP = parseInt(card.power, 10);
     const curT = parseInt(card.toughness ?? "0", 10);
-    const buffed = curP > card.basePower || curT > (card.baseToughness ?? 0);
-    const debuffed = curP < card.basePower || curT < (card.baseToughness ?? 0);
-    if (buffed) return { backgroundColor: themeColors.pt.buffed, color: fg };
-    if (debuffed) return { backgroundColor: themeColors.pt.debuffed, color: fg };
-    return { backgroundColor: themeColors.pt.neutral, color: fg };
-  }, [lethal, card.basePower, card.baseToughness, card.power, card.toughness, themeColors]);
+    if (curP > card.basePower || curT > (card.baseToughness ?? 0)) return "buffed" as const;
+    if (curP < card.basePower || curT < (card.baseToughness ?? 0)) return "debuffed" as const;
+    return "neutral" as const;
+  }, [lethal, card.basePower, card.baseToughness, card.power, card.toughness]);
 
+  const ptStyle = useMemo<CSSProperties>(() => {
+    const fg = themeColors.textOnTinted;
+    switch (ptState) {
+      case "lethal":
+        return { backgroundColor: themeColors.pt.lethal, color: fg };
+      case "buffed":
+        return { backgroundColor: themeColors.pt.buffed, color: fg };
+      case "debuffed":
+        return { backgroundColor: themeColors.pt.debuffed, color: fg };
+      default:
+        return { backgroundColor: themeColors.pt.neutral, color: fg };
+    }
+  }, [ptState, themeColors]);
+
+  const ptModified = ptState !== "neutral" && ptState !== "unknown";
   const showTopStrip = statusBadges.length > 0 || keywords.length > 0;
-  const showPT = creature && !!card.power && !!card.toughness;
-  const damage = card.damage ?? 0;
+  const showPT = creature && !!card.power && !!card.toughness && (ptModified || damage > 0);
 
   return (
     <>

--- a/src/components/game/CardPreview.tsx
+++ b/src/components/game/CardPreview.tsx
@@ -218,7 +218,7 @@ function CardDetailOverlay({ card, horizontal }: { card: GameCard; horizontal: b
             showPT || showLoyalty ? "pr-12" : "right-1",
           )}
         >
-          <CounterDisplay counters={overlayCounters} size="sm" />
+          <CounterDisplay counters={overlayCounters} size="md" />
         </div>
       )}
 

--- a/src/components/game/CardPreview.tsx
+++ b/src/components/game/CardPreview.tsx
@@ -91,26 +91,22 @@ function CardDetailOverlay({ card, horizontal }: { card: GameCard; horizontal: b
     return "neutral" as const;
   }, [lethal, card.basePower, card.baseToughness, card.power, card.toughness]);
 
-  const ptStyle = useMemo<CSSProperties>(() => {
-    const fg = themeColors.textOnTinted;
-    const base: CSSProperties = {
-      color: fg,
-      backgroundColor:
-        ptState === "lethal"
-          ? themeColors.pt.lethal
-          : ptState === "buffed"
-            ? themeColors.pt.buffed
-            : ptState === "debuffed"
-              ? themeColors.pt.debuffed
-              : themeColors.pt.neutral,
-    };
-    const toughness = parseInt(card.toughness ?? "0", 10);
-    if (ptState !== "lethal" && damage > 0 && toughness > 0) {
-      const tint = withAlpha(themeColors.pt.lethal, Math.min(0.85, damage / toughness));
-      base.backgroundImage = `linear-gradient(${tint}, ${tint})`;
-    }
-    return base;
-  }, [ptState, damage, card.toughness, themeColors]);
+  const ptStyle: CSSProperties = {
+    color: themeColors.textOnTinted,
+    backgroundColor:
+      ptState === "lethal"
+        ? themeColors.pt.lethal
+        : ptState === "buffed"
+          ? themeColors.pt.buffed
+          : ptState === "debuffed"
+            ? themeColors.pt.debuffed
+            : themeColors.pt.neutral,
+  };
+  const ptToughness = parseInt(card.toughness ?? "0", 10);
+  if (ptState !== "lethal" && damage > 0 && ptToughness > 0) {
+    const tint = withAlpha(themeColors.pt.lethal, Math.min(0.85, damage / ptToughness));
+    ptStyle.backgroundImage = `linear-gradient(${tint}, ${tint})`;
+  }
 
   const ptModified = ptState !== "neutral" && ptState !== "unknown";
   const isPlaneswalker = card.types?.some((t) => t.toLowerCase() === "planeswalker") ?? false;

--- a/src/components/game/CardPreview.tsx
+++ b/src/components/game/CardPreview.tsx
@@ -88,7 +88,7 @@ function CardDetailOverlay({ card }: { card: GameCard }) {
     const debuffed = curP < card.basePower || curT < (card.baseToughness ?? 0);
     if (buffed) return { backgroundColor: themeColors.pt.buffed, color: fg };
     if (debuffed) return { backgroundColor: themeColors.pt.debuffed, color: fg };
-    return { backgroundColor: withAlpha(themeColors.pt.neutral, 0.85), color: fg };
+    return { backgroundColor: themeColors.pt.neutral, color: fg };
   }, [lethal, card.basePower, card.baseToughness, card.power, card.toughness, themeColors]);
 
   const showTopStrip = statusBadges.length > 0 || keywords.length > 0;

--- a/src/components/game/CardPreview.tsx
+++ b/src/components/game/CardPreview.tsx
@@ -167,6 +167,13 @@ function CardDetailOverlay({ card, horizontal }: { card: GameCard; horizontal: b
 
       {showPT && (
         <div className="absolute bottom-[5.5%] right-[5.5%] z-10 flex flex-col items-end gap-1 pointer-events-none">
+          {(ptState === "buffed" || ptState === "debuffed") &&
+            card.basePower != null &&
+            card.baseToughness != null && (
+              <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-black/60 text-white/80 line-through leading-none">
+                {card.basePower}/{card.baseToughness}
+              </span>
+            )}
           <span
             className="text-lg font-bold px-3 py-1 rounded-md shadow-md leading-none"
             style={ptStyle}

--- a/src/components/game/CardPreview.tsx
+++ b/src/components/game/CardPreview.tsx
@@ -80,7 +80,7 @@ function CardDetailOverlay({ card }: { card: GameCard }) {
     const fg = themeColors.textOnTinted;
     if (lethal) return { backgroundColor: themeColors.pt.lethal, color: fg };
     if (card.basePower == null || card.power == null) {
-      return { backgroundColor: withAlpha(themeColors.pt.neutral, 0.85), color: fg };
+      return { backgroundColor: themeColors.pt.neutral, color: fg };
     }
     const curP = parseInt(card.power, 10);
     const curT = parseInt(card.toughness ?? "0", 10);
@@ -136,9 +136,9 @@ function CardDetailOverlay({ card }: { card: GameCard }) {
       )}
 
       {showPT && (
-        <div className="absolute bottom-2 right-2 z-10 flex flex-col items-end gap-1 pointer-events-none">
+        <div className="absolute bottom-[5.5%] right-[5.5%] z-10 flex flex-col items-end gap-1 pointer-events-none">
           <span
-            className="text-base font-bold px-2 py-0.5 rounded shadow-md leading-none"
+            className="text-lg font-bold px-3 py-1 rounded-md shadow-md leading-none"
             style={ptStyle}
           >
             {card.power}/{card.toughness}

--- a/src/components/game/CardPreview.tsx
+++ b/src/components/game/CardPreview.tsx
@@ -606,6 +606,32 @@ export function CardPreview({
                   </span>
                 </button>
               ))}
+              <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 px-1 text-[10px] text-muted-foreground">
+                <span>
+                  <kbd className="rounded border border-border bg-muted px-1 font-mono text-[9px]">
+                    1
+                  </kbd>
+                  –
+                  <kbd className="rounded border border-border bg-muted px-1 font-mono text-[9px]">
+                    9
+                  </kbd>{" "}
+                  select
+                </span>
+                <span>
+                  <kbd className="rounded border border-border bg-muted px-1 font-mono text-[9px]">
+                    Esc
+                  </kbd>{" "}
+                  close
+                </span>
+                {hasFlippableFaces && (
+                  <span>
+                    <kbd className="rounded border border-border bg-muted px-1 font-mono text-[9px]">
+                      F
+                    </kbd>{" "}
+                    flip
+                  </span>
+                )}
+              </div>
             </div>
           )}
         </div>

--- a/src/components/game/CardPreview.tsx
+++ b/src/components/game/CardPreview.tsx
@@ -300,6 +300,8 @@ export function CardPreview({
     ? {
         frontImageUrl: faces![0].image_uris![imageSize],
         backImageUrl: faces![1].image_uris![imageSize],
+        frontImageUrlLow: faces![0].image_uris!.normal,
+        backImageUrlLow: faces![1].image_uris!.normal,
         frontName: faces![0].name,
         backName: faces![1].name,
       }
@@ -307,6 +309,10 @@ export function CardPreview({
       ? {
           frontImageUrl: imageUrl,
           backImageUrl: derivedBackImageUrl,
+          frontImageUrlLow: deckCard.uris.normal,
+          backImageUrlLow: deckCard.uris.normal?.includes("/front/")
+            ? deckCard.uris.normal.replace("/front/", "/back/")
+            : derivedBackImageUrl,
           frontName: card.name,
           backName: card.name,
         }
@@ -425,6 +431,14 @@ export function CardPreview({
   const hasDoubleFace = !!doubleFacedData;
   const currentImageUrl = hasDoubleFace && showBackFace ? doubleFacedData.backImageUrl : imageUrl;
   const currentCardName = hasDoubleFace && showBackFace ? doubleFacedData.backName : card.name;
+  const currentLowResUrl =
+    imageSize !== "large"
+      ? null
+      : hasDoubleFace
+        ? showBackFace
+          ? doubleFacedData.backImageUrlLow
+          : doubleFacedData.frontImageUrlLow
+        : deckCard.uris.normal;
   const imgLoaded = loadedSrc === currentImageUrl;
 
   return createPortal(
@@ -472,6 +486,25 @@ export function CardPreview({
           >
             {currentImageUrl ? (
               <>
+                {currentLowResUrl &&
+                  !imgLoaded &&
+                  (horizontal ? (
+                    <ScryfallImg
+                      src={currentLowResUrl}
+                      alt=""
+                      title=""
+                      aria-hidden
+                      className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rotate-90 origin-center h-[calc(100%*7/5)] aspect-[5/7]"
+                    />
+                  ) : (
+                    <ScryfallImg
+                      src={currentLowResUrl}
+                      alt=""
+                      title=""
+                      aria-hidden
+                      className="absolute inset-0 w-full h-full object-cover"
+                    />
+                  ))}
                 {horizontal ? (
                   <ScryfallImg
                     src={currentImageUrl}
@@ -489,7 +522,7 @@ export function CardPreview({
                     className="w-full h-full object-cover"
                   />
                 )}
-                {!imgLoaded && (
+                {!imgLoaded && !currentLowResUrl && (
                   <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 p-4 bg-black">
                     <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
                     <span className="text-xs text-muted-foreground text-center">

--- a/src/components/game/CounterBadge.tsx
+++ b/src/components/game/CounterBadge.tsx
@@ -56,7 +56,7 @@ const COUNTER_CONFIG: Record<string, CounterConfig> = {
     title: "Depletion",
   },
   Page: { iconName: "scroll-unfurled", label: "Page", colorKey: "page", title: "Page" },
-  Shield: { iconName: "shield", label: "Shield", colorKey: "shield", title: "Shield" },
+  Shield: { iconName: "round-shield", label: "Shield", colorKey: "shield", title: "Shield" },
 };
 
 function getCounterConfig(type: string): CounterConfig {

--- a/src/components/game/CounterBadge.tsx
+++ b/src/components/game/CounterBadge.tsx
@@ -56,6 +56,7 @@ const COUNTER_CONFIG: Record<string, CounterConfig> = {
     title: "Depletion",
   },
   Page: { iconName: "scroll-unfurled", label: "Page", colorKey: "page", title: "Page" },
+  Shield: { iconName: "shield", label: "Shield", colorKey: "shield", title: "Shield" },
 };
 
 function getCounterConfig(type: string): CounterConfig {
@@ -88,6 +89,7 @@ const COUNTER_BG_CLASS: Record<CounterColorKey, string> = {
   brick: "bg-counter-brick",
   depletion: "bg-counter-depletion",
   page: "bg-counter-page",
+  shield: "bg-counter-shield",
 };
 
 // ---------------------------------------------------------------------------

--- a/src/components/game/GameIcon.tsx
+++ b/src/components/game/GameIcon.tsx
@@ -27,7 +27,7 @@ export type GameIconName =
   | "skull-crack"
   | "shiny-omega"
   | "vibrating-shield"
-  | "shield"
+  | "round-shield"
   | "scroll-quill"
   | "spell-book"
   | "hourglass"

--- a/src/components/game/GameIcon.tsx
+++ b/src/components/game/GameIcon.tsx
@@ -27,6 +27,7 @@ export type GameIconName =
   | "skull-crack"
   | "shiny-omega"
   | "vibrating-shield"
+  | "shield"
   | "scroll-quill"
   | "spell-book"
   | "hourglass"

--- a/src/index.css
+++ b/src/index.css
@@ -90,6 +90,7 @@
   --color-counter-brick: var(--counter-brick);
   --color-counter-depletion: var(--counter-depletion);
   --color-counter-page: var(--counter-page);
+  --color-counter-shield: var(--counter-shield);
   --color-player-colors-self: var(--player-colors-self);
   --color-player-colors-opponent1: var(--player-colors-opponent1);
   --color-player-colors-opponent2: var(--player-colors-opponent2);

--- a/src/themes/buildGameColors.ts
+++ b/src/themes/buildGameColors.ts
@@ -168,6 +168,7 @@ export function buildGameColors(p: BasePalette): GameThemeColorMap {
     "counter.brick": p.brown,
     "counter.depletion": p.redDeep,
     "counter.page": p.paper,
+    "counter.shield": p.amber,
 
     // ── Player seat colours ──────────────────────────────────────────
     // Phase strip indicator + turn tint. Seat-to-hue mapping is fixed

--- a/src/themes/gameTheme.ts
+++ b/src/themes/gameTheme.ts
@@ -103,6 +103,7 @@ export interface GameThemeColors {
     brick: string;
     depletion: string;
     page: string;
+    shield: string;
   };
   cardRing: string;
   playerColors: {


### PR DESCRIPTION
## Summary
A batch of card-preview (`CardPreview.tsx`) improvements, each its own commit:

1. **P/T badge alignment** — proportional `bottom/right` offset (5:7 `object-cover`), larger, fully opaque so it covers the printed stats.
2. **Badge only when modified** — the synthetic P/T badge shows only when stats differ from printed (buff/debuff/damage/lethal); otherwise the real card shows through. Also fixes alignment fragility across frames.
3. **Loading spinner** — wired real load state (the old `isLoading` was dead-coded to `false`); no more black-box pop-in.
4. **Planeswalker loyalty badge** — prominent loyalty badge bottom-right (de-duped from the counter row).
5. **Horizontal guard** — suppress bottom-right stat badges on rotated (battle/saga/split) frames where the offset would misplace them.
6. **Damage tint** — P/T badge tints toward lethal as damage approaches toughness.
7. **Base P/T** — shows struck-through base stats when buffed/debuffed.
8. **Keyboard hints** — `1–9 / Esc / F` shortcut hints in the interactive actions panel.
9. **Keyword overflow** — caps keyword chips at 8 with a `+N` chip.
10. **Flip correctness** — no bogus flip affordance on split/aftermath/room (two-halves) layouts.
11. **Progressive load** — shows the `normal`-res image immediately while `large` streams in.
12. **Fade-in** — large image fades in on load and on flip.
13. **Cleanup** — inlined the P/T style (removed an unstable memo).

<img width="504" height="544" alt="image" src="https://github.com/user-attachments/assets/13b4f682-894a-482b-a42f-8494fdebfa89" />

<img width="483" height="560" alt="image" src="https://github.com/user-attachments/assets/6f1dbd08-9699-4c39-b4e9-fc06e32397f2" />


## Why
The preview is the primary way to read a card's live state. The P/T badge drifted off printed stats, images popped in over black, planeswalker loyalty wasn't surfaced, and several states (damage, buffs) weren't legible at a glance.

## Test plan
- Hover/select creatures (unmodified, buffed, debuffed, damaged, lethal), planeswalkers, DFCs, split/room, and horizontal cards; confirm badges, loyalty, fades, spinner, and flip behave.
- `yarn lint:all` TS side clean (eslint/prettier/tsc) on each commit.

## Build artifacts
- [ ] Build macOS .dmg
- [ ] Build Windows .exe