### PR TITLE
fix(forge): wistfulness not triggering ETB

### DIFF
--- a/forge-harness/src/main/java/forge/harness/common/AutoPay.java
+++ b/forge-harness/src/main/java/forge/harness/common/AutoPay.java
@@ -52,10 +52,10 @@ public final class AutoPay {
     public PayManaCostResult payManaCostWithTrace(final ManaCost toPay, final SpellAbility saBeingPaid, final boolean effect) {
         final ManaCostBeingPaid unpaid = new ManaCostBeingPaid(toPay);
         final ManaPool pool = payer.getManaPool();
-        final List<Mana> spentFromPool = new ArrayList<>();
+        final List<Mana> manaSpentToPay = saBeingPaid.getPayingMana();
         final List<String> steps = new ArrayList<>();
 
-        if (pool.payManaCostFromPool(unpaid, saBeingPaid, false, spentFromPool)) {
+        if (pool.payManaCostFromPool(unpaid, saBeingPaid, false, manaSpentToPay)) {
             CostPayment.handleOfferings(saBeingPaid, false, true);
             steps.add("Pay");
             return new PayManaCostResult(true, steps);
@@ -83,7 +83,7 @@ public final class AutoPay {
             payer.getGame().getStack().addAndUnfreeze(chosen.spellAbility);
 
             pool.payManaFromAbility(saBeingPaid, unpaid, chosen.spellAbility);
-            pool.payManaCostFromPool(unpaid, saBeingPaid, false, spentFromPool);
+            pool.payManaCostFromPool(unpaid, saBeingPaid, false, manaSpentToPay);
         }
 
         if (!unpaid.isPaid()) {
@@ -122,7 +122,7 @@ public final class AutoPay {
         final boolean paid = unpaid.isPaid();
         CostPayment.handleOfferings(saBeingPaid, false, paid);
         if (!paid) {
-            pool.refundMana(spentFromPool);
+            pool.refundMana(manaSpentToPay);
             saBeingPaid.setSkip(true);
             steps.add("Cancel");
         } else {

--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveController.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveController.java
@@ -1881,7 +1881,7 @@ public final class ManaBrewInteractiveController extends PlayerController implem
                     if (!canConfirm) {
                         break;
                     }
-                    pool.payManaCostFromPool(unpaid, sa, false, new ArrayList<>());
+                    pool.payManaCostFromPool(unpaid, sa, false, sa.getPayingMana());
                     if (unpaid.isPaid()) {
                         return true;
                     }


### PR DESCRIPTION
## Summary
`forge-harness` was swallowing mana being paid during a cast. As a result, [[Wistfulness]] would miss ETB as it relied on a reference of the mana that was paid to cast it

closes #249 


## Build artifacts

<!--
  Check the boxes below to build the corresponding installer on merge to main
  (uploaded to the Actions run, 30-day retention).
  Leave unchecked to skip — faster CI, no binaries produced.
  Tag pushes (v*) always build both and publish a GitHub Release regardless.
-->

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
