### PR TITLE
feat(ui): warn about manabrew engine in offline engine modal

### DIFF
--- a/src/components/lobby/EngineChoiceModal.tsx
+++ b/src/components/lobby/EngineChoiceModal.tsx
@@ -6,7 +6,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import { Badge } from "@/components/ui/badge";
-import { Cpu, Cloud } from "lucide-react";
+import { Cpu, Cloud, TriangleAlert } from "lucide-react";
 import type { EngineKind } from "@/types/server";
 
 interface EngineChoiceModalProps {
@@ -63,6 +63,14 @@ export function EngineChoiceModal({ onChoose, onCancel, hostedAvailable }: Engin
                 : "Forge on a Manabrew-hosted node — full card support. Not available in this build."}
             </p>
           </button>
+        </div>
+        <div className="flex items-start gap-2 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning">
+          <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <p>
+            {hostedAvailable
+              ? "The Manabrew engine is a work in progress and may have bugs or missing cards. For the most stable experience, play on the Forge engine."
+              : "The Manabrew engine is a work in progress and may have bugs or missing cards."}
+          </p>
         </div>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary

- Add the Manabrew-engine work-in-progress warning banner (the one shown when creating a room in the lobby) to the offline `EngineChoiceModal` used in the play route.

## Why

When starting an offline game vs AI, the engine picker offered Manabrew with no caveat that its card support is an in-progress Rust port — unlike the lobby room-creation flow, which already warns. This brings the two entry points in line so players know what to expect (and to prefer Forge when it's available).

## Test plan

- `yarn lint` (eslint + prettier + tsc) passes.
- Manual: open the play route, start a game vs AI → the engine modal now shows the warning banner below the two engine cards. The "play on the Forge engine" suggestion only appears when a hosted Forge node is available (`hostedAvailable`); offline-only builds get the trimmed WIP wording.

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
