### PR TITLE
fix(harness): adapt PlayerController impls to bumped Forge API

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ To get started visit our [landing page](https://manabrew.app)
 - Node.js 22.12+ recommended
 - Yarn v1
 - Rust stable
-- Java 18 and Maven for Java Forge parity runs
+- JDK 18–21 and Maven for the Java Forge harness / parity runs. Newer JDKs
+  (e.g. 26) currently fail to compile Forge; if `/usr/libexec/java_home`
+  resolves to one, pin an older one: `JAVA_HOME="$(/usr/libexec/java_home -v 21)"`.
 - Platform prerequisites for [Tauri](https://tauri.app/start/prerequisites/)
 
 ### Clone with submodules
@@ -125,34 +127,78 @@ If you already cloned without it, initialize the submodule before building:
 git submodule update --init --recursive
 ```
 
+### Keep the `forge` submodule in sync
+
+The `forge` submodule is **pinned**: every branch records the exact Forge commit
+it expects (the gitlink). Git does **not** move the submodule for you when you
+switch branches or pull, so after either of those — or whenever `git status`
+shows `M forge` you didn't intend — sync your working copy back to the pinned
+commit:
+
+```bash
+git submodule update --init forge   # checks out the *recorded* commit (the pin)
+```
+
+Note this is **not** `--remote`: `--init` restores the pin, `--remote` advances
+to the latest upstream (see "Bump the Forge submodule" below). Check the state
+with:
+
+```bash
+git submodule status forge
+#  <sha> forge   → in sync with the pin
+# +<sha> forge   → your forge is AHEAD of the pin; run the sync command above
+# -<sha> forge   → not initialized; run the sync command above
+```
+
+An out-of-sync submodule means the Java engine, card scripts, and the harness
+jar disagree on which Forge version they target. Symptoms: cards silently
+stripped from decks, `No enum constant forge.card.CardSplitType.X` at deck load,
+or a `NoClassDefFoundError` at runtime. When in doubt, re-sync and rebuild.
+
 ### Install
 
 ```bash
 yarn install
 ```
 
-### Update the Forge submodule
+### Bump the Forge submodule
 
-The `forge` submodule is the whole Forge tree — the Java reference engine plus
-card scripts, editions, and token data. Pull the latest commit (it tracks the
+Do this only when you intentionally want **newer** Forge — not to fix an
+out-of-sync checkout (for that, use the sync command above). The `forge`
+submodule is the whole Forge tree — the Java reference engine plus card scripts,
+editions, and token data. Advance it to the latest commit (it tracks the
 `manabrew` branch — see `.gitmodules`) with:
 
 ```bash
 git submodule update --remote forge
 ```
 
-Then rebuild so the new submodule content is picked up — the Java harness, the
-WASM engine, and the bundled card archives all build from `forge/`. Skipping
-this leaves stale builds; one visible symptom is the deck loader stripping any
-card missing from the bundle.
+Then **clean-rebuild** so the new Forge is actually picked up — the Java harness,
+the WASM engine, and the bundled card archives all build from `forge/`:
 
 ```bash
-yarn build:harness   # rebuilds the Java harness + restages the Tauri card bundle
-yarn web             # rebuilds the WASM engine and card archive (yarn dev does too)
+# Clean rebuild — a plain build reuses stale .class files compiled against the
+# old Forge and silently ships a broken jar. Pin a JDK Forge can compile with.
+JAVA_HOME="$(/usr/libexec/java_home -v 21)" \
+  mvn -pl forge-harness -am clean package -DskipTests
+yarn ensure:harness   # restages the Tauri card bundle + updates the build checksum
+yarn web              # rebuilds the WASM engine and card archive (yarn dev does too)
 ```
 
-Committing the resulting submodule pointer bump (`git status` shows `M forge`) is
-a normal change — open a PR for it like any other.
+Two gotchas this avoids:
+
+- `yarn build:harness` / `yarn ensure:harness` run an **incremental** Maven build.
+  After a Forge bump they may reuse stale classes, so do the `mvn … clean package`
+  above at least once; the symptoms are deck cards stripped, `No enum constant …`,
+  or a `NoClassDefFoundError` at runtime.
+- `cargo run -p self-hosted-node` does **not** rebuild the harness; it loads the
+  prebuilt jar from `forge-harness/target/`. Rebuild the harness yourself after
+  any Forge change.
+
+A Forge bump can change Forge's Java API, which may require fixing compile errors
+in `forge-harness/` before it builds — do that in the same change. Then commit
+the submodule pointer bump (`git status` shows `M forge`) and open a PR like any
+other.
 
 ### Run the desktop app
 

--- a/forge-harness/src/main/java/forge/harness/AGENTS.md
+++ b/forge-harness/src/main/java/forge/harness/AGENTS.md
@@ -37,3 +37,5 @@ Jar is produced by `node scripts/harness.mjs ensure` (or `mvn -pl forge-harness 
 ```
 javac -d /tmp/out -cp target/forge-harness-jar-with-dependencies.jar $(find src/main/java -name '*.java')
 ```
+
+**After a `forge` submodule bump, do a _clean_ rebuild** (`mvn -pl forge-harness -am clean package -DskipTests`). `ensure`/`package` are incremental and key off source mtime, not the classpath — so a Forge change recompiles `forge/` but reuses the harness `.class` files compiled against the **old** Forge, silently shipping a broken jar (missing newer card enums like `CardSplitType.Prepare`, or synthetic `switch`-map classes like `SnapshotExtractor$1` → deck-load failures or a runtime `NoClassDefFoundError`). A Forge API change may also require updating the `PlayerController` overrides in `host/ManaBrewInteractiveController` + `parity/DeterministicController` (and call sites in `common/HarnessPlayPlumbing`) before it compiles. Keep the submodule pinned to the recorded gitlink with `git submodule update --init forge`; only `--remote` advances it. Build with JDK 18–21 — newer JDKs (e.g. 26) fail to compile Forge.

--- a/forge-harness/src/main/java/forge/harness/common/HarnessPlayPlumbing.java
+++ b/forge-harness/src/main/java/forge/harness/common/HarnessPlayPlumbing.java
@@ -256,7 +256,7 @@ public final class HarnessPlayPlumbing {
             for (final String aVar : announce.split(",")) {
                 final String varName = aVar.trim();
 
-                final Integer value = controller.announceRequirements(ability, varName);
+                final Integer value = controller.announceRequirements(ability, 0, Integer.MAX_VALUE, varName);
                 if (value == null) {
                     return false;
                 }
@@ -276,7 +276,7 @@ public final class HarnessPlayPlumbing {
                 final String sVar = ability.getParamOrDefault("XAlternative", ability.getSVar("X"));
                 boolean replacedXshard = ability.isSpell() && ability.getHostCard().getManaCost().countX() > 0 && !cost.hasXInAnyCostPart();
                 if (("Count$xPaid".equals(sVar) && !replacedXshard) || sVar.isEmpty()) {
-                    final Integer value = controller.announceRequirements(ability, "X");
+                    final Integer value = controller.announceRequirements(ability, 0, Integer.MAX_VALUE, "X");
                     if (value == null) {
                         return false;
                     }
@@ -422,13 +422,13 @@ public final class HarnessPlayPlumbing {
         return sa.setupTargets();
     }
 
-    public void orderAndPlaySimultaneousSa(List<SpellAbility> activePlayerSAs, final Game game) {
-        // Sort simultaneous triggers deterministically by host card zone-entry
-        // timestamp, with trigger ID as tiebreaker.  The engine's
-        // TriggerWaiting stores triggers in a HashMap which does not preserve
-        // insertion order; re-sorting here in the harness avoids modifying the
-        // engine's TriggerWaiting.java while matching the Rust engine's
-        // zone_timestamp ordering.
+    // Sort simultaneous triggers deterministically by host card zone-entry
+    // timestamp, with trigger ID as tiebreaker.  The engine's
+    // TriggerWaiting stores triggers in a HashMap which does not preserve
+    // insertion order; re-sorting here in the harness avoids modifying the
+    // engine's TriggerWaiting.java while matching the Rust engine's
+    // zone_timestamp ordering.
+    public List<SpellAbility> orderSimultaneousSa(List<SpellAbility> activePlayerSAs) {
         activePlayerSAs.sort((a, b) -> {
             long tsA = a.getHostCard().getGameTimestamp();
             long tsB = b.getHostCard().getGameTimestamp();
@@ -437,6 +437,11 @@ public final class HarnessPlayPlumbing {
             int idB = b.isTrigger() ? b.getTrigger().getId() : -1;
             return Integer.compare(idA, idB);
         });
+        return activePlayerSAs;
+    }
+
+    public void orderAndPlaySimultaneousSa(List<SpellAbility> activePlayerSAs, final Game game) {
+        orderSimultaneousSa(activePlayerSAs);
         for (final SpellAbility sa : activePlayerSAs) {
             if (sa.isTrigger() && !sa.isCopied()) {
                 boolean prepared = prepareSingleSa(sa.getHostCard(), sa, true);

--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveController.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveController.java
@@ -15,6 +15,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import forge.LobbyPlayer;
+import forge.ai.AiCostDecision;
 import forge.ai.ComputerUtilCombat;
 import forge.ai.ComputerUtilCost;
 import forge.card.ColorSet;
@@ -113,11 +114,15 @@ public final class ManaBrewInteractiveController extends PlayerController implem
     }
 
     @Override
-    public CardCollection tuckCardsViaMulligan(final Player mulliganingPlayer, final int cardsToReturn) {
+    public CardCollection tuckCardsViaMulligan(final CardCollectionView hand, final int cardsToReturn) {
         return new CardCollection();
     }
 
     @Override
+    public CostDecisionMakerBase getCostDecisionMaker(Player player, SpellAbility ability, boolean effect, String prompt) {
+        return new AiCostDecision(player, ability, effect);
+    }
+
     public boolean confirmMulliganScry(final Player p) {
         return session.awaitBooleanChoice(
                 "confirm_action", me(), "Scry 1 after mulligan?", null, "confirm_mulligan_scry", null, null);
@@ -213,6 +218,11 @@ public final class ManaBrewInteractiveController extends PlayerController implem
             return;
         }
         playPlumbing.playNoStack(player, effectSA, getGame(), true);
+    }
+
+    @Override
+    public List<SpellAbility> orderSimultaneousSa(final List<SpellAbility> activePlayerSAs) {
+        return playPlumbing.orderSimultaneousSa(activePlayerSAs);
     }
 
     @Override
@@ -611,7 +621,8 @@ public final class ManaBrewInteractiveController extends PlayerController implem
 
     @Override
     public CardCollection chooseCardsToDiscardFrom(
-            final Player playerDiscard, final SpellAbility sa, final CardCollection validCards, final int min, final int max) {
+            final Player playerDiscard, final SpellAbility sa, final CardCollection validCards, final int min, final int max,
+            final CardCollectionView visibleToChooser) {
         return session.awaitCardChoice("choose_discard", me(), validCards, min, max);
     }
 
@@ -623,8 +634,7 @@ public final class ManaBrewInteractiveController extends PlayerController implem
 
     @Override
     public CardCollectionView chooseCardsToDiscardUnlessType(
-            final int min, final CardCollectionView hand, final String param, final SpellAbility sa) {
-        final String[] splitUTypes = param.split(",");
+            final int min, final CardCollectionView hand, final String[] unlessTypes, final SpellAbility sa) {
         final int max = Math.min(min, hand.size());
         if (max == 0) {
             return session.awaitCardChoice("choose_discard", me(), hand, 0, 0, sourceName(sa), null);
@@ -633,11 +643,22 @@ public final class ManaBrewInteractiveController extends PlayerController implem
         while (guard++ < 512) {
             final CardCollection chosen =
                     session.awaitCardChoice("choose_discard", me(), hand, 1, max, sourceName(sa), null);
-            if (chosen.size() >= max || containsType(chosen, splitUTypes, sa)) {
+            if (chosen.size() >= max || containsType(chosen, unlessTypes, sa)) {
                 return chosen;
             }
         }
         return new CardCollection(new CardCollection(hand).subList(0, max));
+    }
+
+    @Override
+    public CardCollectionView chooseCardsForCost(final CardCollectionView optionList, final SpellAbility sa,
+            final CostPartWithList cpl, final int amount, final boolean isOptional, final String prompt) {
+        final CardCollection selected =
+                session.awaitCardChoice("choose_cards_for_cost", me(), optionList, amount, amount, sourceName(sa), prompt);
+        if (isOptional && selected.size() != amount) {
+            return null;
+        }
+        return selected;
     }
 
     private static boolean containsType(final CardCollection chosen, final String[] splitUTypes, final SpellAbility sa) {
@@ -1035,7 +1056,7 @@ public final class ManaBrewInteractiveController extends PlayerController implem
     }
 
     @Override
-    public StaticAbility chooseSingleStaticAbility(final String prompt, final List<StaticAbility> possibleReplacers) {
+    public StaticAbility chooseSingleStaticAbility(final List<StaticAbility> possibleReplacers) {
         return possibleReplacers == null || possibleReplacers.isEmpty() ? null : possibleReplacers.get(0);
     }
 
@@ -1176,7 +1197,7 @@ public final class ManaBrewInteractiveController extends PlayerController implem
     }
 
     @Override
-    public boolean chooseFlipResult(final SpellAbility sa, final Player flipper, final boolean[] results, final boolean call) {
+    public boolean chooseFlipResult(final SpellAbility sa, final Player flipper, final boolean call) {
         final List<String> labels = call
                 ? Lists.newArrayList("heads", "tails")
                 : Lists.newArrayList("win the flip", "lose the flip");
@@ -1325,11 +1346,13 @@ public final class ManaBrewInteractiveController extends PlayerController implem
     }
 
     @Override
-    public Integer announceRequirements(final SpellAbility ability, final String announce) {
+    public Integer announceRequirements(final SpellAbility ability, final int min, final int max, final String announce) {
         final int[] bounds = EngineHandler.announceBounds(player, ability, announce);
         if (bounds == null) {
             return null;
         }
+        bounds[0] = Math.max(bounds[0], min);
+        bounds[1] = Math.min(bounds[1], max);
         if (bounds[0] >= bounds[1]) {
             return bounds[0];
         }
@@ -1422,11 +1445,8 @@ public final class ManaBrewInteractiveController extends PlayerController implem
     }
 
     @Override
-    public int chooseSprocket(final Card assignee, final boolean forceDifferent) {
-        final List<Integer> options = new ArrayList<>(List.of(1, 2, 3));
-        if (forceDifferent && assignee != null) {
-            options.remove(Integer.valueOf(assignee.getSprocket()));
-        }
+    public int chooseSprocket(final Card assignee, final List<Integer> sprockets) {
+        final List<Integer> options = sprockets == null ? new ArrayList<>(List.of(1, 2, 3)) : new ArrayList<>(sprockets);
         return chooseNumber(null, "Choose sprocket", options, null);
     }
 
@@ -1441,9 +1461,9 @@ public final class ManaBrewInteractiveController extends PlayerController implem
     }
 
     @Override
-    public String chooseProtectionType(final String string, final SpellAbility sa, final List<String> choices) {
+    public String chooseProtectionType(final SpellAbility sa, final List<String> choices) {
         final List<String> options = choices == null ? new ArrayList<>() : new ArrayList<>(choices);
-        final String chosen = session.awaitStringChoice("choose_type", me(), options, sourceName(sa), string == null ? "Protection" : string);
+        final String chosen = session.awaitStringChoice("choose_type", me(), options, sourceName(sa), "Protection");
         return EngineHandler.validateOption(chosen, options, false);
     }
 
@@ -1565,7 +1585,7 @@ public final class ManaBrewInteractiveController extends PlayerController implem
     }
 
     @Override
-    public boolean payCostDuringRoll(final Cost cost, final SpellAbility sa, final FCollectionView<Player> allPayers) {
+    public boolean payCostDuringRoll(final Cost cost, final SpellAbility sa) {
         probingPayability = true;
         try {
             if (!ComputerUtilCost.canPayCost(cost, sa, player, true)) {
@@ -1591,6 +1611,20 @@ public final class ManaBrewInteractiveController extends PlayerController implem
     }
 
     // ── Mana payment (interactive) ────────────────────────────────────
+
+    @Override
+    public boolean applyManaToCost(
+            final ManaCostBeingPaid toPay,
+            final SpellAbility ability,
+            final String prompt,
+            final ManaConversionMatrix matrix,
+            final boolean effect
+    ) {
+        if (ability != null) {
+            applyManaConversionMatrix(matrix, ability);
+        }
+        return autoPay.payManaCost(toPay.toManaCost(), ability, effect);
+    }
 
     @Override
     public boolean payManaCost(

--- a/forge-harness/src/main/java/forge/harness/parity/DeterministicController.java
+++ b/forge-harness/src/main/java/forge/harness/parity/DeterministicController.java
@@ -18,14 +18,17 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import forge.StaticData;
 import forge.LobbyPlayer;
+import forge.ai.AiCostDecision;
 import forge.ai.ComputerUtilCombat;
 import forge.ai.ComputerUtilCost;
 import forge.game.ability.ApiType;
 import forge.game.ability.effects.RollDiceEffect;
 import forge.game.cost.Cost;
 import forge.game.cost.CostAdjustment;
+import forge.game.cost.CostDecisionMakerBase;
 import forge.game.cost.CostEnlist;
 import forge.game.cost.CostPart;
+import forge.game.cost.CostPartWithList;
 import forge.game.player.PlayerController;
 import forge.game.cost.CostPartMana;
 import forge.card.mana.ManaCost;
@@ -248,6 +251,11 @@ public class DeterministicController extends PlayerController implements Harness
         }
     }
 
+    @Override
+    public CostDecisionMakerBase getCostDecisionMaker(Player player, SpellAbility ability, boolean effect, String prompt) {
+        return new AiCostDecision(player, ability, effect);
+    }
+
     private List<SpellAbility> filterFailedPaymentActions(final List<SpellAbility> actions) {
         if (failedPaymentCardsThisTurn.isEmpty()) {
             return actions;
@@ -278,7 +286,6 @@ public class DeterministicController extends PlayerController implements Harness
         return result;
     }
 
-    @Override
     public boolean confirmMulliganScry(Player p) {
         onCallback("confirm_mulligan_scry", "false");
         return false;
@@ -354,7 +361,7 @@ public class DeterministicController extends PlayerController implements Harness
         if (payCosts != null) {
             ManaCost mana = payCosts.getTotalMana();
             if (mana != null && mana.countX() > 0) {
-                int maxX = ComputerUtilCost.getMaxXValue(sa, player, sa.isTrigger());
+                int maxX = ComputerUtilCost.setMaxXValue(sa, player, sa.isTrigger());
                 sa.setXManaCostPaid(Math.max(maxX, 0));
             }
         }
@@ -782,6 +789,15 @@ public class DeterministicController extends PlayerController implements Harness
     // Rust's choose_sacrifice sorts alphabetically by name, picks first.
 
     @Override
+    public CardCollectionView chooseCardsForCost(CardCollectionView optionList, SpellAbility sa,
+            CostPartWithList cpl, int amount, boolean isOptional, String prompt) {
+        final List<Card> sorted = ParityOrder.sortCardsByNameThenId(new ArrayList<Card>(optionList));
+        final CardCollectionView result = ChoiceSpace.pickManyCards(new CardCollection(sorted), amount, amount, rng);
+        onCallback("choose_cards_for_cost", formatCards(result), String.valueOf(optionList.size()), String.valueOf(amount));
+        return result;
+    }
+
+    @Override
     public CardCollectionView choosePermanentsToSacrifice(SpellAbility sa, int min, int max,
             CardCollectionView validTargets, String message) {
         captureDeepCheckpoint("choose_sacrifice");
@@ -825,7 +841,7 @@ public class DeterministicController extends PlayerController implements Harness
 
     @Override
     public CardCollection chooseCardsToDiscardFrom(Player playerDiscard, SpellAbility sa,
-            CardCollection validCards, int min, int max) {
+            CardCollection validCards, int min, int max, CardCollectionView visibleToChooser) {
         final List<Card> sorted = ParityOrder.sortCardsByNameThenId(new ArrayList<Card>(validCards));
         final CardCollection result = ChoiceSpace.pickManyCards(new CardCollection(sorted), min, max, rng);
         onCallback("choose_discard", formatCards(result), String.valueOf(validCards.size()), String.valueOf(min), String.valueOf(max));
@@ -990,8 +1006,11 @@ public class DeterministicController extends PlayerController implements Harness
     // not about paying or validating an entire cost payment plan.
 
     @Override
-    public Integer announceRequirements(SpellAbility ability, String announce) {
-        final Integer result = EngineHandler.announceRequirements(player, ability, announce, rng);
+    public Integer announceRequirements(SpellAbility ability, int min, int max, String announce) {
+        Integer result = EngineHandler.announceRequirements(player, ability, announce, rng);
+        if (result != null) {
+            result = Math.max(min, Math.min(max, result));
+        }
         onCallback("announce_requirements", String.valueOf(result), announce != null ? announce : "?");
         return result;
     }
@@ -1103,7 +1122,7 @@ public class DeterministicController extends PlayerController implements Harness
     // Rust default flip_coin_call returns true (always call heads).
 
     @Override
-    public boolean chooseFlipResult(SpellAbility sa, Player flipper, boolean[] results, boolean call) {
+    public boolean chooseFlipResult(SpellAbility sa, Player flipper, boolean call) {
         final boolean chosen = ChoiceSpace.pickBool(rng);
         onCallback("flip_coin_call", String.valueOf(chosen));
         return chosen;
@@ -1113,8 +1132,7 @@ public class DeterministicController extends PlayerController implements Harness
     // Rust default choose_cards_to_bottom returns first N cards.
 
     @Override
-    public CardCollectionView tuckCardsViaMulligan(Player mulliganingPlayer, int cardsToReturn) {
-        CardCollectionView hand = mulliganingPlayer.getCardsIn(ZoneType.Hand);
+    public CardCollectionView tuckCardsViaMulligan(CardCollectionView hand, int cardsToReturn) {
         CardCollection pool = new CardCollection(hand);
         CardCollection out = new CardCollection();
         int count = Math.min(cardsToReturn, pool.size());
@@ -1190,6 +1208,11 @@ public class DeterministicController extends PlayerController implements Harness
         final boolean result = playPlumbing.playNoStack(c.getController(), sa, getGame(), true);
         onCallback("pay_combat_cost", Boolean.toString(result), formatCard(c));
         return result;
+    }
+
+    @Override
+    public List<SpellAbility> orderSimultaneousSa(List<SpellAbility> activePlayerSAs) {
+        return playPlumbing.orderSimultaneousSa(activePlayerSAs);
     }
 
     @Override
@@ -1404,7 +1427,7 @@ public class DeterministicController extends PlayerController implements Harness
     }
 
     @Override
-    public CardCollectionView chooseCardsToDiscardUnlessType(int min, CardCollectionView hand, String param, SpellAbility sa) {
+    public CardCollectionView chooseCardsToDiscardUnlessType(int min, CardCollectionView hand, String[] unlessTypes, SpellAbility sa) {
         final List<Card> sorted = ParityOrder.sortCardsByNameThenId(new ArrayList<Card>(hand));
         final CardCollectionView result = ChoiceSpace.pickManyCards(new CardCollection(sorted), min, min, rng);
         onCallback("choose_discard_unless_type", formatCards(result), String.valueOf(hand.size()), String.valueOf(min));
@@ -1527,8 +1550,9 @@ public class DeterministicController extends PlayerController implements Harness
     }
 
     @Override
-    public int chooseSprocket(Card assignee, boolean forceDifferent) {
-        final int result = ChoiceSpace.pickIntInRange(1, 3, rng);
+    public int chooseSprocket(Card assignee, List<Integer> sprockets) {
+        final Integer picked = ChoiceSpace.pickOne(sprockets, rng);
+        final int result = picked == null ? 1 : picked;
         onCallback("choose_sprocket", String.valueOf(result));
         return result;
     }
@@ -1677,7 +1701,7 @@ public class DeterministicController extends PlayerController implements Harness
     }
 
     @Override
-    public StaticAbility chooseSingleStaticAbility(String prompt, List<StaticAbility> possibleReplacers) {
+    public StaticAbility chooseSingleStaticAbility(List<StaticAbility> possibleReplacers) {
         // Do NOT consume RNG here. This method is called during action-space evaluation
         // (canPlay() checks), not just at resolution time. Consuming RNG here causes
         // desync with Rust, which selects static abilities algorithmically without
@@ -1690,7 +1714,7 @@ public class DeterministicController extends PlayerController implements Harness
     }
 
     @Override
-    public String chooseProtectionType(String string, SpellAbility sa, List<String> choices) {
+    public String chooseProtectionType(SpellAbility sa, List<String> choices) {
         final String result = ChoiceSpace.pickOne(choices, rng);
         onCallback("choose_protection_type", result == null ? "null" : result, String.valueOf(choices.size()));
         return result;
@@ -1729,7 +1753,7 @@ public class DeterministicController extends PlayerController implements Harness
     }
 
     @Override
-    public boolean payCostDuringRoll(Cost cost, SpellAbility sa, FCollectionView<Player> allPayers) {
+    public boolean payCostDuringRoll(Cost cost, SpellAbility sa) {
         if (!ComputerUtilCost.canPayCost(cost, sa, player, true)) {
             onCallback("pay_cost_during_roll", "false", "cannot_pay");
             return false;
@@ -1737,6 +1761,17 @@ public class DeterministicController extends PlayerController implements Harness
         final boolean result = costPlumbing.payWithControllerDecision(cost, sa, true);
         onCallback("pay_cost_during_roll", Boolean.toString(result));
         return result;
+    }
+
+    @Override
+    public boolean applyManaToCost(
+            ManaCostBeingPaid toPay,
+            SpellAbility ability,
+            String prompt,
+            ManaConversionMatrix matrix,
+            boolean effect
+    ) {
+        return autoPay.payManaCost(toPay.toManaCost(), ability, effect);
     }
 
     @Override

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -39,5 +39,5 @@ Never use `--no-verify` to bypass the commit-msg or pre-commit hooks. If a hook 
 
 - **New scripts must be runnable via `yarn`.** Add the entry to `package.json`'s `scripts` so CI and humans use the same surface.
 - **Don't hardcode absolute paths.** Resolve from the repo root via `process.cwd()` or the script's own location.
-- **JDK 18 for harness work.** Set `JAVA_HOME` explicitly (`/Library/Java/JavaVirtualMachines/zulu-18.jdk/Contents/Home` on macOS).
+- **JDK 18–21 for harness work; newer JDKs (e.g. 26) fail to compile Forge.** Set `JAVA_HOME` explicitly — `/usr/libexec/java_home -v 21` on macOS (or a zulu-18 path). After a `forge` submodule bump, run `mvn -pl forge-harness -am clean package -DskipTests` once: `yarn build:harness`/`ensure:harness` are incremental and will otherwise reuse stale classes compiled against the old Forge. `cargo run` never rebuilds the harness.
 - **Keep stdout machine-readable when CI consumes it.** Status text → stderr; results → stdout.


### PR DESCRIPTION
## Summary
- Adapts the Forge harness (`forge-harness/`) to the `PlayerController` API changes introduced by the forge-submodule bump in #207, so it compiles **cleanly** against the pinned Forge again.
- Updates ~10 changed method signatures in `ManaBrewInteractiveController` and `DeterministicController` (e.g. `announceRequirements` gained `int min, int max`; `chooseFlipResult` lost `boolean[]`; `tuckCardsViaMulligan` takes the hand instead of the player; `chooseCardsToDiscardUnlessType` takes `String[]`; `chooseSprocket` takes `List<Integer>`; `chooseCardsToDiscardFrom` gained `visibleToChooser`; `chooseSingleStaticAbility`/`chooseProtectionType`/`payCostDuringRoll` dropped params; `confirmMulliganScry` is no longer an override).
- Implements the methods that became **newly abstract**: `getCostDecisionMaker(…, String prompt)` (→ `AiCostDecision`), `chooseCardsForCost`, `applyManaToCost` (→ existing harness `autoPay`), and `orderSimultaneousSa`. The parity controller's versions use the repo's deterministic `ParityOrder`/`ChoiceSpace`/`onCallback` conventions.
- Replaces removed `ComputerUtilCost.getMaxXValue` with `setMaxXValue`; updates both `announceRequirements` call sites in `HarnessPlayPlumbing` to the 4-arg form (`0` / `Integer.MAX_VALUE`, preserving prior behavior).

## Why
After #207 bumped the forge submodule, a **clean** harness build fails on `main` — but stale incremental `.class` reuse hid it, so the packaged jar was silently built against the *older* Forge. That produced jars missing newer enum values (e.g. `CardSplitType.Prepare`) and even synthetic classes (`SnapshotExtractor$1`, the `switch`-map for `phaseToRustName`). The visible symptoms in self-hosted games: decks with newer cards failed to load (`No enum constant CardSplitType.Prepare`), and games stalled right after mulligan with `NoClassDefFoundError: SnapshotExtractor$1` when building the first priority prompt. This restores a correct, complete harness jar for everyone.

## Test plan
- `JAVA_HOME="$(/usr/libexec/java_home -v 21)" mvn -pl forge-harness -am clean package -DskipTests` → **BUILD SUCCESS**, 0 checkstyle violations.
- `node scripts/harness.mjs build` → SUCCESS; runtime staged; checksum updated.
- Verified the rebuilt jar now contains `forge/harness/common/SnapshotExtractor$1.class` (the previously-missing switch-map) — the post-mulligan `NoClassDefFoundError` is resolved.
- Manual: self-hosted Forge room now advances past first-player-roll → mulligan → first priority prompt.

**Build note:** Forge must be built with **JDK 21** — `/usr/libexec/java_home` defaults to JDK 26, which fails the compile (and no JDK 18 is installed). Running the engine on JDK 26 is fine (it only loads the prebuilt jar); only the build needs 21.

**CI gap (follow-up):** no workflow does a clean harness build, which is how #207 merged with a broken harness. Worth adding a clean `forge-harness` build gate.

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
