### PR TITLE
fix(docker): generate harness protocol classes

### DIFF
--- a/manabrew-rs/crates/parity/Dockerfile
+++ b/manabrew-rs/crates/parity/Dockerfile
@@ -1,4 +1,26 @@
 # syntax=docker/dockerfile:1
+# ── Stage 0: Generate Java prompt protocol classes ──────────────────
+FROM rust:1.88-bookworm AS protocol-builder
+
+WORKDIR /build
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY Cargo.toml Cargo.lock ./
+COPY manabrew-rs/ manabrew-rs/
+COPY src-tauri/Cargo.toml src-tauri/Cargo.toml
+RUN mkdir -p src-tauri/src && echo "fn main() {}" > src-tauri/src/main.rs && touch src-tauri/src/lib.rs
+COPY tree-sitter-forge-card-script/ tree-sitter-forge-card-script/
+COPY scripts/gen-harness-prompts.mjs scripts/gen-harness-prompts.mjs
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/build/target \
+    cargo run -q -p manabrew-protocol --bin gen-protocol -- src/protocol && \
+    node scripts/gen-harness-prompts.mjs /generated
+
 # ── Stage 1: Build Java harness JAR ─────────────────────────────────
 FROM maven:3.9-eclipse-temurin-17 AS java-builder
 
@@ -46,6 +68,8 @@ COPY forge/forge-game/    forge/forge-game/
 COPY forge/forge-ai/      forge/forge-ai/
 COPY forge/forge-gui/     forge/forge-gui/
 COPY forge-harness/       forge-harness/
+COPY --from=protocol-builder /generated/forge/harness/protocol/ \
+    forge-harness/src/main/java/forge/harness/protocol/
 
 # Build the harness fat JAR in one reactor with its engine deps
 RUN --mount=type=cache,target=/root/.m2/repository \

--- a/manabrew-rs/crates/self-hosted-node/Dockerfile
+++ b/manabrew-rs/crates/self-hosted-node/Dockerfile
@@ -6,6 +6,28 @@
 # counters can't race across games. The Rust backend exists too
 # (SELF_HOSTED_NODE_ENGINE_BACKEND=manabrew) but this image defaults to forge.
 
+# ── Stage 0: Generate Java prompt protocol classes ──────────────────
+FROM rust:1.88-bookworm AS protocol-builder
+
+WORKDIR /build
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY Cargo.toml Cargo.lock ./
+COPY manabrew-rs/ manabrew-rs/
+COPY src-tauri/Cargo.toml src-tauri/Cargo.toml
+RUN mkdir -p src-tauri/src && echo "fn main() {}" > src-tauri/src/main.rs && touch src-tauri/src/lib.rs
+COPY tree-sitter-forge-card-script/ tree-sitter-forge-card-script/
+COPY scripts/gen-harness-prompts.mjs scripts/gen-harness-prompts.mjs
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/build/target \
+    cargo run -q -p manabrew-protocol --bin gen-protocol -- src/protocol && \
+    node scripts/gen-harness-prompts.mjs /generated
+
 # ── Stage 1: Build the Java Forge harness JAR ───────────────────────
 # Mirrors parity/Dockerfile — the harness jar bundles forge-core / game
 # / ai / gui and exposes forge.harness.ManaBrewEngineAdapter, the class j4rs
@@ -48,6 +70,8 @@ COPY forge/forge-game/    forge/forge-game/
 COPY forge/forge-ai/      forge/forge-ai/
 COPY forge/forge-gui/     forge/forge-gui/
 COPY forge-harness/       forge-harness/
+COPY --from=protocol-builder /generated/forge/harness/protocol/ \
+    forge-harness/src/main/java/forge/harness/protocol/
 
 RUN --mount=type=cache,target=/root/.m2/repository \
     mvn -pl forge-harness -am -DskipTests -Dcheckstyle.skip package -q

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -23,6 +23,8 @@ The **runtime** client-half prompt check is a vitest test (`src/stores/gameStore
 
 The **Java harness-half** is checked at **compile time**, not runtime: `gen-harness-prompts.mjs` generates typed Java prompt classes from the protocol, and the harness builds every prompt from them — so a protocol change the harness no longer matches fails `yarn build:harness` (the compiler is the check). This replaced an earlier static-string guard.
 
+Docker images that build the harness directly must perform the same generation step before Maven runs. The generated `forge.harness.protocol.*` sources are gitignored, so any Dockerfile that copies `forge-harness/` and invokes `mvn -pl forge-harness ...` without first running `gen-protocol` + `gen-harness-prompts.mjs` will fail with missing classes such as `ChooseCardsInput` or `CardDto`.
+
 ## Lint and format (yarn)
 
 These are `package.json` scripts (not files in this folder). **Run before every commit** — see the root `/AGENTS.md` "Before every commit" section.


### PR DESCRIPTION
## Summary

- Adds a protocol generation stage to the parity and self-hosted-node Dockerfiles.
- Copies generated `forge.harness.protocol.*` Java sources into `forge-harness` before Maven compiles the harness.
- Documents the required Docker generation step in `scripts/AGENTS.md`.

## Why

The Java harness prompt protocol classes are generated and gitignored. Docker images that build `forge-harness` directly were copying the harness source and running Maven without first generating those classes, which can fail with missing symbols such as `ChooseCardsInput` and `CardDto`.

## Test plan

- `docker build --target java-builder -f manabrew-rs/crates/parity/Dockerfile .`
- `docker build --target java-builder -f manabrew-rs/crates/self-hosted-node/Dockerfile .`
- `yarn lint:all` *(fails on existing Rust clippy baseline in `forge-card-script`, `forge-foundation`, and `manabrew-protocol`; JS lint, Prettier, protocol generation, and TypeScript completed before the clippy failures.)*

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
