### PR TITLE
ci(deploy): harden discord notify + add demo section to pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,27 @@
 ## Summary
+
 <!-- 1-3 bullets describing what this PR does. -->
 
 ## Why
+
 <!-- Motivation / context. Link related issues (Fixes #123). -->
 
 ## Test plan
+
 <!-- How was this verified? Commands, screenshots, parity scan results, etc. -->
 
+## Demo
+
+<!-- For UI changes, add before/after screenshots or a screen recording. Delete this section if not applicable. -->
+
 ## Build artifacts
+
 <!--
   Check the boxes below to build the corresponding installer on merge to main
   (uploaded to the Actions run, 30-day retention).
   Leave unchecked to skip — faster CI, no binaries produced.
   Tag pushes (v*) always build both and publish a GitHub Release regardless.
 -->
+
 - [ ] Build macOS .dmg on merge to main
 - [ ] Build Windows .exe / .msi on merge to main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,7 @@ jobs:
 
       - name: Post Discord embed (as bot)
         if: always()
+        continue-on-error: true
         env:
           BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
           CHANNEL_ID: ${{ secrets.DISCORD_DEPLOY_CHANNEL_ID }}
@@ -116,19 +117,32 @@ jobs:
               }]
             }')
 
+          # A failed notification (stale bot token, Discord outage, network
+          # blip) must never fail the deploy job: capture the HTTP status and
+          # downgrade any non-2xx to a ::warning:: annotation.
+          body=$(mktemp)
           if [ "$DEPLOY_OUTCOME" != "success" ] && [ -f deploy-raw.log ] && [ -s deploy-raw.log ]; then
-            curl -fsS -X POST \
+            http=$(curl -sS -X POST \
               -H "Authorization: Bot $BOT_TOKEN" \
               -F "payload_json=$PAYLOAD" \
               -F "files[0]=@deploy-raw.log;type=text/plain" \
-              "https://discord.com/api/v10/channels/$CHANNEL_ID/messages"
+              -o "$body" -w "%{http_code}" \
+              "https://discord.com/api/v10/channels/$CHANNEL_ID/messages" || echo "000")
           else
-            curl -fsS -X POST \
+            http=$(curl -sS -X POST \
               -H "Authorization: Bot $BOT_TOKEN" \
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \
-              "https://discord.com/api/v10/channels/$CHANNEL_ID/messages"
+              -o "$body" -w "%{http_code}" \
+              "https://discord.com/api/v10/channels/$CHANNEL_ID/messages" || echo "000")
           fi
+
+          if [ "$http" -ge 200 ] && [ "$http" -lt 300 ]; then
+            echo "Discord notification posted (HTTP $http)."
+          else
+            echo "::warning::Discord notification failed (HTTP $http): $(cat "$body" 2>/dev/null); deploy result is unaffected."
+          fi
+          rm -f "$body"
 
       - name: Fail job if deploy failed
         if: steps.deploy.outcome != 'success'


### PR DESCRIPTION
## Summary
- Make the Wasm-deploy Discord notification non-blocking: a failed notification (stale bot token, Discord outage, network blip) now downgrades to a `::warning::` annotation instead of failing the `deploy` job.
- Replace the bare `curl -fsS` calls in `deploy.yml` with status-capturing curls (`-w "%{http_code}"`, `|| echo "000"`) and add `continue-on-error: true` as a belt-and-suspenders guard.
- Add a **Demo** section to the PR template (between Test plan and Build artifacts) for before/after screenshots or a screen recording on UI changes.

## Why
The Discord step in `deploy.yml` used `curl -fsS`, where `-f` makes curl exit non-zero on any HTTP error. A stale `DISCORD_BOT_TOKEN` (returns `401`) therefore failed the step and the entire deploy job — a notification problem taking down the actual deploy result. The other Discord steps in `release-artifacts.yml` already use a resilient wrapper; this brings `deploy.yml` in line.

The PR-template change is a small docs tweak bundled here at the author's request.

Note: after merge, with a wrong token the job passes but emits a yellow warning on every run until the `DISCORD_BOT_TOKEN` secret is refreshed.

## Test plan
- Audited every Discord call in `.github/workflows/`: `deploy.yml` was the only one using `curl -f`; the three steps in `release-artifacts.yml` already retry + warn + return 0. No third-party Discord/webhook actions exist.
- `ruby -ryaml -e "YAML.load_file('.github/workflows/deploy.yml')"` parses clean; prettier (lint-staged pre-commit hook) reformatted and passed.

## Demo
N/A — CI/docs change.

## Build artifacts
- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main