### PR TITLE
fix(dev) harden vite file watching

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,7 +41,20 @@ export default defineConfig({
     host: host || false,
     hmr: host ? { protocol: "ws", host, port: 1421 } : undefined,
     watch: {
-      ignored: ["**/src-tauri/**", "**/forge/**", "**/node_modules/**"],
+      useFsEvents: false,
+      usePolling: true,
+      interval: 750,
+      ignored: [
+        "**/.logs/**",
+        "**/forge/**",
+        "**/forge-harness/**",
+        "**/manabrew-rs/**",
+        "**/node_modules/**",
+        "**/parity_decks/**",
+        "**/src-tauri/**",
+        "**/target/**",
+        "**/website/**",
+      ],
     },
     headers: {
       "Cross-Origin-Opener-Policy": "same-origin",


### PR DESCRIPTION
## Summary

- Forces Vite's file watcher off macOS FSEvents and onto polling.
- Ignores backend, build, docs, log, and generated trees that should not trigger frontend HMR.

## Why

Local dev was receiving metadata-only filesystem events for unchanged files. Vite treated those as frontend updates and eventually emitted a full reload while a game was in progress. 

## Test plan

- `yarn prettier --check vite.config.ts`
- `yarn tsc --noEmit --pretty false`
- `yarn lint:all` was attempted, but fails on existing `forge-card-script` clippy `unnecessary_lazy_evaluations` warnings in `manabrew-rs/crates/forge-card-script/src/lib.rs` at lines 748, 757, 766, 775, and 869.

## Demo

Not applicable.

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
