### PR TITLE
chore(docs): bump forge submodule and document submodule workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,46 @@ To get started visit our [landing page](https://manabrew.app)
 - Java 18 and Maven for Java Forge parity runs
 - Platform prerequisites for [Tauri](https://tauri.app/start/prerequisites/)
 
+### Clone with submodules
+
+The Java reference engine and all card scripts live in the `forge` submodule, so
+clone with `--recurse-submodules`:
+
+```bash
+git clone --recurse-submodules https://github.com/witchesofthehill/manabrew.git
+```
+
+If you already cloned without it, initialize the submodule before building:
+
+```bash
+git submodule update --init --recursive
+```
+
 ### Install
 
 ```bash
 yarn install
 ```
+
+### Update the Forge submodule
+
+Card data and the Java reference engine ship from the `forge` submodule. Pull the
+latest card scripts (it tracks the `manabrew` branch — see `.gitmodules`) with:
+
+```bash
+git submodule update --remote forge
+```
+
+Then rebuild the bundled card archives so the new cards are available — otherwise
+the deck loader strips any card missing from the bundle:
+
+```bash
+yarn build:harness   # restages the Java harness + Tauri cardsfolder.zip
+yarn web             # rebuilds the WASM card archive (yarn dev does too)
+```
+
+Committing the resulting submodule pointer bump (`git status` shows `M forge`) is
+a normal change — open a PR for it like any other.
 
 ### Run the desktop app
 

--- a/README.md
+++ b/README.md
@@ -133,19 +133,22 @@ yarn install
 
 ### Update the Forge submodule
 
-Card data and the Java reference engine ship from the `forge` submodule. Pull the
-latest card scripts (it tracks the `manabrew` branch — see `.gitmodules`) with:
+The `forge` submodule is the whole Forge tree — the Java reference engine plus
+card scripts, editions, and token data. Pull the latest commit (it tracks the
+`manabrew` branch — see `.gitmodules`) with:
 
 ```bash
 git submodule update --remote forge
 ```
 
-Then rebuild the bundled card archives so the new cards are available — otherwise
-the deck loader strips any card missing from the bundle:
+Then rebuild so the new submodule content is picked up — the Java harness, the
+WASM engine, and the bundled card archives all build from `forge/`. Skipping
+this leaves stale builds; one visible symptom is the deck loader stripping any
+card missing from the bundle.
 
 ```bash
-yarn build:harness   # restages the Java harness + Tauri cardsfolder.zip
-yarn web             # rebuilds the WASM card archive (yarn dev does too)
+yarn build:harness   # rebuilds the Java harness + restages the Tauri card bundle
+yarn web             # rebuilds the WASM engine and card archive (yarn dev does too)
 ```
 
 Committing the resulting submodule pointer bump (`git status` shows `M forge`) is

--- a/website/src/content/docs/getting-started.md
+++ b/website/src/content/docs/getting-started.md
@@ -45,6 +45,28 @@ yarn dev
 The `forge` submodule provides card scripts and the Java reference engine —
 the `--recurse-submodules` flag matters.
 
+### Initialize the submodule
+
+If you cloned without `--recurse-submodules`, set it up before building:
+
+```bash
+git submodule update --init --recursive
+```
+
+### Update card data
+
+New cards land in the `forge` submodule (it tracks the `manabrew` branch). Pull
+the latest scripts and rebuild the bundled card archives:
+
+```bash
+git submodule update --remote forge
+yarn build:harness   # restages the Java harness + Tauri card bundle
+yarn web             # rebuilds the WASM card archive (yarn dev does too)
+```
+
+Without the rebuild, the deck loader removes any card that is not yet in the
+bundle — that "Removed from your deck" notice means the archives are stale.
+
 ## Getting help
 
 Questions, deck sharing, and bug reports all happen on

--- a/website/src/content/docs/getting-started.md
+++ b/website/src/content/docs/getting-started.md
@@ -55,17 +55,19 @@ git submodule update --init --recursive
 
 ### Update the submodule
 
-New cards land in the `forge` submodule (it tracks the `manabrew` branch). Pull
-the latest commit and rebuild the bundled card archives:
+The `forge` submodule is the whole Forge tree — the Java reference engine plus
+card scripts, editions, and tokens (it tracks the `manabrew` branch). Pull the
+latest commit and rebuild, since the harness, the WASM engine, and the card
+archives all build from it:
 
 ```bash
 git submodule update --remote forge
-yarn build:harness   # restages the Java harness + Tauri card bundle
-yarn web             # rebuilds the WASM card archive (yarn dev does too)
+yarn build:harness   # rebuilds the Java harness + restages the Tauri card bundle
+yarn web             # rebuilds the WASM engine and card archive (yarn dev does too)
 ```
 
-Without the rebuild, the deck loader removes any card that is not yet in the
-bundle — that "Removed from your deck" notice means the archives are stale.
+Skipping the rebuild leaves stale builds; one visible symptom is the deck loader
+removing any card not yet in the bundle — that "Removed from your deck" notice.
 
 ## Getting help
 

--- a/website/src/content/docs/getting-started.md
+++ b/website/src/content/docs/getting-started.md
@@ -53,10 +53,10 @@ If you cloned without `--recurse-submodules`, set it up before building:
 git submodule update --init --recursive
 ```
 
-### Update card data
+### Update the submodule
 
 New cards land in the `forge` submodule (it tracks the `manabrew` branch). Pull
-the latest scripts and rebuild the bundled card archives:
+the latest commit and rebuild the bundled card archives:
 
 ```bash
 git submodule update --remote forge


### PR DESCRIPTION
## Summary

- Bump the `forge` submodule `d658cbc` → `6ab83898` (the `manabrew` branch merged with upstream master, 1156 commits), pulling in newly-added card scripts that were missing from the bundled card database.
- Document the submodule **init** (`--init --recursive`) and **update** (`--remote` + rebuild archives) workflow in the README and the docs site.

## Why

A deck containing recently-added cards (e.g. *Studious First-Year, Rampant Growth* and *Witherbloom, the Balancer*) showed a "Removed from your deck" notice in-game. Root cause: the submodule was pinned at an old commit, so those card scripts never made it into the bundled card archives — the bundling pipeline itself was working correctly. Bumping the submodule and rebuilding fixes it, and the new docs help contributors avoid the same trap.

## Test plan

- `git submodule update --remote forge` → submodule advances to `6ab83898`; both card `.txt` files present on disk.
- `yarn build:harness` → BUILD SUCCESS; both cards present in staged `cardsfolder.zip`.
- `yarn web` (via `ensure-wasm`) → rebuilt `cardset.rkyv` (33,213 cards); both card names verified inside the archive.
- Docs are markdown-only; prettier ran via the pre-commit hook.

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main