### PR TITLE
docs: add demo section to pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,27 @@
 ## Summary
+
 <!-- 1-3 bullets describing what this PR does. -->
 
 ## Why
+
 <!-- Motivation / context. Link related issues (Fixes #123). -->
 
 ## Test plan
+
 <!-- How was this verified? Commands, screenshots, parity scan results, etc. -->
 
+## Demo
+
+<!-- For UI changes, add before/after screenshots or a screen recording. Delete this section if not applicable. -->
+
 ## Build artifacts
+
 <!--
   Check the boxes below to build the corresponding installer on merge to main
   (uploaded to the Actions run, 30-day retention).
   Leave unchecked to skip — faster CI, no binaries produced.
   Tag pushes (v*) always build both and publish a GitHub Release regardless.
 -->
+
 - [ ] Build macOS .dmg on merge to main
 - [ ] Build Windows .exe / .msi on merge to main


### PR DESCRIPTION
## Summary
- Add a **Demo** section to the PR template (between Test plan and Build artifacts) for before/after screenshots or a screen recording on UI changes.

## Why
UI PRs benefit from visual evidence; a dedicated, clearly-named section prompts authors to include it (and to delete it when not applicable).

## Test plan
- Markdown-only change to `.github/pull_request_template.md`; prettier (lint-staged pre-commit hook) passed.

## Demo
N/A — template/docs change.