### PR TITLE
feat(ui): custom playmats and player avatars

### DIFF
--- a/manabrew-rs/crates/manabot/src/state.rs
+++ b/manabrew-rs/crates/manabot/src/state.rs
@@ -111,6 +111,7 @@ impl BotState {
                         deck_name: self.config.deck_name.clone(),
                         deck: self.config.deck.clone(),
                         commander_name: self.config.commander_name.clone(),
+                        avatar: None,
                     },
                     ClientMessage::SetReady { ready: true },
                 ]

--- a/manabrew-rs/crates/manabrew-protocol/src/deck_dto.rs
+++ b/manabrew-rs/crates/manabrew-protocol/src/deck_dto.rs
@@ -92,6 +92,8 @@ pub struct PlaymatSettings {
     pub border_width: Option<f32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub border_color: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fit: Option<String>,
 }
 
 /// Mirror of `manabrew.ts:Deck`. The engine cares about `cards`,

--- a/manabrew-rs/crates/manabrew-protocol/src/deck_dto.rs
+++ b/manabrew-rs/crates/manabrew-protocol/src/deck_dto.rs
@@ -98,6 +98,8 @@ pub struct PlaymatSettings {
     pub offset_x: Option<f32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub offset_y: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
 }
 
 /// Mirror of `manabrew.ts:Deck`. The engine cares about `cards`,

--- a/manabrew-rs/crates/manabrew-protocol/src/deck_dto.rs
+++ b/manabrew-rs/crates/manabrew-protocol/src/deck_dto.rs
@@ -3,6 +3,11 @@
 //! it cares about (cards, sideboard, commanders, supplementary decks)
 //! and serde silently drops the rest (UI-only state like
 //! `stackPositions`, `customTags`, `coverCardName`, etc.).
+//!
+//! The engine ignores `playmat` too, but the relay does not: because the deck
+//! travels inside `PlayerDeckInfo`, the deck's `playmat` cosmetic reaches every
+//! player in the `GameStarted` broadcast. It is sanitized server-side
+//! (`lobby::sanitize_cosmetic`) to a bounded WebP data URL before forwarding.
 
 use serde::{Deserialize, Serialize};
 
@@ -120,6 +125,8 @@ pub struct Deck {
     pub cover_card_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cover_card_face: Option<u8>,
+    /// Battlefield playmat cosmetic — a bounded WebP data URL. Forwarded to
+    /// opponents at game start; see the module doc.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub playmat: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/manabrew-rs/crates/manabrew-protocol/src/deck_dto.rs
+++ b/manabrew-rs/crates/manabrew-protocol/src/deck_dto.rs
@@ -94,6 +94,10 @@ pub struct PlaymatSettings {
     pub border_color: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fit: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub offset_x: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub offset_y: Option<f32>,
 }
 
 /// Mirror of `manabrew.ts:Deck`. The engine cares about `cards`,

--- a/manabrew-rs/crates/manabrew-protocol/src/deck_dto.rs
+++ b/manabrew-rs/crates/manabrew-protocol/src/deck_dto.rs
@@ -79,6 +79,21 @@ pub struct DeckLabel {
     pub color: Option<String>,
 }
 
+/// Mirror of `manabrew.ts:PlaymatSettings`. UI-only render tuning carried with
+/// the deck so opponents see the same customized playmat.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PlaymatSettings {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub opacity: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub texture: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub border_width: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub border_color: Option<String>,
+}
+
 /// Mirror of `manabrew.ts:Deck`. The engine cares about `cards`,
 /// `sideboard`, `commanders`, and the supplementary decks
 /// (`attractions`/`contraptions`/`schemes`/`planes`); the rest is UI
@@ -129,6 +144,8 @@ pub struct Deck {
     /// opponents at game start; see the module doc.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub playmat: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub playmat_settings: Option<PlaymatSettings>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stack_positions: Option<serde_json::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/manabrew-rs/crates/manabrew-protocol/src/deck_dto.rs
+++ b/manabrew-rs/crates/manabrew-protocol/src/deck_dto.rs
@@ -121,6 +121,8 @@ pub struct Deck {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cover_card_face: Option<u8>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub playmat: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stack_positions: Option<serde_json::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tokens: Option<Vec<DeckCard>>,

--- a/manabrew-rs/crates/manabrew-protocol/src/deck_dto.rs
+++ b/manabrew-rs/crates/manabrew-protocol/src/deck_dto.rs
@@ -3,11 +3,6 @@
 //! it cares about (cards, sideboard, commanders, supplementary decks)
 //! and serde silently drops the rest (UI-only state like
 //! `stackPositions`, `customTags`, `coverCardName`, etc.).
-//!
-//! The engine ignores `playmat` too, but the relay does not: because the deck
-//! travels inside `PlayerDeckInfo`, the deck's `playmat` cosmetic reaches every
-//! player in the `GameStarted` broadcast. It is sanitized server-side
-//! (`lobby::sanitize_cosmetic`) to a bounded WebP data URL before forwarding.
 
 use serde::{Deserialize, Serialize};
 
@@ -79,8 +74,6 @@ pub struct DeckLabel {
     pub color: Option<String>,
 }
 
-/// Mirror of `manabrew.ts:PlaymatSettings`. UI-only render tuning carried with
-/// the deck so opponents see the same customized playmat.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PlaymatSettings {
@@ -148,8 +141,6 @@ pub struct Deck {
     pub cover_card_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cover_card_face: Option<u8>,
-    /// Battlefield playmat cosmetic — a bounded WebP data URL. Forwarded to
-    /// opponents at game start; see the module doc.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub playmat: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/manabrew-rs/crates/manabrew-protocol/src/protocol.rs
+++ b/manabrew-rs/crates/manabrew-protocol/src/protocol.rs
@@ -8,6 +8,8 @@ pub struct PlayerDeckInfo {
     pub deck: Deck,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub commander_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub avatar: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -66,6 +68,8 @@ pub enum ClientMessage {
         deck_name: String,
         deck: Deck,
         commander_name: Option<String>,
+        #[serde(default)]
+        avatar: Option<String>,
     },
 
     SetFormat {

--- a/manabrew-rs/crates/manabrew-protocol/src/protocol.rs
+++ b/manabrew-rs/crates/manabrew-protocol/src/protocol.rs
@@ -8,6 +8,9 @@ pub struct PlayerDeckInfo {
     pub deck: Deck,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub commander_name: Option<String>,
+    /// The player's global avatar (bounded WebP data URL), broadcast to everyone
+    /// in `GameStarted`. Sanitized server-side (`lobby::sanitize_cosmetic`). The
+    /// deck's own playmat cosmetic rides along inside `deck`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub avatar: Option<String>,
 }
@@ -68,6 +71,8 @@ pub enum ClientMessage {
         deck_name: String,
         deck: Deck,
         commander_name: Option<String>,
+        /// Sender's global avatar (WebP data URL). Stored on the room slot and
+        /// surfaced to all players via `PlayerDeckInfo.avatar` at game start.
         #[serde(default)]
         avatar: Option<String>,
     },

--- a/manabrew-rs/crates/manabrew-protocol/src/protocol.rs
+++ b/manabrew-rs/crates/manabrew-protocol/src/protocol.rs
@@ -8,9 +8,6 @@ pub struct PlayerDeckInfo {
     pub deck: Deck,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub commander_name: Option<String>,
-    /// The player's global avatar (bounded WebP data URL), broadcast to everyone
-    /// in `GameStarted`. Sanitized server-side (`lobby::sanitize_cosmetic`). The
-    /// deck's own playmat cosmetic rides along inside `deck`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub avatar: Option<String>,
 }
@@ -71,8 +68,6 @@ pub enum ClientMessage {
         deck_name: String,
         deck: Deck,
         commander_name: Option<String>,
-        /// Sender's global avatar (WebP data URL). Stored on the room slot and
-        /// surfaced to all players via `PlayerDeckInfo.avatar` at game start.
         #[serde(default)]
         avatar: Option<String>,
     },

--- a/manabrew-rs/crates/manabrew-server/src/connection.rs
+++ b/manabrew-rs/crates/manabrew-server/src/connection.rs
@@ -743,6 +743,7 @@ fn handle_client_message(
             deck_name,
             deck,
             commander_name,
+            avatar,
         } => {
             info!(
                 "[lobby] '{}' selected deck '{}' ({} cards)",
@@ -750,8 +751,14 @@ fn handle_client_message(
                 deck_name,
                 deck.cards.len()
             );
-            match lobby::set_deck_selection_sync(state, player_id, deck_name, deck, commander_name)
-            {
+            match lobby::set_deck_selection_sync(
+                state,
+                player_id,
+                deck_name,
+                deck,
+                commander_name,
+                avatar,
+            ) {
                 Ok(room_id) => {
                     if let Some(room) = state.rooms.get(&room_id) {
                         broadcast_to_room(

--- a/manabrew-rs/crates/manabrew-server/src/lobby.rs
+++ b/manabrew-rs/crates/manabrew-server/src/lobby.rs
@@ -253,15 +253,10 @@ const MAX_COSMETIC_LEN: usize = 1_500_000;
 const COSMETIC_PREFIX: &str = "data:image/webp;base64,";
 const MAX_COLOR_LEN: usize = 32;
 
-/// Drop any cosmetic image that isn't a bounded WebP data URL — the client
-/// normalizes to WebP before sending, so anything else is malformed or oversized
-/// and must never reach a `GameStarted` broadcast.
 fn sanitize_cosmetic(value: Option<String>) -> Option<String> {
     value.filter(|s| s.len() <= MAX_COSMETIC_LEN && s.starts_with(COSMETIC_PREFIX))
 }
 
-/// Playmat render-tuning colors are free strings broadcast to everyone; cap their
-/// length so a deck can't smuggle a large payload through `playmatSettings`.
 fn sanitize_playmat_settings(settings: &mut PlaymatSettings) {
     settings.color = settings.color.take().filter(|s| s.len() <= MAX_COLOR_LEN);
     settings.border_color = settings

--- a/manabrew-rs/crates/manabrew-server/src/lobby.rs
+++ b/manabrew-rs/crates/manabrew-server/src/lobby.rs
@@ -7,7 +7,7 @@ use crate::protocol::{
 use crate::replay::GameReplayCache;
 use crate::room::Room;
 use crate::state::ServerState;
-use manabrew_protocol::deck_dto::Deck;
+use manabrew_protocol::deck_dto::{Deck, PlaymatSettings};
 use manabrew_protocol::protocol::DEFAULT_RECONNECT_TIMEOUT_S;
 
 const MIN_RECONNECT_TIMEOUT_S: u32 = 10;
@@ -251,12 +251,23 @@ pub fn set_ready_sync(
 
 const MAX_COSMETIC_LEN: usize = 1_500_000;
 const COSMETIC_PREFIX: &str = "data:image/webp;base64,";
+const MAX_COLOR_LEN: usize = 32;
 
 /// Drop any cosmetic image that isn't a bounded WebP data URL — the client
 /// normalizes to WebP before sending, so anything else is malformed or oversized
 /// and must never reach a `GameStarted` broadcast.
 fn sanitize_cosmetic(value: Option<String>) -> Option<String> {
     value.filter(|s| s.len() <= MAX_COSMETIC_LEN && s.starts_with(COSMETIC_PREFIX))
+}
+
+/// Playmat render-tuning colors are free strings broadcast to everyone; cap their
+/// length so a deck can't smuggle a large payload through `playmatSettings`.
+fn sanitize_playmat_settings(settings: &mut PlaymatSettings) {
+    settings.color = settings.color.take().filter(|s| s.len() <= MAX_COLOR_LEN);
+    settings.border_color = settings
+        .border_color
+        .take()
+        .filter(|s| s.len() <= MAX_COLOR_LEN);
 }
 
 pub fn set_deck_selection_sync(
@@ -276,6 +287,9 @@ pub fn set_deck_selection_sync(
     };
 
     deck.playmat = sanitize_cosmetic(deck.playmat.take());
+    if let Some(settings) = deck.playmat_settings.as_mut() {
+        sanitize_playmat_settings(settings);
+    }
     let avatar = sanitize_cosmetic(avatar);
 
     {

--- a/manabrew-rs/crates/manabrew-server/src/lobby.rs
+++ b/manabrew-rs/crates/manabrew-server/src/lobby.rs
@@ -249,12 +249,23 @@ pub fn set_ready_sync(
     Ok(room_id)
 }
 
+const MAX_COSMETIC_LEN: usize = 1_500_000;
+const COSMETIC_PREFIX: &str = "data:image/webp;base64,";
+
+/// Drop any cosmetic image that isn't a bounded WebP data URL — the client
+/// normalizes to WebP before sending, so anything else is malformed or oversized
+/// and must never reach a `GameStarted` broadcast.
+fn sanitize_cosmetic(value: Option<String>) -> Option<String> {
+    value.filter(|s| s.len() <= MAX_COSMETIC_LEN && s.starts_with(COSMETIC_PREFIX))
+}
+
 pub fn set_deck_selection_sync(
     state: &Arc<ServerState>,
     player_id: &str,
     deck_name: String,
-    deck: Deck,
+    mut deck: Deck,
     commander_name: Option<String>,
+    avatar: Option<String>,
 ) -> Result<String, ServerError> {
     let room_id = {
         state
@@ -263,6 +274,9 @@ pub fn set_deck_selection_sync(
             .and_then(|p| p.room_id.clone())
             .ok_or(ServerError::NotInRoom)?
     };
+
+    deck.playmat = sanitize_cosmetic(deck.playmat.take());
+    let avatar = sanitize_cosmetic(avatar);
 
     {
         let mut room = state
@@ -274,7 +288,7 @@ pub fn set_deck_selection_sync(
             return Err(ServerError::GameAlreadyStarted);
         }
 
-        room.set_deck_selection(player_id, deck_name, deck, commander_name)
+        room.set_deck_selection(player_id, deck_name, deck, commander_name, avatar)
             .map_err(|_| ServerError::NotInRoom)?;
     }
 

--- a/manabrew-rs/crates/manabrew-server/src/room.rs
+++ b/manabrew-rs/crates/manabrew-server/src/room.rs
@@ -15,6 +15,7 @@ pub struct RoomSlot {
     pub selected_deck_name: Option<String>,
     pub selected_deck: Option<Deck>,
     pub selected_commander_name: Option<String>,
+    pub avatar: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -72,6 +73,7 @@ impl Room {
                     selected_deck_name: None,
                     selected_deck: None,
                     selected_commander_name: None,
+                    avatar: None,
                 }],
                 vec![],
             )
@@ -162,6 +164,7 @@ impl Room {
             selected_deck_name: None,
             selected_deck: None,
             selected_commander_name: None,
+            avatar: None,
         });
         Ok(())
     }
@@ -237,11 +240,13 @@ impl Room {
         deck_name: String,
         deck: Deck,
         commander_name: Option<String>,
+        avatar: Option<String>,
     ) -> Result<(), String> {
         if let Some(slot) = self.players.iter_mut().find(|p| p.player_id == player_id) {
             slot.selected_deck_name = Some(deck_name);
             slot.selected_deck = Some(deck);
             slot.selected_commander_name = commander_name;
+            slot.avatar = avatar;
             slot.ready = false;
             Ok(())
         } else {
@@ -269,6 +274,7 @@ impl Room {
                         .unwrap_or_else(|| "Unknown Deck".to_string()),
                     deck,
                     commander_name: p.selected_commander_name.clone(),
+                    avatar: p.avatar.clone(),
                 })
             })
             .collect()

--- a/manabrew-rs/crates/self-hosted-node/src/main.rs
+++ b/manabrew-rs/crates/self-hosted-node/src/main.rs
@@ -408,6 +408,7 @@ async fn seat_client(
             deck_name: deck.name.clone(),
             deck: deck.deck.clone(),
             commander_name: deck.commander_name.clone(),
+            avatar: None,
         })
         .await?;
     client

--- a/manabrew-rs/crates/self-hosted-node/tests/hosted_smoke.rs
+++ b/manabrew-rs/crates/self-hosted-node/tests/hosted_smoke.rs
@@ -169,6 +169,7 @@ async fn play_game(
                 deck: serde_json::from_value(basic_deck("Smoke Player", "Mountain", "Hill Giant"))
                     .map_err(|e| e.to_string())?,
                 commander_name: None,
+                avatar: None,
             },
         )
         .await?;

--- a/src-tauri/src/server_commands.rs
+++ b/src-tauri/src/server_commands.rs
@@ -156,6 +156,7 @@ pub async fn server_set_deck_selection(
     deck_name: String,
     deck: Deck,
     commander_name: Option<String>,
+    avatar: Option<String>,
 ) -> Result<(), String> {
     send_server_message(
         &client,
@@ -164,6 +165,7 @@ pub async fn server_set_deck_selection(
             "deck_name": deck_name,
             "deck": deck,
             "commander_name": commander_name,
+            "avatar": avatar,
         }),
     )
 }

--- a/src/components/editor/DeckHero.tsx
+++ b/src/components/editor/DeckHero.tsx
@@ -1,6 +1,5 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { ArrowLeft, Check, ChevronDown, ImagePlus, Pencil } from "lucide-react";
-import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -15,7 +14,6 @@ import { DeckLabelBadge } from "@/components/deck/DeckLabelBadge";
 import { resolveCoverCard } from "@/components/deck/deckCover.utils";
 import { GAME_FORMATS, getFormat } from "@/lib/formats";
 import { useDeckStore } from "@/stores/useDeckStore";
-import { normalizeToWebp, ImageTooLargeError, PLAYMAT_IMAGE_BUDGET } from "@/lib/imageEncode";
 import { PlaymatEditorModal } from "./PlaymatEditorModal";
 import { cn } from "@/lib/utils";
 import type { DeckFormatId } from "@/types/manabrew";
@@ -25,28 +23,15 @@ export function DeckHero({ onBack }: { onBack?: () => void }) {
   const isReadOnly = useDeckStore((s) => s.isReadOnly);
   const setDeckName = useDeckStore((s) => s.setDeckName);
   const setDeckFormat = useDeckStore((s) => s.setDeckFormat);
-  const setPlaymat = useDeckStore((s) => s.setPlaymat);
 
   const [editingName, setEditingName] = useState(false);
   const [nameInput, setNameInput] = useState(currentDeck.name);
   const [editorOpen, setEditorOpen] = useState(false);
-  const playmatInputRef = useRef<HTMLInputElement>(null);
 
   const playmat = currentDeck.playmat;
+  const playmatColor = currentDeck.playmatSettings?.color;
   const coverArt = resolveCoverCard(currentDeck)?.uris?.art_crop;
 
-  async function onPlaymatPick(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    e.target.value = "";
-    if (!file) return;
-    try {
-      setPlaymat(await normalizeToWebp(file, PLAYMAT_IMAGE_BUDGET));
-    } catch (err) {
-      toast.error(
-        err instanceof ImageTooLargeError ? err.message : "Couldn't use that image as a playmat",
-      );
-    }
-  }
   const commanders = currentDeck.commanders ?? [];
   const mainCount = currentDeck.cards.length + commanders.length;
   const sideCount = currentDeck.sideboard.length;
@@ -91,34 +76,28 @@ export function DeckHero({ onBack }: { onBack?: () => void }) {
 
       {!isReadOnly && (
         <div className="absolute right-3 top-3 z-10 flex items-center gap-2">
-          <input
-            ref={playmatInputRef}
-            type="file"
-            accept="image/*"
-            className="hidden"
-            onChange={onPlaymatPick}
-          />
-          {playmat ? (
-            <button
-              type="button"
-              title="Customize playmat"
-              onClick={() => setEditorOpen(true)}
-              className="inline-flex items-center gap-2 rounded-md border bg-background/60 p-1 pr-2.5 text-xs font-medium text-muted-foreground backdrop-blur-sm transition-colors hover:bg-background/80 hover:text-foreground"
-            >
-              <img src={playmat} alt="Deck playmat" className="h-7 w-11 rounded object-cover" />
-              <span>Edit playmat</span>
-            </button>
-          ) : (
-            <button
-              type="button"
-              title="Add playmat"
-              onClick={() => playmatInputRef.current?.click()}
-              className="inline-flex h-8 items-center gap-1.5 rounded-md border bg-background/60 px-2.5 text-xs font-medium text-muted-foreground backdrop-blur-sm transition-colors hover:bg-background/80 hover:text-foreground"
-            >
+          <button
+            type="button"
+            title="Customize playmat"
+            onClick={() => setEditorOpen(true)}
+            className={cn(
+              "inline-flex h-8 items-center gap-2 rounded-md border bg-background/60 text-xs font-medium text-muted-foreground backdrop-blur-sm transition-colors hover:bg-background/80 hover:text-foreground",
+              playmat || playmatColor ? "p-1 pr-2.5" : "px-2.5",
+            )}
+          >
+            {playmat ? (
+              <img src={playmat} alt="Deck playmat" className="h-6 w-10 rounded object-cover" />
+            ) : playmatColor ? (
+              <span
+                className="h-6 w-10 rounded border"
+                style={{ backgroundColor: playmatColor }}
+                aria-hidden
+              />
+            ) : (
               <ImagePlus className="h-4 w-4" />
-              <span>Playmat</span>
-            </button>
-          )}
+            )}
+            <span>{playmat || playmatColor ? "Edit playmat" : "Playmat"}</span>
+          </button>
         </div>
       )}
 

--- a/src/components/editor/DeckHero.tsx
+++ b/src/components/editor/DeckHero.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
-import { ArrowLeft, Check, ChevronDown, Pencil } from "lucide-react";
+import { useRef, useState } from "react";
+import { ArrowLeft, Check, ChevronDown, ImagePlus, Pencil, Trash2 } from "lucide-react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -14,6 +15,7 @@ import { DeckLabelBadge } from "@/components/deck/DeckLabelBadge";
 import { resolveCoverCard } from "@/components/deck/deckCover.utils";
 import { GAME_FORMATS, getFormat } from "@/lib/formats";
 import { useDeckStore } from "@/stores/useDeckStore";
+import { normalizeToWebp, ImageTooLargeError, PLAYMAT_IMAGE_BUDGET } from "@/lib/imageEncode";
 import { cn } from "@/lib/utils";
 import type { DeckFormatId } from "@/types/manabrew";
 
@@ -22,11 +24,27 @@ export function DeckHero({ onBack }: { onBack?: () => void }) {
   const isReadOnly = useDeckStore((s) => s.isReadOnly);
   const setDeckName = useDeckStore((s) => s.setDeckName);
   const setDeckFormat = useDeckStore((s) => s.setDeckFormat);
+  const setPlaymat = useDeckStore((s) => s.setPlaymat);
 
   const [editingName, setEditingName] = useState(false);
   const [nameInput, setNameInput] = useState(currentDeck.name);
+  const playmatInputRef = useRef<HTMLInputElement>(null);
 
+  const playmat = currentDeck.playmat;
   const coverArt = resolveCoverCard(currentDeck)?.uris?.art_crop;
+
+  async function onPlaymatPick(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+    try {
+      setPlaymat(await normalizeToWebp(file, PLAYMAT_IMAGE_BUDGET));
+    } catch (err) {
+      toast.error(
+        err instanceof ImageTooLargeError ? err.message : "Couldn't use that image as a playmat",
+      );
+    }
+  }
   const commanders = currentDeck.commanders ?? [];
   const mainCount = currentDeck.cards.length + commanders.length;
   const sideCount = currentDeck.sideboard.length;
@@ -67,6 +85,49 @@ export function DeckHero({ onBack }: { onBack?: () => void }) {
         >
           <ArrowLeft className="h-4 w-4" />
         </button>
+      )}
+
+      {!isReadOnly && (
+        <div className="absolute right-3 top-3 z-10 flex items-center gap-2">
+          <input
+            ref={playmatInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={onPlaymatPick}
+          />
+          {playmat && (
+            <img
+              src={playmat}
+              alt="Deck playmat"
+              className="h-8 w-12 rounded border object-cover shadow-sm"
+            />
+          )}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="inline-flex h-8 items-center gap-1.5 rounded-md border bg-background/60 px-2.5 text-xs font-medium text-muted-foreground backdrop-blur-sm transition-colors hover:bg-background/80 hover:text-foreground"
+                title="Deck playmat"
+              >
+                <ImagePlus className="h-4 w-4" />
+                <span>Playmat</span>
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onSelect={() => playmatInputRef.current?.click()}>
+                <ImagePlus className="h-4 w-4" />
+                {playmat ? "Replace playmat" : "Upload playmat"}
+              </DropdownMenuItem>
+              {playmat && (
+                <DropdownMenuItem onSelect={() => setPlaymat(undefined)}>
+                  <Trash2 className="h-4 w-4" />
+                  Remove playmat
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       )}
 
       <div className={cn("relative flex flex-col gap-1.5 px-5 pb-4", onBack ? "pt-16" : "pt-10")}>

--- a/src/components/editor/DeckHero.tsx
+++ b/src/components/editor/DeckHero.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from "react";
-import { ArrowLeft, Check, ChevronDown, ImagePlus, Pencil, Trash2 } from "lucide-react";
+import { ArrowLeft, Check, ChevronDown, ImagePlus, Pencil } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -16,6 +16,7 @@ import { resolveCoverCard } from "@/components/deck/deckCover.utils";
 import { GAME_FORMATS, getFormat } from "@/lib/formats";
 import { useDeckStore } from "@/stores/useDeckStore";
 import { normalizeToWebp, ImageTooLargeError, PLAYMAT_IMAGE_BUDGET } from "@/lib/imageEncode";
+import { PlaymatEditorModal } from "./PlaymatEditorModal";
 import { cn } from "@/lib/utils";
 import type { DeckFormatId } from "@/types/manabrew";
 
@@ -28,6 +29,7 @@ export function DeckHero({ onBack }: { onBack?: () => void }) {
 
   const [editingName, setEditingName] = useState(false);
   const [nameInput, setNameInput] = useState(currentDeck.name);
+  const [editorOpen, setEditorOpen] = useState(false);
   const playmatInputRef = useRef<HTMLInputElement>(null);
 
   const playmat = currentDeck.playmat;
@@ -96,39 +98,31 @@ export function DeckHero({ onBack }: { onBack?: () => void }) {
             className="hidden"
             onChange={onPlaymatPick}
           />
-          {playmat && (
-            <img
-              src={playmat}
-              alt="Deck playmat"
-              className="h-8 w-12 rounded border object-cover shadow-sm"
-            />
+          {playmat ? (
+            <button
+              type="button"
+              title="Customize playmat"
+              onClick={() => setEditorOpen(true)}
+              className="inline-flex items-center gap-2 rounded-md border bg-background/60 p-1 pr-2.5 text-xs font-medium text-muted-foreground backdrop-blur-sm transition-colors hover:bg-background/80 hover:text-foreground"
+            >
+              <img src={playmat} alt="Deck playmat" className="h-7 w-11 rounded object-cover" />
+              <span>Edit playmat</span>
+            </button>
+          ) : (
+            <button
+              type="button"
+              title="Add playmat"
+              onClick={() => playmatInputRef.current?.click()}
+              className="inline-flex h-8 items-center gap-1.5 rounded-md border bg-background/60 px-2.5 text-xs font-medium text-muted-foreground backdrop-blur-sm transition-colors hover:bg-background/80 hover:text-foreground"
+            >
+              <ImagePlus className="h-4 w-4" />
+              <span>Playmat</span>
+            </button>
           )}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                className="inline-flex h-8 items-center gap-1.5 rounded-md border bg-background/60 px-2.5 text-xs font-medium text-muted-foreground backdrop-blur-sm transition-colors hover:bg-background/80 hover:text-foreground"
-                title="Deck playmat"
-              >
-                <ImagePlus className="h-4 w-4" />
-                <span>Playmat</span>
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onSelect={() => playmatInputRef.current?.click()}>
-                <ImagePlus className="h-4 w-4" />
-                {playmat ? "Replace playmat" : "Upload playmat"}
-              </DropdownMenuItem>
-              {playmat && (
-                <DropdownMenuItem onSelect={() => setPlaymat(undefined)}>
-                  <Trash2 className="h-4 w-4" />
-                  Remove playmat
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
         </div>
       )}
+
+      {editorOpen && <PlaymatEditorModal onClose={() => setEditorOpen(false)} />}
 
       <div className={cn("relative flex flex-col gap-1.5 px-5 pb-4", onBack ? "pt-16" : "pt-10")}>
         <div className="flex flex-wrap items-center gap-1.5">

--- a/src/components/editor/PlaymatEditorModal.tsx
+++ b/src/components/editor/PlaymatEditorModal.tsx
@@ -60,7 +60,7 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
 
   const sampleA = useCard({ name: "Serra Angel" });
   const sampleB = useCard({ name: "Tarmogoyf" });
-  const sampleC = useCard({ name: "Steam Vents" });
+  const sampleC = useCard({ name: "Llanowar Elves" });
   const previewCards = useMemo(
     () =>
       [sampleA, sampleB, sampleC]
@@ -231,10 +231,7 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
       return sprite;
     });
     return () => {
-      for (const sprite of sprites) {
-        app.stage.removeChild(sprite);
-        safeDestroy(sprite);
-      }
+      for (const sprite of sprites) safeDestroy(sprite);
     };
   }, [ready, previewCards, previewHeight]);
 

--- a/src/components/editor/PlaymatEditorModal.tsx
+++ b/src/components/editor/PlaymatEditorModal.tsx
@@ -14,9 +14,11 @@ import { HAND_CARD_BASE } from "@/components/game/game.styles";
 import { BG_ALPHA_IDLE, GAP, TABLE_RADIUS } from "@/pixi/constants";
 import { hexToNum } from "@/pixi/colorUtils";
 import { normalizeToWebp, ImageTooLargeError, PLAYMAT_IMAGE_BUDGET } from "@/lib/imageEncode";
+import { cn } from "@/lib/utils";
 import type { PlaymatSettings } from "@/types/manabrew";
 
 const PREVIEW_WIDTH = 560;
+const clamp01 = (v: number): number => Math.max(0, Math.min(1, v));
 
 /** The local player's battlefield felt aspect ratio, mirroring GameBoard's
  *  region + hand-reserve math, so the preview is shaped like the real board. */
@@ -50,7 +52,17 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
   const layerRef = useRef<PlaymatLayer | null>(null);
   const feltRef = useRef<Graphics | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const naturalRef = useRef<{ w: number; h: number }>({ w: 1, h: 1 });
   const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (!playmat) return;
+    const img = new Image();
+    img.onload = () => {
+      naturalRef.current = { w: img.naturalWidth || 1, h: img.naturalHeight || 1 };
+    };
+    img.src = playmat;
+  }, [playmat]);
 
   function update(patch: Partial<PlaymatSettings>) {
     setSettings((prev) => {
@@ -58,6 +70,39 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
       setPlaymatSettings(next);
       return next;
     });
+  }
+
+  // Drag the cover image to reposition its focal point. Offsets are normalized,
+  // so the same `offsetX/offsetY` reproduce exactly on the battlefield.
+  function onPreviewPointerDown(e: React.PointerEvent<HTMLCanvasElement>) {
+    if (settings.fit !== "cover") return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const start = {
+      sx: e.clientX,
+      sy: e.clientY,
+      ox: settings.offsetX,
+      oy: settings.offsetY,
+      rectW: rect.width || PREVIEW_WIDTH,
+      rectH: rect.height || previewHeight,
+    };
+    const move = (ev: PointerEvent) => {
+      const { w: nw, h: nh } = naturalRef.current;
+      const scale = Math.max(PREVIEW_WIDTH / nw, previewHeight / nh);
+      const overflowX = nw * scale - PREVIEW_WIDTH;
+      const overflowY = nh * scale - previewHeight;
+      const dx = ((ev.clientX - start.sx) * PREVIEW_WIDTH) / start.rectW;
+      const dy = ((ev.clientY - start.sy) * previewHeight) / start.rectH;
+      update({
+        offsetX: overflowX > 0 ? clamp01(start.ox - dx / overflowX) : start.ox,
+        offsetY: overflowY > 0 ? clamp01(start.oy - dy / overflowY) : start.oy,
+      });
+    };
+    const up = () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
   }
 
   async function onPick(e: React.ChangeEvent<HTMLInputElement>) {
@@ -142,12 +187,19 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
       <Modal.Header>Customize Playmat</Modal.Header>
       <Modal.Body>
         <div className="space-y-4">
-          <div className="flex justify-center">
+          <div className="flex flex-col items-center gap-1">
             <canvas
               ref={canvasRef}
+              onPointerDown={onPreviewPointerDown}
               style={{ width: PREVIEW_WIDTH, height: previewHeight }}
-              className="max-w-full rounded-md border"
+              className={cn(
+                "max-w-full touch-none rounded-md border",
+                settings.fit === "cover" && "cursor-grab active:cursor-grabbing",
+              )}
             />
+            {settings.fit === "cover" && (
+              <p className="text-xs text-muted-foreground">Drag the image to reposition</p>
+            )}
           </div>
 
           <div className="space-y-1.5">

--- a/src/components/editor/PlaymatEditorModal.tsx
+++ b/src/components/editor/PlaymatEditorModal.tsx
@@ -57,6 +57,8 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
   const [ready, setReady] = useState(false);
   const [borderHex, setBorderHex] = useState(settings.borderColor);
   useEffect(() => setBorderHex(settings.borderColor), [settings.borderColor]);
+  const [bgHex, setBgHex] = useState(settings.color);
+  useEffect(() => setBgHex(settings.color), [settings.color]);
 
   useEffect(() => {
     if (!playmat) return;
@@ -273,6 +275,40 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
                 />
               </div>
             </div>
+
+            <div className="space-y-2 rounded-lg border bg-card/40 p-3">
+              <Label className="text-xs font-medium">Background color</Label>
+              <div className="flex items-center gap-2">
+                <input
+                  type="color"
+                  value={settings.color || "#000000"}
+                  onChange={(e) => update({ color: e.target.value })}
+                  className="h-8 w-10 shrink-0 cursor-pointer rounded border border-input bg-transparent p-0.5"
+                />
+                <input
+                  value={bgHex}
+                  placeholder="none"
+                  onChange={(e) => {
+                    setBgHex(e.target.value);
+                    if (HEX_RE.test(e.target.value)) update({ color: e.target.value });
+                  }}
+                  onBlur={() => setBgHex(settings.color)}
+                  spellCheck={false}
+                  autoComplete="off"
+                  className="h-8 min-w-0 flex-1 rounded border border-input bg-background px-2 font-mono text-xs uppercase"
+                />
+                {settings.color && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="shrink-0 px-2"
+                    onClick={() => update({ color: "" })}
+                  >
+                    Clear
+                  </Button>
+                )}
+              </div>
+            </div>
           </div>
         </div>
       </Modal.Body>
@@ -286,19 +322,22 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
         />
         <Button variant="outline" size="sm" onClick={() => fileInputRef.current?.click()}>
           <ImagePlus className="h-4 w-4" />
-          Replace image
+          {playmat ? "Replace image" : "Upload image"}
         </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => {
-            setPlaymat(undefined);
-            onClose();
-          }}
-        >
-          <Trash2 className="h-4 w-4" />
-          Remove playmat
-        </Button>
+        {(playmat || settings.color) && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setPlaymat(undefined);
+              update({ color: "" });
+              onClose();
+            }}
+          >
+            <Trash2 className="h-4 w-4" />
+            Remove playmat
+          </Button>
+        )}
         <Button size="sm" className="ml-auto" onClick={onClose}>
           Done
         </Button>

--- a/src/components/editor/PlaymatEditorModal.tsx
+++ b/src/components/editor/PlaymatEditorModal.tsx
@@ -150,6 +150,24 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
             />
           </div>
 
+          <div className="space-y-1.5">
+            <Label className="text-xs text-muted-foreground">Image placement</Label>
+            <div className="flex gap-2">
+              {(["cover", "fit", "stretch"] as const).map((mode) => (
+                <Button
+                  key={mode}
+                  type="button"
+                  size="sm"
+                  variant={settings.fit === mode ? "default" : "outline"}
+                  onClick={() => update({ fit: mode })}
+                  className="flex-1 capitalize"
+                >
+                  {mode}
+                </Button>
+              ))}
+            </div>
+          </div>
+
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-1.5">
               <Label className="text-xs text-muted-foreground">

--- a/src/components/editor/PlaymatEditorModal.tsx
+++ b/src/components/editor/PlaymatEditorModal.tsx
@@ -1,0 +1,240 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Application, Graphics } from "pixi.js";
+import { toast } from "sonner";
+import { Modal } from "@/components/game/modals/Modal";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { ImagePlus, Trash2 } from "lucide-react";
+import { useDeckStore } from "@/stores/useDeckStore";
+import { useTheme } from "@/hooks/useTheme";
+import { useHandScale } from "@/hooks/useHandScale";
+import { PlaymatLayer, DEFAULT_PLAYMAT_SETTINGS } from "@/pixi/board/PlaymatLayer";
+import { computeBoardLayout } from "@/pixi/board/boardLayout";
+import { HAND_CARD_BASE } from "@/components/game/game.styles";
+import { BG_ALPHA_IDLE, GAP, TABLE_RADIUS } from "@/pixi/constants";
+import { hexToNum } from "@/pixi/colorUtils";
+import { normalizeToWebp, ImageTooLargeError, PLAYMAT_IMAGE_BUDGET } from "@/lib/imageEncode";
+import type { PlaymatSettings } from "@/types/manabrew";
+
+const PREVIEW_WIDTH = 560;
+
+/** The local player's battlefield felt aspect ratio, mirroring GameBoard's
+ *  region + hand-reserve math, so the preview is shaped like the real board. */
+function useBattlefieldAspect(): number {
+  const vScale = useHandScale();
+  return useMemo(() => {
+    const layout = computeBoardLayout(window.innerWidth, window.innerHeight, 1, "row");
+    const handReserve = Math.round(0.55 * HAND_CARD_BASE.cardH * vScale) + GAP;
+    const feltHeight = Math.max(1, layout.self.height - handReserve);
+    return layout.self.width / feltHeight;
+  }, [vScale]);
+}
+
+export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
+  const theme = useTheme();
+  const playmat = useDeckStore((s) => s.currentDeck.playmat);
+  const storedSettings = useDeckStore((s) => s.currentDeck.playmatSettings);
+  const setPlaymat = useDeckStore((s) => s.setPlaymat);
+  const setPlaymatSettings = useDeckStore((s) => s.setPlaymatSettings);
+
+  const [settings, setSettings] = useState<Required<PlaymatSettings>>({
+    ...DEFAULT_PLAYMAT_SETTINGS,
+    ...(storedSettings ?? {}),
+  });
+
+  const aspect = useBattlefieldAspect();
+  const previewHeight = Math.round(PREVIEW_WIDTH / aspect);
+
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const appRef = useRef<Application | null>(null);
+  const layerRef = useRef<PlaymatLayer | null>(null);
+  const feltRef = useRef<Graphics | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [ready, setReady] = useState(false);
+
+  function update(patch: Partial<PlaymatSettings>) {
+    setSettings((prev) => {
+      const next = { ...prev, ...patch };
+      setPlaymatSettings(next);
+      return next;
+    });
+  }
+
+  async function onPick(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+    try {
+      setPlaymat(await normalizeToWebp(file, PLAYMAT_IMAGE_BUDGET));
+    } catch (err) {
+      toast.error(
+        err instanceof ImageTooLargeError ? err.message : "Couldn't use that image as a playmat",
+      );
+    }
+  }
+
+  // Init the Pixi preview once; tear it down on unmount.
+  useEffect(() => {
+    let disposed = false;
+    const app = new Application();
+    const felt = new Graphics();
+    const layer = new PlaymatLayer();
+    (async () => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      try {
+        await app.init({
+          canvas,
+          width: PREVIEW_WIDTH,
+          height: previewHeight,
+          backgroundColor: hexToNum(theme.gameTheme.canvas.background),
+          antialias: true,
+          autoDensity: true,
+          resolution: Math.min(2, window.devicePixelRatio || 1),
+        });
+      } catch (err) {
+        console.error("[pixi] playmat preview init failed:", err);
+        return;
+      }
+      if (disposed) {
+        app.destroy(true);
+        return;
+      }
+      app.stage.addChild(felt, layer.container);
+      appRef.current = app;
+      layerRef.current = layer;
+      feltRef.current = felt;
+      setReady(true);
+    })();
+    return () => {
+      disposed = true;
+      setReady(false);
+      layer.destroy();
+      if (appRef.current) appRef.current.destroy(true);
+      appRef.current = null;
+      layerRef.current = null;
+      feltRef.current = null;
+    };
+    // Built once; live updates flow through the settings/image effect below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Push image, settings, and geometry to the preview whenever they change.
+  useEffect(() => {
+    const layer = layerRef.current;
+    const felt = feltRef.current;
+    const app = appRef.current;
+    if (!layer || !felt || !app) return;
+    app.renderer.resize(PREVIEW_WIDTH, previewHeight);
+    felt.clear();
+    felt.roundRect(0, 0, PREVIEW_WIDTH, previewHeight, TABLE_RADIUS);
+    felt.fill({ color: hexToNum(theme.gameTheme.canvas.background), alpha: BG_ALPHA_IDLE });
+    layer.setImage(playmat);
+    layer.setSettings(settings);
+    layer.layout(
+      { x: 0, y: 0, width: PREVIEW_WIDTH, height: previewHeight },
+      { dropActive: false },
+    );
+  }, [ready, playmat, settings, previewHeight, theme.gameTheme.canvas.background]);
+
+  return (
+    <Modal onClose={onClose} maxWidth="max-w-2xl">
+      <Modal.Header>Customize Playmat</Modal.Header>
+      <Modal.Body>
+        <div className="space-y-4">
+          <div className="flex justify-center">
+            <canvas
+              ref={canvasRef}
+              style={{ width: PREVIEW_WIDTH, height: previewHeight }}
+              className="max-w-full rounded-md border"
+            />
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label className="text-xs text-muted-foreground">
+                Opacity ({Math.round(settings.opacity * 100)}%)
+              </Label>
+              <input
+                type="range"
+                min={10}
+                max={100}
+                step={1}
+                value={Math.round(settings.opacity * 100)}
+                onChange={(e) => update({ opacity: Number(e.target.value) / 100 })}
+                className="w-full accent-primary"
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label className="text-xs text-muted-foreground">
+                Cloth texture ({Math.round(settings.texture * 100)}%)
+              </Label>
+              <input
+                type="range"
+                min={0}
+                max={100}
+                step={1}
+                value={Math.round(settings.texture * 100)}
+                onChange={(e) => update({ texture: Number(e.target.value) / 100 })}
+                className="w-full accent-primary"
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label className="text-xs text-muted-foreground">
+                Border width ({settings.borderWidth}px)
+              </Label>
+              <input
+                type="range"
+                min={0}
+                max={40}
+                step={1}
+                value={settings.borderWidth}
+                onChange={(e) => update({ borderWidth: Number(e.target.value) })}
+                className="w-full accent-primary"
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label className="text-xs text-muted-foreground">Border color</Label>
+              <input
+                type="color"
+                value={settings.borderColor}
+                onChange={(e) => update({ borderColor: e.target.value })}
+                className="h-9 w-full cursor-pointer rounded-md border bg-background"
+              />
+            </div>
+          </div>
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={onPick}
+        />
+        <Button variant="outline" size="sm" onClick={() => fileInputRef.current?.click()}>
+          <ImagePlus className="h-4 w-4" />
+          Replace image
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            setPlaymat(undefined);
+            onClose();
+          }}
+        >
+          <Trash2 className="h-4 w-4" />
+          Remove playmat
+        </Button>
+        <Button size="sm" className="ml-auto" onClick={onClose}>
+          Done
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/components/editor/PlaymatEditorModal.tsx
+++ b/src/components/editor/PlaymatEditorModal.tsx
@@ -8,7 +8,11 @@ import { ImagePlus, Trash2 } from "lucide-react";
 import { useDeckStore } from "@/stores/useDeckStore";
 import { useTheme } from "@/hooks/useTheme";
 import { useHandScale } from "@/hooks/useHandScale";
-import { PlaymatLayer, DEFAULT_PLAYMAT_SETTINGS } from "@/pixi/board/PlaymatLayer";
+import {
+  PlaymatLayer,
+  DEFAULT_PLAYMAT_SETTINGS,
+  clampBorderColor,
+} from "@/pixi/board/PlaymatLayer";
 import { computeBoardLayout } from "@/pixi/board/boardLayout";
 import { HAND_CARD_BASE } from "@/components/game/game.styles";
 import { BG_ALPHA_IDLE, GAP, TABLE_RADIUS } from "@/pixi/constants";
@@ -259,14 +263,15 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
                 <input
                   type="color"
                   value={settings.borderColor}
-                  onChange={(e) => update({ borderColor: e.target.value })}
+                  onChange={(e) => update({ borderColor: clampBorderColor(e.target.value) })}
                   className="h-8 w-10 shrink-0 cursor-pointer rounded border border-input bg-transparent p-0.5"
                 />
                 <input
                   value={borderHex}
                   onChange={(e) => {
                     setBorderHex(e.target.value);
-                    if (HEX_RE.test(e.target.value)) update({ borderColor: e.target.value });
+                    if (HEX_RE.test(e.target.value))
+                      update({ borderColor: clampBorderColor(e.target.value) });
                   }}
                   onBlur={() => setBorderHex(settings.borderColor)}
                   spellCheck={false}

--- a/src/components/editor/PlaymatEditorModal.tsx
+++ b/src/components/editor/PlaymatEditorModal.tsx
@@ -1,50 +1,23 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { Application, Graphics } from "pixi.js";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { Modal } from "@/components/game/modals/Modal";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { ImagePlus, Trash2 } from "lucide-react";
 import { useDeckStore } from "@/stores/useDeckStore";
-import { useCard } from "@/stores/useScryfallStore";
-import { scryfallToSampleGameCard } from "@/lib/sampleGameCard";
-import { CardSprite } from "@/pixi/CardSprite";
-import { CARD_W, CARD_H } from "@/components/game/game.constants";
-import { safeDestroy } from "@/pixi/board/pixiHelpers";
-import { useTheme } from "@/hooks/useTheme";
-import { useHandScale } from "@/hooks/useHandScale";
 import {
-  PlaymatLayer,
   DEFAULT_PLAYMAT_SETTINGS,
   clampBorderColor,
   clampPlaymatColor,
 } from "@/pixi/board/PlaymatLayer";
-import { computeBoardLayout } from "@/pixi/board/boardLayout";
-import { HAND_CARD_BASE } from "@/components/game/game.styles";
-import { BG_ALPHA_IDLE, GAP, TABLE_RADIUS } from "@/pixi/constants";
-import { hexToNum } from "@/pixi/colorUtils";
 import { normalizeToWebp, ImageTooLargeError, PLAYMAT_IMAGE_BUDGET } from "@/lib/imageEncode";
+import { usePlaymatPreview } from "./usePlaymatPreview";
 import { cn } from "@/lib/utils";
 import type { PlaymatSettings } from "@/types/manabrew";
 
-const PREVIEW_WIDTH = 560;
-const clamp01 = (v: number): number => Math.max(0, Math.min(1, v));
 const HEX_RE = /^#[0-9a-fA-F]{6}$/;
 
-/** The local player's battlefield felt aspect ratio, mirroring GameBoard's
- *  region + hand-reserve math, so the preview is shaped like the real board. */
-function useBattlefieldAspect(): number {
-  const vScale = useHandScale();
-  return useMemo(() => {
-    const layout = computeBoardLayout(window.innerWidth, window.innerHeight, 1, "row");
-    const handReserve = Math.round(0.55 * HAND_CARD_BASE.cardH * vScale) + GAP;
-    const feltHeight = Math.max(1, layout.self.height - handReserve);
-    return layout.self.width / feltHeight;
-  }, [vScale]);
-}
-
 export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
-  const theme = useTheme();
   const playmat = useDeckStore((s) => s.currentDeck.playmat);
   const storedSettings = useDeckStore((s) => s.currentDeck.playmatSettings);
   const setPlaymat = useDeckStore((s) => s.setPlaymat);
@@ -54,41 +27,21 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
     ...DEFAULT_PLAYMAT_SETTINGS,
     ...(storedSettings ?? {}),
   });
-
-  const aspect = useBattlefieldAspect();
-  const previewHeight = Math.round(PREVIEW_WIDTH / aspect);
-
-  const sampleA = useCard({ name: "Serra Angel" });
-  const sampleB = useCard({ name: "Tarmogoyf" });
-  const sampleC = useCard({ name: "Llanowar Elves" });
-  const previewCards = useMemo(
-    () =>
-      [sampleA, sampleB, sampleC]
-        .filter((e): e is NonNullable<typeof e> => !!e)
-        .map((e) => scryfallToSampleGameCard(e.info)),
-    [sampleA, sampleB, sampleC],
-  );
-
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const appRef = useRef<Application | null>(null);
-  const layerRef = useRef<PlaymatLayer | null>(null);
-  const feltRef = useRef<Graphics | null>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const naturalRef = useRef<{ w: number; h: number }>({ w: 1, h: 1 });
-  const [ready, setReady] = useState(false);
+  // Local copies so the hex fields accept in-progress (invalid) typing; resync
+  // when the committed color changes (e.g. from the swatch) without an effect.
   const [borderHex, setBorderHex] = useState(settings.borderColor);
-  useEffect(() => setBorderHex(settings.borderColor), [settings.borderColor]);
+  const [prevBorder, setPrevBorder] = useState(settings.borderColor);
+  if (prevBorder !== settings.borderColor) {
+    setPrevBorder(settings.borderColor);
+    setBorderHex(settings.borderColor);
+  }
   const [bgHex, setBgHex] = useState(settings.color);
-  useEffect(() => setBgHex(settings.color), [settings.color]);
-
-  useEffect(() => {
-    if (!playmat) return;
-    const img = new Image();
-    img.onload = () => {
-      naturalRef.current = { w: img.naturalWidth || 1, h: img.naturalHeight || 1 };
-    };
-    img.src = playmat;
-  }, [playmat]);
+  const [prevBg, setPrevBg] = useState(settings.color);
+  if (prevBg !== settings.color) {
+    setPrevBg(settings.color);
+    setBgHex(settings.color);
+  }
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   function update(patch: Partial<PlaymatSettings>) {
     setSettings((prev) => {
@@ -98,38 +51,11 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
     });
   }
 
-  // Drag the cover image to reposition its focal point. Offsets are normalized,
-  // so the same `offsetX/offsetY` reproduce exactly on the battlefield.
-  function onPreviewPointerDown(e: React.PointerEvent<HTMLCanvasElement>) {
-    if (settings.fit !== "cover") return;
-    const rect = e.currentTarget.getBoundingClientRect();
-    const start = {
-      sx: e.clientX,
-      sy: e.clientY,
-      ox: settings.offsetX,
-      oy: settings.offsetY,
-      rectW: rect.width || PREVIEW_WIDTH,
-      rectH: rect.height || previewHeight,
-    };
-    const move = (ev: PointerEvent) => {
-      const { w: nw, h: nh } = naturalRef.current;
-      const scale = Math.max(PREVIEW_WIDTH / nw, previewHeight / nh);
-      const overflowX = nw * scale - PREVIEW_WIDTH;
-      const overflowY = nh * scale - previewHeight;
-      const dx = ((ev.clientX - start.sx) * PREVIEW_WIDTH) / start.rectW;
-      const dy = ((ev.clientY - start.sy) * previewHeight) / start.rectH;
-      update({
-        offsetX: overflowX > 0 ? clamp01(start.ox - dx / overflowX) : start.ox,
-        offsetY: overflowY > 0 ? clamp01(start.oy - dy / overflowY) : start.oy,
-      });
-    };
-    const up = () => {
-      window.removeEventListener("pointermove", move);
-      window.removeEventListener("pointerup", up);
-    };
-    window.addEventListener("pointermove", move);
-    window.addEventListener("pointerup", up);
-  }
+  const { canvasRef, previewWidth, previewHeight, onPointerDown } = usePlaymatPreview({
+    playmat,
+    settings,
+    onOffsetChange: (offset) => update(offset),
+  });
 
   async function onPick(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
@@ -144,97 +70,6 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
     }
   }
 
-  // Init the Pixi preview once; tear it down on unmount.
-  useEffect(() => {
-    let disposed = false;
-    const app = new Application();
-    const felt = new Graphics();
-    const layer = new PlaymatLayer();
-    (async () => {
-      const canvas = canvasRef.current;
-      if (!canvas) return;
-      try {
-        await app.init({
-          canvas,
-          width: PREVIEW_WIDTH,
-          height: previewHeight,
-          backgroundColor: hexToNum(theme.gameTheme.canvas.background),
-          antialias: true,
-          autoDensity: true,
-          resolution: Math.min(2, window.devicePixelRatio || 1),
-        });
-      } catch (err) {
-        console.error("[pixi] playmat preview init failed:", err);
-        return;
-      }
-      if (disposed) {
-        app.destroy(true);
-        return;
-      }
-      app.stage.addChild(felt, layer.container);
-      appRef.current = app;
-      layerRef.current = layer;
-      feltRef.current = felt;
-      setReady(true);
-    })();
-    return () => {
-      disposed = true;
-      setReady(false);
-      layer.destroy();
-      if (appRef.current) appRef.current.destroy(true);
-      appRef.current = null;
-      layerRef.current = null;
-      feltRef.current = null;
-    };
-    // Built once; live updates flow through the settings/image effect below.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // Push image, settings, and geometry to the preview whenever they change.
-  useEffect(() => {
-    const layer = layerRef.current;
-    const felt = feltRef.current;
-    const app = appRef.current;
-    if (!layer || !felt || !app) return;
-    app.renderer.resize(PREVIEW_WIDTH, previewHeight);
-    felt.clear();
-    felt.roundRect(0, 0, PREVIEW_WIDTH, previewHeight, TABLE_RADIUS);
-    felt.fill({ color: hexToNum(theme.gameTheme.canvas.background), alpha: BG_ALPHA_IDLE });
-    layer.setImage(playmat);
-    layer.setSettings(settings);
-    layer.layout(
-      { x: 0, y: 0, width: PREVIEW_WIDTH, height: previewHeight },
-      { dropActive: false },
-    );
-  }, [ready, playmat, settings, previewHeight, theme.gameTheme.canvas.background]);
-
-  // Real CardSprites over the mat — the same renderer the battlefield uses — so the
-  // preview shows the exact foreground/background relationship, in your card style.
-  useEffect(() => {
-    const app = appRef.current;
-    if (!ready || !app || previewCards.length === 0) return;
-    const scale = (previewHeight * 0.62) / CARD_H;
-    const cardW = CARD_W * scale;
-    const gap = cardW * 0.16;
-    const total = previewCards.length * cardW + (previewCards.length - 1) * gap;
-    let x = (PREVIEW_WIDTH - total) / 2 + cardW / 2;
-    const cy = previewHeight * 0.56;
-    const sprites = previewCards.map((card) => {
-      const sprite = new CardSprite(card);
-      sprite.updateCardContent(card);
-      sprite.eventMode = "none";
-      sprite.scale.set(scale);
-      sprite.x = x;
-      sprite.y = cy;
-      x += cardW + gap;
-      app.stage.addChild(sprite);
-      return sprite;
-    });
-    return () => {
-      for (const sprite of sprites) safeDestroy(sprite);
-    };
-  }, [ready, previewCards, previewHeight]);
-
   return (
     <Modal onClose={onClose} maxWidth="max-w-2xl">
       <Modal.Header>Customize Playmat</Modal.Header>
@@ -243,8 +78,8 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
           <div className="flex flex-col items-center gap-1">
             <canvas
               ref={canvasRef}
-              onPointerDown={onPreviewPointerDown}
-              style={{ width: PREVIEW_WIDTH, height: previewHeight }}
+              onPointerDown={onPointerDown}
+              style={{ width: previewWidth, height: previewHeight }}
               className={cn(
                 "max-w-full touch-none rounded-md border",
                 settings.fit === "cover" && "cursor-grab active:cursor-grabbing",

--- a/src/components/editor/PlaymatEditorModal.tsx
+++ b/src/components/editor/PlaymatEditorModal.tsx
@@ -19,6 +19,7 @@ import type { PlaymatSettings } from "@/types/manabrew";
 
 const PREVIEW_WIDTH = 560;
 const clamp01 = (v: number): number => Math.max(0, Math.min(1, v));
+const HEX_RE = /^#[0-9a-fA-F]{6}$/;
 
 /** The local player's battlefield felt aspect ratio, mirroring GameBoard's
  *  region + hand-reserve math, so the preview is shaped like the real board. */
@@ -54,6 +55,8 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const naturalRef = useRef<{ w: number; h: number }>({ w: 1, h: 1 });
   const [ready, setReady] = useState(false);
+  const [borderHex, setBorderHex] = useState(settings.borderColor);
+  useEffect(() => setBorderHex(settings.borderColor), [settings.borderColor]);
 
   useEffect(() => {
     if (!playmat) return;
@@ -203,77 +206,72 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
           </div>
 
           <div className="space-y-1.5">
-            <Label className="text-xs text-muted-foreground">Image placement</Label>
-            <div className="flex gap-2">
+            <Label className="text-xs font-medium text-muted-foreground">Image placement</Label>
+            <div className="inline-flex w-full rounded-lg border bg-muted/40 p-1">
               {(["cover", "fit", "stretch"] as const).map((mode) => (
-                <Button
+                <button
                   key={mode}
                   type="button"
-                  size="sm"
-                  variant={settings.fit === mode ? "default" : "outline"}
                   onClick={() => update({ fit: mode })}
-                  className="flex-1 capitalize"
+                  className={cn(
+                    "flex-1 rounded-md px-3 py-1.5 text-xs font-medium capitalize transition-colors",
+                    settings.fit === mode
+                      ? "bg-primary text-primary-foreground shadow-sm"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
                 >
                   {mode}
-                </Button>
+                </button>
               ))}
             </div>
           </div>
 
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div className="space-y-1.5">
-              <Label className="text-xs text-muted-foreground">
-                Opacity ({Math.round(settings.opacity * 100)}%)
-              </Label>
-              <input
-                type="range"
-                min={10}
-                max={100}
-                step={1}
-                value={Math.round(settings.opacity * 100)}
-                onChange={(e) => update({ opacity: Number(e.target.value) / 100 })}
-                className="w-full accent-primary"
-              />
-            </div>
-
-            <div className="space-y-1.5">
-              <Label className="text-xs text-muted-foreground">
-                Cloth texture ({Math.round(settings.texture * 100)}%)
-              </Label>
-              <input
-                type="range"
-                min={0}
-                max={100}
-                step={1}
-                value={Math.round(settings.texture * 100)}
-                onChange={(e) => update({ texture: Number(e.target.value) / 100 })}
-                className="w-full accent-primary"
-              />
-            </div>
-
-            <div className="space-y-1.5">
-              <Label className="text-xs text-muted-foreground">
-                Border width ({settings.borderWidth}px)
-              </Label>
-              <input
-                type="range"
-                min={0}
-                max={40}
-                step={1}
-                value={settings.borderWidth}
-                onChange={(e) => update({ borderWidth: Number(e.target.value) })}
-                className="w-full accent-primary"
-              />
-            </div>
-
-            <div className="space-y-1.5">
-              <Label className="text-xs text-muted-foreground">Border color</Label>
-              <input
-                type="color"
-                value={settings.borderColor}
-                onChange={(e) => update({ borderColor: e.target.value })}
-                className="h-9 w-full cursor-pointer rounded-md border bg-background"
-              />
+          <div className="grid gap-3 sm:grid-cols-2">
+            <SliderControl
+              label="Opacity"
+              value={`${Math.round(settings.opacity * 100)}%`}
+              min={10}
+              max={100}
+              current={Math.round(settings.opacity * 100)}
+              onChange={(v) => update({ opacity: v / 100 })}
+            />
+            <SliderControl
+              label="Cloth texture"
+              value={`${Math.round(settings.texture * 100)}%`}
+              min={0}
+              max={100}
+              current={Math.round(settings.texture * 100)}
+              onChange={(v) => update({ texture: v / 100 })}
+            />
+            <SliderControl
+              label="Border width"
+              value={`${settings.borderWidth}px`}
+              min={0}
+              max={40}
+              current={settings.borderWidth}
+              onChange={(v) => update({ borderWidth: v })}
+            />
+            <div className="rounded-lg border bg-card/40 p-3 space-y-2">
+              <Label className="text-xs font-medium">Border color</Label>
+              <div className="flex items-center gap-2">
+                <input
+                  type="color"
+                  value={settings.borderColor}
+                  onChange={(e) => update({ borderColor: e.target.value })}
+                  className="h-8 w-10 shrink-0 cursor-pointer rounded border border-input bg-transparent p-0.5"
+                />
+                <input
+                  value={borderHex}
+                  onChange={(e) => {
+                    setBorderHex(e.target.value);
+                    if (HEX_RE.test(e.target.value)) update({ borderColor: e.target.value });
+                  }}
+                  onBlur={() => setBorderHex(settings.borderColor)}
+                  spellCheck={false}
+                  autoComplete="off"
+                  className="h-8 min-w-0 flex-1 rounded border border-input bg-background px-2 font-mono text-xs uppercase"
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -306,5 +304,41 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
         </Button>
       </Modal.Footer>
     </Modal>
+  );
+}
+
+function SliderControl({
+  label,
+  value,
+  min,
+  max,
+  current,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  min: number;
+  max: number;
+  current: number;
+  onChange: (value: number) => void;
+}) {
+  return (
+    <div className="space-y-2 rounded-lg border bg-card/40 p-3">
+      <div className="flex items-center justify-between">
+        <Label className="text-xs font-medium">{label}</Label>
+        <span className="rounded-full bg-muted px-2 py-0.5 font-mono text-[11px] text-muted-foreground">
+          {value}
+        </span>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={1}
+        value={current}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-full accent-primary"
+      />
+    </div>
   );
 }

--- a/src/components/editor/PlaymatEditorModal.tsx
+++ b/src/components/editor/PlaymatEditorModal.tsx
@@ -13,6 +13,7 @@ import {
   PlaymatLayer,
   DEFAULT_PLAYMAT_SETTINGS,
   clampBorderColor,
+  clampPlaymatColor,
 } from "@/pixi/board/PlaymatLayer";
 import { computeBoardLayout } from "@/pixi/board/boardLayout";
 import { HAND_CARD_BASE } from "@/components/game/game.styles";
@@ -318,7 +319,7 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
                 <input
                   type="color"
                   value={settings.color || "#000000"}
-                  onChange={(e) => update({ color: e.target.value })}
+                  onChange={(e) => update({ color: clampPlaymatColor(e.target.value) })}
                   className="h-8 w-10 shrink-0 cursor-pointer rounded border border-input bg-transparent p-0.5"
                 />
                 <input
@@ -326,7 +327,8 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
                   placeholder="none"
                   onChange={(e) => {
                     setBgHex(e.target.value);
-                    if (HEX_RE.test(e.target.value)) update({ color: e.target.value });
+                    if (HEX_RE.test(e.target.value))
+                      update({ color: clampPlaymatColor(e.target.value) });
                   }}
                   onBlur={() => setBgHex(settings.color)}
                   spellCheck={false}

--- a/src/components/editor/PlaymatEditorModal.tsx
+++ b/src/components/editor/PlaymatEditorModal.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Application, Graphics } from "pixi.js";
+import { Application, Graphics, Sprite, Texture } from "pixi.js";
 import { toast } from "sonner";
 import { Modal } from "@/components/game/modals/Modal";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { ImagePlus, Trash2 } from "lucide-react";
 import { useDeckStore } from "@/stores/useDeckStore";
+import { useScryfallStore } from "@/stores/useScryfallStore";
 import { useTheme } from "@/hooks/useTheme";
 import { useHandScale } from "@/hooks/useHandScale";
 import {
@@ -19,11 +20,17 @@ import { BG_ALPHA_IDLE, GAP, TABLE_RADIUS } from "@/pixi/constants";
 import { hexToNum } from "@/pixi/colorUtils";
 import { normalizeToWebp, ImageTooLargeError, PLAYMAT_IMAGE_BUDGET } from "@/lib/imageEncode";
 import { cn } from "@/lib/utils";
-import type { PlaymatSettings } from "@/types/manabrew";
+import type { DeckCard, PlaymatSettings } from "@/types/manabrew";
 
 const PREVIEW_WIDTH = 560;
 const clamp01 = (v: number): number => Math.max(0, Math.min(1, v));
 const HEX_RE = /^#[0-9a-fA-F]{6}$/;
+
+// A few real cards shown over the preview so the mat reads as the background it is.
+const PREVIEW_CARD_NAMES = ["Serra Angel", "Tarmogoyf", "Steam Vents"];
+function sampleDeckCard(name: string): DeckCard {
+  return { name, setCode: "", cardNumber: "" } as unknown as DeckCard;
+}
 
 /** The local player's battlefield felt aspect ratio, mirroring GameBoard's
  *  region + hand-reserve math, so the preview is shaped like the real board. */
@@ -159,6 +166,30 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
       layerRef.current = layer;
       feltRef.current = felt;
       setReady(true);
+
+      const cardH = previewHeight * 0.62;
+      const cardW = cardH * 0.716;
+      const gap = cardW * 0.16;
+      const total = PREVIEW_CARD_NAMES.length * cardW + (PREVIEW_CARD_NAMES.length - 1) * gap;
+      let cardX = (PREVIEW_WIDTH - total) / 2 + cardW / 2;
+      const cardY = previewHeight * 0.56;
+      for (const name of PREVIEW_CARD_NAMES) {
+        const tex = await useScryfallStore
+          .getState()
+          .getCardTexture(sampleDeckCard(name), "full", 0)
+          .catch(() => Texture.EMPTY);
+        if (disposed) return;
+        if (tex !== Texture.EMPTY) {
+          const sprite = new Sprite(tex);
+          sprite.anchor.set(0.5);
+          sprite.eventMode = "none";
+          sprite.scale.set(cardH / (tex.height || 1040));
+          sprite.x = cardX;
+          sprite.y = cardY;
+          app.stage.addChild(sprite);
+        }
+        cardX += cardW + gap;
+      }
     })();
     return () => {
       disposed = true;

--- a/src/components/editor/PlaymatEditorModal.tsx
+++ b/src/components/editor/PlaymatEditorModal.tsx
@@ -27,8 +27,6 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
     ...DEFAULT_PLAYMAT_SETTINGS,
     ...(storedSettings ?? {}),
   });
-  // Local copies so the hex fields accept in-progress (invalid) typing; resync
-  // when the committed color changes (e.g. from the swatch) without an effect.
   const [borderHex, setBorderHex] = useState(settings.borderColor);
   const [prevBorder, setPrevBorder] = useState(settings.borderColor);
   if (prevBorder !== settings.borderColor) {

--- a/src/components/editor/PlaymatEditorModal.tsx
+++ b/src/components/editor/PlaymatEditorModal.tsx
@@ -1,12 +1,16 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Application, Graphics, Sprite, Texture } from "pixi.js";
+import { Application, Graphics } from "pixi.js";
 import { toast } from "sonner";
 import { Modal } from "@/components/game/modals/Modal";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { ImagePlus, Trash2 } from "lucide-react";
 import { useDeckStore } from "@/stores/useDeckStore";
-import { useScryfallStore } from "@/stores/useScryfallStore";
+import { useCard } from "@/stores/useScryfallStore";
+import { scryfallToSampleGameCard } from "@/lib/sampleGameCard";
+import { CardSprite } from "@/pixi/CardSprite";
+import { CARD_W, CARD_H } from "@/components/game/game.constants";
+import { safeDestroy } from "@/pixi/board/pixiHelpers";
 import { useTheme } from "@/hooks/useTheme";
 import { useHandScale } from "@/hooks/useHandScale";
 import {
@@ -21,17 +25,11 @@ import { BG_ALPHA_IDLE, GAP, TABLE_RADIUS } from "@/pixi/constants";
 import { hexToNum } from "@/pixi/colorUtils";
 import { normalizeToWebp, ImageTooLargeError, PLAYMAT_IMAGE_BUDGET } from "@/lib/imageEncode";
 import { cn } from "@/lib/utils";
-import type { DeckCard, PlaymatSettings } from "@/types/manabrew";
+import type { PlaymatSettings } from "@/types/manabrew";
 
 const PREVIEW_WIDTH = 560;
 const clamp01 = (v: number): number => Math.max(0, Math.min(1, v));
 const HEX_RE = /^#[0-9a-fA-F]{6}$/;
-
-// A few real cards shown over the preview so the mat reads as the background it is.
-const PREVIEW_CARD_NAMES = ["Serra Angel", "Tarmogoyf", "Steam Vents"];
-function sampleDeckCard(name: string): DeckCard {
-  return { name, setCode: "", cardNumber: "" } as unknown as DeckCard;
-}
 
 /** The local player's battlefield felt aspect ratio, mirroring GameBoard's
  *  region + hand-reserve math, so the preview is shaped like the real board. */
@@ -59,6 +57,17 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
 
   const aspect = useBattlefieldAspect();
   const previewHeight = Math.round(PREVIEW_WIDTH / aspect);
+
+  const sampleA = useCard({ name: "Serra Angel" });
+  const sampleB = useCard({ name: "Tarmogoyf" });
+  const sampleC = useCard({ name: "Steam Vents" });
+  const previewCards = useMemo(
+    () =>
+      [sampleA, sampleB, sampleC]
+        .filter((e): e is NonNullable<typeof e> => !!e)
+        .map((e) => scryfallToSampleGameCard(e.info)),
+    [sampleA, sampleB, sampleC],
+  );
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const appRef = useRef<Application | null>(null);
@@ -167,30 +176,6 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
       layerRef.current = layer;
       feltRef.current = felt;
       setReady(true);
-
-      const cardH = previewHeight * 0.62;
-      const cardW = cardH * 0.716;
-      const gap = cardW * 0.16;
-      const total = PREVIEW_CARD_NAMES.length * cardW + (PREVIEW_CARD_NAMES.length - 1) * gap;
-      let cardX = (PREVIEW_WIDTH - total) / 2 + cardW / 2;
-      const cardY = previewHeight * 0.56;
-      for (const name of PREVIEW_CARD_NAMES) {
-        const tex = await useScryfallStore
-          .getState()
-          .getCardTexture(sampleDeckCard(name), "full", 0)
-          .catch(() => Texture.EMPTY);
-        if (disposed) return;
-        if (tex !== Texture.EMPTY) {
-          const sprite = new Sprite(tex);
-          sprite.anchor.set(0.5);
-          sprite.eventMode = "none";
-          sprite.scale.set(cardH / (tex.height || 1040));
-          sprite.x = cardX;
-          sprite.y = cardY;
-          app.stage.addChild(sprite);
-        }
-        cardX += cardW + gap;
-      }
     })();
     return () => {
       disposed = true;
@@ -222,6 +207,36 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
       { dropActive: false },
     );
   }, [ready, playmat, settings, previewHeight, theme.gameTheme.canvas.background]);
+
+  // Real CardSprites over the mat — the same renderer the battlefield uses — so the
+  // preview shows the exact foreground/background relationship, in your card style.
+  useEffect(() => {
+    const app = appRef.current;
+    if (!ready || !app || previewCards.length === 0) return;
+    const scale = (previewHeight * 0.62) / CARD_H;
+    const cardW = CARD_W * scale;
+    const gap = cardW * 0.16;
+    const total = previewCards.length * cardW + (previewCards.length - 1) * gap;
+    let x = (PREVIEW_WIDTH - total) / 2 + cardW / 2;
+    const cy = previewHeight * 0.56;
+    const sprites = previewCards.map((card) => {
+      const sprite = new CardSprite(card);
+      sprite.updateCardContent(card);
+      sprite.eventMode = "none";
+      sprite.scale.set(scale);
+      sprite.x = x;
+      sprite.y = cy;
+      x += cardW + gap;
+      app.stage.addChild(sprite);
+      return sprite;
+    });
+    return () => {
+      for (const sprite of sprites) {
+        app.stage.removeChild(sprite);
+        safeDestroy(sprite);
+      }
+    };
+  }, [ready, previewCards, previewHeight]);
 
   return (
     <Modal onClose={onClose} maxWidth="max-w-2xl">

--- a/src/components/editor/deckBuilder.unsavedChanges.ts
+++ b/src/components/editor/deckBuilder.unsavedChanges.ts
@@ -37,6 +37,7 @@ export function buildDeckSnapshot(deck: Deck): string {
     cardTags: deck.cardTags ?? {},
     coverCardName: deck.coverCardName,
     coverCardFace: deck.coverCardFace,
+    playmat: deck.playmat,
     stackPositions: deck.stackPositions,
   });
 }

--- a/src/components/editor/deckBuilder.unsavedChanges.ts
+++ b/src/components/editor/deckBuilder.unsavedChanges.ts
@@ -38,6 +38,7 @@ export function buildDeckSnapshot(deck: Deck): string {
     coverCardName: deck.coverCardName,
     coverCardFace: deck.coverCardFace,
     playmat: deck.playmat,
+    playmatSettings: deck.playmatSettings,
     stackPositions: deck.stackPositions,
   });
 }

--- a/src/components/editor/usePlaymatPreview.ts
+++ b/src/components/editor/usePlaymatPreview.ts
@@ -17,8 +17,6 @@ import type { PlaymatSettings } from "@/types/manabrew";
 export const PREVIEW_WIDTH = 560;
 const clamp01 = (v: number): number => Math.max(0, Math.min(1, v));
 
-/** Local player's battlefield felt aspect ratio (region + hand-reserve math),
- *  so the preview is shaped like the real board. */
 function useBattlefieldAspect(): number {
   const vScale = useHandScale();
   return useMemo(() => {
@@ -35,9 +33,6 @@ interface PlaymatPreviewArgs {
   onOffsetChange: (offset: { offsetX: number; offsetY: number }) => void;
 }
 
-/** Drives the Pixi playmat preview: a felt + the shared `PlaymatLayer` + real
- *  `CardSprite`s on top, so the editor matches the battlefield. Returns the
- *  canvas ref, its size, and the cover drag-to-reposition handler. */
 export function usePlaymatPreview({ playmat, settings, onOffsetChange }: PlaymatPreviewArgs) {
   const theme = useTheme();
   const aspect = useBattlefieldAspect();
@@ -156,8 +151,6 @@ export function usePlaymatPreview({ playmat, settings, onOffsetChange }: Playmat
     };
   }, [ready, previewCards, previewHeight]);
 
-  // Offsets are normalized, so the dragged focal point reproduces exactly on the
-  // battlefield regardless of size; only the overflowing axis can move.
   function onPointerDown(e: React.PointerEvent<HTMLCanvasElement>) {
     if (settings.fit !== "cover") return;
     const rect = e.currentTarget.getBoundingClientRect();

--- a/src/components/editor/usePlaymatPreview.ts
+++ b/src/components/editor/usePlaymatPreview.ts
@@ -1,0 +1,193 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Application, Graphics } from "pixi.js";
+import { useCard } from "@/stores/useScryfallStore";
+import { scryfallToSampleGameCard } from "@/lib/sampleGameCard";
+import { CardSprite } from "@/pixi/CardSprite";
+import { CARD_W, CARD_H } from "@/components/game/game.constants";
+import { safeDestroy } from "@/pixi/board/pixiHelpers";
+import { useTheme } from "@/hooks/useTheme";
+import { useHandScale } from "@/hooks/useHandScale";
+import { PlaymatLayer } from "@/pixi/board/PlaymatLayer";
+import { computeBoardLayout } from "@/pixi/board/boardLayout";
+import { HAND_CARD_BASE } from "@/components/game/game.styles";
+import { BG_ALPHA_IDLE, GAP, TABLE_RADIUS } from "@/pixi/constants";
+import { hexToNum } from "@/pixi/colorUtils";
+import type { PlaymatSettings } from "@/types/manabrew";
+
+export const PREVIEW_WIDTH = 560;
+const clamp01 = (v: number): number => Math.max(0, Math.min(1, v));
+
+/** Local player's battlefield felt aspect ratio (region + hand-reserve math),
+ *  so the preview is shaped like the real board. */
+function useBattlefieldAspect(): number {
+  const vScale = useHandScale();
+  return useMemo(() => {
+    const layout = computeBoardLayout(window.innerWidth, window.innerHeight, 1, "row");
+    const handReserve = Math.round(0.55 * HAND_CARD_BASE.cardH * vScale) + GAP;
+    const feltHeight = Math.max(1, layout.self.height - handReserve);
+    return layout.self.width / feltHeight;
+  }, [vScale]);
+}
+
+interface PlaymatPreviewArgs {
+  playmat: string | undefined;
+  settings: Required<PlaymatSettings>;
+  onOffsetChange: (offset: { offsetX: number; offsetY: number }) => void;
+}
+
+/** Drives the Pixi playmat preview: a felt + the shared `PlaymatLayer` + real
+ *  `CardSprite`s on top, so the editor matches the battlefield. Returns the
+ *  canvas ref, its size, and the cover drag-to-reposition handler. */
+export function usePlaymatPreview({ playmat, settings, onOffsetChange }: PlaymatPreviewArgs) {
+  const theme = useTheme();
+  const aspect = useBattlefieldAspect();
+  const previewHeight = Math.round(PREVIEW_WIDTH / aspect);
+
+  const sampleA = useCard({ name: "Serra Angel" });
+  const sampleB = useCard({ name: "Tarmogoyf" });
+  const sampleC = useCard({ name: "Llanowar Elves" });
+  const previewCards = useMemo(
+    () =>
+      [sampleA, sampleB, sampleC]
+        .filter((e): e is NonNullable<typeof e> => !!e)
+        .map((e) => scryfallToSampleGameCard(e.info)),
+    [sampleA, sampleB, sampleC],
+  );
+
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const appRef = useRef<Application | null>(null);
+  const layerRef = useRef<PlaymatLayer | null>(null);
+  const feltRef = useRef<Graphics | null>(null);
+  const naturalRef = useRef<{ w: number; h: number }>({ w: 1, h: 1 });
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (!playmat) return;
+    const img = new Image();
+    img.onload = () => {
+      naturalRef.current = { w: img.naturalWidth || 1, h: img.naturalHeight || 1 };
+    };
+    img.src = playmat;
+  }, [playmat]);
+
+  useEffect(() => {
+    let disposed = false;
+    const app = new Application();
+    const felt = new Graphics();
+    const layer = new PlaymatLayer();
+    (async () => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      try {
+        await app.init({
+          canvas,
+          width: PREVIEW_WIDTH,
+          height: previewHeight,
+          backgroundColor: hexToNum(theme.gameTheme.canvas.background),
+          antialias: true,
+          autoDensity: true,
+          resolution: Math.min(2, window.devicePixelRatio || 1),
+        });
+      } catch (err) {
+        console.error("[pixi] playmat preview init failed:", err);
+        return;
+      }
+      if (disposed) {
+        app.destroy(true);
+        return;
+      }
+      app.stage.addChild(felt, layer.container);
+      appRef.current = app;
+      layerRef.current = layer;
+      feltRef.current = felt;
+      setReady(true);
+    })();
+    return () => {
+      disposed = true;
+      setReady(false);
+      layer.destroy();
+      if (appRef.current) appRef.current.destroy(true);
+      appRef.current = null;
+      layerRef.current = null;
+      feltRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const layer = layerRef.current;
+    const felt = feltRef.current;
+    const app = appRef.current;
+    if (!layer || !felt || !app) return;
+    app.renderer.resize(PREVIEW_WIDTH, previewHeight);
+    felt.clear();
+    felt.roundRect(0, 0, PREVIEW_WIDTH, previewHeight, TABLE_RADIUS);
+    felt.fill({ color: hexToNum(theme.gameTheme.canvas.background), alpha: BG_ALPHA_IDLE });
+    layer.setImage(playmat);
+    layer.setSettings(settings);
+    layer.layout(
+      { x: 0, y: 0, width: PREVIEW_WIDTH, height: previewHeight },
+      { dropActive: false },
+    );
+  }, [ready, playmat, settings, previewHeight, theme.gameTheme.canvas.background]);
+
+  useEffect(() => {
+    const app = appRef.current;
+    if (!ready || !app || previewCards.length === 0) return;
+    const scale = (previewHeight * 0.62) / CARD_H;
+    const cardW = CARD_W * scale;
+    const gap = cardW * 0.16;
+    const total = previewCards.length * cardW + (previewCards.length - 1) * gap;
+    let x = (PREVIEW_WIDTH - total) / 2 + cardW / 2;
+    const cy = previewHeight * 0.56;
+    const sprites = previewCards.map((card) => {
+      const sprite = new CardSprite(card);
+      sprite.updateCardContent(card);
+      sprite.eventMode = "none";
+      sprite.scale.set(scale);
+      sprite.x = x;
+      sprite.y = cy;
+      x += cardW + gap;
+      app.stage.addChild(sprite);
+      return sprite;
+    });
+    return () => {
+      for (const sprite of sprites) safeDestroy(sprite);
+    };
+  }, [ready, previewCards, previewHeight]);
+
+  // Offsets are normalized, so the dragged focal point reproduces exactly on the
+  // battlefield regardless of size; only the overflowing axis can move.
+  function onPointerDown(e: React.PointerEvent<HTMLCanvasElement>) {
+    if (settings.fit !== "cover") return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const start = {
+      sx: e.clientX,
+      sy: e.clientY,
+      ox: settings.offsetX,
+      oy: settings.offsetY,
+      rectW: rect.width || PREVIEW_WIDTH,
+      rectH: rect.height || previewHeight,
+    };
+    const move = (ev: PointerEvent) => {
+      const { w: nw, h: nh } = naturalRef.current;
+      const scale = Math.max(PREVIEW_WIDTH / nw, previewHeight / nh);
+      const overflowX = nw * scale - PREVIEW_WIDTH;
+      const overflowY = nh * scale - previewHeight;
+      const dx = ((ev.clientX - start.sx) * PREVIEW_WIDTH) / start.rectW;
+      const dy = ((ev.clientY - start.sy) * previewHeight) / start.rectH;
+      onOffsetChange({
+        offsetX: overflowX > 0 ? clamp01(start.ox - dx / overflowX) : start.ox,
+        offsetY: overflowY > 0 ? clamp01(start.oy - dy / overflowY) : start.oy,
+      });
+    };
+    const up = () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+  }
+
+  return { canvasRef, previewWidth: PREVIEW_WIDTH, previewHeight, onPointerDown };
+}

--- a/src/components/game/GameBoard.tsx
+++ b/src/components/game/GameBoard.tsx
@@ -10,6 +10,7 @@ import { isFeatureEnabled } from "@/featureFlags";
 import type { BoardScene } from "@/pixi/board/BoardScene";
 import type { BlockingRect } from "@/pixi/board/types";
 import { usePreferencesStore } from "@/stores/usePreferencesStore";
+import { useGameStore } from "@/stores/useGameStore";
 import type { ArrowSpec, BattlefieldState, GameCanvasCallbacks, ScreenBounds } from "@/pixi/types";
 import { usePhaseStopStore } from "@/stores/usePhaseStopStore";
 import type { PromptType } from "@/protocol";
@@ -510,6 +511,8 @@ export function GameBoard({
     [opponents.length, opponentSplits],
   );
 
+  const gameDecks = useGameStore((s) => s.gameDecks);
+
   const unifiedRegions = useMemo((): BoardCanvasRegion[] => {
     const oppState = (cards: GameCard[]): BattlefieldState => ({
       cards,
@@ -519,11 +522,17 @@ export function GameBoard({
       hostileTargeting,
     });
     return [
-      { playerId: me.id, isLocal: true, state: pixiBattlefield },
+      {
+        playerId: me.id,
+        isLocal: true,
+        state: pixiBattlefield,
+        playmat: gameDecks[me.id]?.playmat,
+      },
       ...opponents.map((op) => ({
         playerId: op.id,
         isLocal: false,
         state: oppState(opponentPermanentsByPlayer.get(op.id) ?? []),
+        playmat: gameDecks[op.id]?.playmat,
       })),
     ];
   }, [
@@ -536,6 +545,7 @@ export function GameBoard({
     damageOrder,
     selectableBattlefieldCardIds,
     hostileTargeting,
+    gameDecks,
   ]);
 
   const selfPanelLeftPx = (unifiedLayout?.self?.x ?? 0) + 8;

--- a/src/components/game/GameBoard.tsx
+++ b/src/components/game/GameBoard.tsx
@@ -540,12 +540,14 @@ export function GameBoard({
         isLocal: true,
         state: pixiBattlefield,
         playmat: gameDecks[me.id]?.playmat,
+        playmatSettings: gameDecks[me.id]?.playmatSettings,
       },
       ...opponents.map((op) => ({
         playerId: op.id,
         isLocal: false,
         state: oppState(opponentPermanentsByPlayer.get(op.id) ?? []),
         playmat: gameDecks[op.id]?.playmat,
+        playmatSettings: gameDecks[op.id]?.playmatSettings,
       })),
     ];
   }, [

--- a/src/components/game/GameBoard.tsx
+++ b/src/components/game/GameBoard.tsx
@@ -9,6 +9,7 @@ import { SELF_HEIGHT_FRACTION, STRIP_BAND_PX } from "@/pixi/board/boardLayout";
 import { isFeatureEnabled } from "@/featureFlags";
 import type { BoardScene } from "@/pixi/board/BoardScene";
 import type { BlockingRect } from "@/pixi/board/types";
+import { PLAYMAT_PADDING } from "@/pixi/board/PlaymatLayer";
 import { usePreferencesStore } from "@/stores/usePreferencesStore";
 import { useGameStore } from "@/stores/useGameStore";
 import { useServerStore } from "@/stores/useServerStore";
@@ -779,24 +780,27 @@ export function GameBoard({
         const op = opponents.find((o) => o.id === playerId);
         if (!op) return null;
         const scale = `scale(${UNIFIED_OPPONENT_PANEL_SCALE})`;
+        // Align the panel to the inset playmat (same padding the mat uses) so it
+        // sits flush on the mat corner instead of floating in the felt margin.
+        const pad = Math.min(rect.width, rect.height) * PLAYMAT_PADDING;
         const panelStyle: React.CSSProperties =
           orientation === "left"
             ? {
-                left: rect.x + 8,
+                left: rect.x + 8 + pad,
                 top: rect.y + rect.height / 2,
                 transform: `translateY(-50%) ${scale}`,
                 transformOrigin: "left center",
               }
             : orientation === "right"
               ? {
-                  left: rect.x + rect.width - 8,
+                  left: rect.x + rect.width - 8 - pad,
                   top: rect.y + rect.height / 2,
                   transform: `translate(-100%, -50%) ${scale}`,
                   transformOrigin: "right center",
                 }
               : {
-                  left: rect.x + 8,
-                  top: rect.y + 8,
+                  left: rect.x + 8 + pad,
+                  top: rect.y + 8 + pad,
                   transform: scale,
                   transformOrigin: "top left",
                 };

--- a/src/components/game/GameBoard.tsx
+++ b/src/components/game/GameBoard.tsx
@@ -780,8 +780,6 @@ export function GameBoard({
         const op = opponents.find((o) => o.id === playerId);
         if (!op) return null;
         const scale = `scale(${UNIFIED_OPPONENT_PANEL_SCALE})`;
-        // Align the panel to the inset playmat (same padding the mat uses) so it
-        // sits flush on the mat corner instead of floating in the felt margin.
         const pad = Math.min(rect.width, rect.height) * PLAYMAT_PADDING;
         const panelStyle: React.CSSProperties =
           orientation === "left"

--- a/src/components/game/GameBoard.tsx
+++ b/src/components/game/GameBoard.tsx
@@ -11,6 +11,7 @@ import type { BoardScene } from "@/pixi/board/BoardScene";
 import type { BlockingRect } from "@/pixi/board/types";
 import { usePreferencesStore } from "@/stores/usePreferencesStore";
 import { useGameStore } from "@/stores/useGameStore";
+import { useServerStore } from "@/stores/useServerStore";
 import type { ArrowSpec, BattlefieldState, GameCanvasCallbacks, ScreenBounds } from "@/pixi/types";
 import { usePhaseStopStore } from "@/stores/usePhaseStopStore";
 import type { PromptType } from "@/protocol";
@@ -512,6 +513,18 @@ export function GameBoard({
   );
 
   const gameDecks = useGameStore((s) => s.gameDecks);
+  const myAvatar = usePreferencesStore((s) => s.customAvatar);
+  const playerDecks = useServerStore((s) => s.playerDecks);
+
+  const avatarByPlayerId = useMemo(() => {
+    const map = new Map<string, string>();
+    if (myAvatar) map.set(me.id, myAvatar);
+    for (const op of opponents) {
+      const entry = playerDecks.find((d) => d.username === op.name);
+      if (entry?.avatar) map.set(op.id, entry.avatar);
+    }
+    return map;
+  }, [myAvatar, playerDecks, me.id, opponents]);
 
   const unifiedRegions = useMemo((): BoardCanvasRegion[] => {
     const oppState = (cards: GameCard[]): BattlefieldState => ({
@@ -643,6 +656,7 @@ export function GameBoard({
         player={me}
         isOpponent={false}
         seat="self"
+        avatarUrl={avatarByPlayerId.get(me.id)}
         verticalAlign="bottom"
         split={selfIsSplit}
         zonesGrid={selfSplit.grid}
@@ -795,6 +809,7 @@ export function GameBoard({
               player={op}
               isOpponent
               seat={OPPONENT_SEATS[i] ?? "opponent1"}
+              avatarUrl={avatarByPlayerId.get(op.id)}
               verticalAlign="top"
               zoneOrientation={
                 orientation === "left" || orientation === "right" ? "vertical" : "horizontal"

--- a/src/components/game/panels/PlayerAvatar.tsx
+++ b/src/components/game/panels/PlayerAvatar.tsx
@@ -1,7 +1,7 @@
 import { useState, type CSSProperties } from "react";
 import type { Player } from "@/types/manabrew";
 import { cn } from "@/lib/utils";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Heart } from "lucide-react";
 import { getInitials } from "../game.utils";
 import { withAlpha } from "@/themes/gameTheme";
@@ -12,6 +12,7 @@ export interface PlayerAvatarProps {
   player: Player;
   badges: OrbitBadge[];
   seatColor: string;
+  avatarUrl?: string;
   isActiveTurn?: boolean;
   isPriorityPlayer?: boolean;
   isTargetable?: boolean;
@@ -29,6 +30,7 @@ export function PlayerAvatar({
   player,
   badges,
   seatColor,
+  avatarUrl,
   isActiveTurn,
   isPriorityPlayer,
   isTargetable,
@@ -113,6 +115,7 @@ export function PlayerAvatar({
               : {}),
           }}
         >
+          {avatarUrl && <AvatarImage src={avatarUrl} alt={player.name} />}
           <AvatarFallback
             className="font-bold text-white"
             style={{ backgroundColor: seatColor, fontSize: fontSizes.avatarInitials }}

--- a/src/components/game/panels/PlayerPanel.tsx
+++ b/src/components/game/panels/PlayerPanel.tsx
@@ -19,6 +19,8 @@ interface PlayerPanelProps {
   isOpponent: boolean;
   /** Seat identifier used to pick the per-player theme colour. */
   seat: PlayerSeat;
+  /** This player's custom avatar (normalized WebP data URL); falls back to initials. */
+  avatarUrl?: string;
   className?: string;
   /** `bottom` = avatar anchored at the bottom of the cluster (local player); zones row sits on top. `top` = opponent mirror. */
   /** Retained for backwards compat with existing callers but no longer
@@ -64,6 +66,7 @@ export function PlayerPanel({
   player,
   isOpponent,
   seat,
+  avatarUrl,
   className,
   verticalAlign: _verticalAlign = "bottom",
   zoneOrientation = "horizontal",
@@ -262,6 +265,7 @@ export function PlayerPanel({
         player={effectivePlayer}
         badges={orbitBadges}
         seatColor={seatColor}
+        avatarUrl={avatarUrl}
         isActiveTurn={isActiveTurn}
         isPriorityPlayer={isPriorityPlayer}
         isTargetable={isTargetable}

--- a/src/components/game/panels/PlayerPanel.tsx
+++ b/src/components/game/panels/PlayerPanel.tsx
@@ -19,7 +19,6 @@ interface PlayerPanelProps {
   isOpponent: boolean;
   /** Seat identifier used to pick the per-player theme colour. */
   seat: PlayerSeat;
-  /** This player's custom avatar (normalized WebP data URL); falls back to initials. */
   avatarUrl?: string;
   className?: string;
   /** `bottom` = avatar anchored at the bottom of the cluster (local player); zones row sits on top. `top` = opponent mirror. */

--- a/src/components/prompts/NoAction.tsx
+++ b/src/components/prompts/NoAction.tsx
@@ -11,7 +11,7 @@ export function NoAction({ buttonLayout, label }: NoActionProps) {
             size="sm"
             variant="outline"
             disabled
-            className="h-9 w-full rounded-lg !border-white/20 !bg-white/10 !text-white/70 opacity-30 cursor-default"
+            className="h-9 w-full cursor-default rounded-lg !border-border !bg-muted !text-muted-foreground disabled:!opacity-100"
             title={label}
           >
             <Hourglass className="h-3.5 w-3.5" />
@@ -31,7 +31,7 @@ export function NoAction({ buttonLayout, label }: NoActionProps) {
       size="sm"
       variant="outline"
       disabled
-      className="cursor-default opacity-40"
+      className="cursor-default !bg-muted !text-muted-foreground disabled:!opacity-100"
       title={label}
     >
       <Hourglass className="h-4 w-4" />

--- a/src/game/hostedAiPlay.ts
+++ b/src/game/hostedAiPlay.ts
@@ -44,6 +44,7 @@ export async function startHostedAiGame(request: HostedAiGameRequest): Promise<H
     deckName: request.playerDeck.name || "Player Deck",
     deck: request.playerDeck,
     commanderName: request.commanderName,
+    avatar: usePreferencesStore.getState().customAvatar,
   });
   await platform.server.setReady({ ready: true });
 

--- a/src/lib/imageEncode.ts
+++ b/src/lib/imageEncode.ts
@@ -1,0 +1,82 @@
+const WEBP_MIME = "image/webp";
+const QUALITY_LADDER = [0.85, 0.7, 0.55, 0.4];
+const SHRINK_STEPS = 2;
+const SHRINK_FACTOR = 0.75;
+
+export interface NormalizeImageOptions {
+  maxPx: number;
+  maxBytes: number;
+}
+
+export const AVATAR_IMAGE_BUDGET: NormalizeImageOptions = { maxPx: 512, maxBytes: 256 * 1024 };
+export const PLAYMAT_IMAGE_BUDGET: NormalizeImageOptions = { maxPx: 1024, maxBytes: 512 * 1024 };
+
+export class ImageTooLargeError extends Error {
+  constructor(maxBytes: number) {
+    super(`Image could not be compressed under ${Math.round(maxBytes / 1024)} KB`);
+    this.name = "ImageTooLargeError";
+  }
+}
+
+export async function normalizeToWebp(
+  source: Blob,
+  { maxPx, maxBytes }: NormalizeImageOptions,
+): Promise<string> {
+  const bitmap = await createImageBitmap(source);
+  try {
+    let scale = Math.min(1, maxPx / Math.max(bitmap.width, bitmap.height));
+    for (let step = 0; step <= SHRINK_STEPS; step++) {
+      const width = Math.max(1, Math.round(bitmap.width * scale));
+      const height = Math.max(1, Math.round(bitmap.height * scale));
+      const canvas = createCanvas(width, height);
+      const ctx = canvas.getContext("2d") as
+        | CanvasRenderingContext2D
+        | OffscreenCanvasRenderingContext2D
+        | null;
+      if (!ctx) throw new Error("2d canvas context unavailable");
+      ctx.drawImage(bitmap, 0, 0, width, height);
+      for (const quality of QUALITY_LADDER) {
+        const blob = await canvasToWebp(canvas, quality);
+        if (blob.type !== WEBP_MIME) throw new Error("WebP encoding unsupported");
+        if (blob.size <= maxBytes) return await blobToDataUrl(blob);
+      }
+      scale *= SHRINK_FACTOR;
+    }
+    throw new ImageTooLargeError(maxBytes);
+  } finally {
+    bitmap.close();
+  }
+}
+
+function createCanvas(width: number, height: number): HTMLCanvasElement | OffscreenCanvas {
+  if (typeof OffscreenCanvas !== "undefined") return new OffscreenCanvas(width, height);
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  return canvas;
+}
+
+async function canvasToWebp(
+  canvas: HTMLCanvasElement | OffscreenCanvas,
+  quality: number,
+): Promise<Blob> {
+  if (canvas instanceof OffscreenCanvas) {
+    return canvas.convertToBlob({ type: WEBP_MIME, quality });
+  }
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => (blob ? resolve(blob) : reject(new Error("canvas.toBlob returned null"))),
+      WEBP_MIME,
+      quality,
+    );
+  });
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error ?? new Error("FileReader failed"));
+    reader.readAsDataURL(blob);
+  });
+}

--- a/src/pixi/BoardCanvas.tsx
+++ b/src/pixi/BoardCanvas.tsx
@@ -33,7 +33,7 @@ import { RotateCw } from "lucide-react";
 /** Matches HandCardActions `w-[220px]`. */
 const HAND_ACTIONS_PANEL_W = 220;
 import type { HandActionOption } from "@/stores/useGameUIStore";
-import type { GameCard } from "@/types/manabrew";
+import type { GameCard, PlaymatSettings } from "@/types/manabrew";
 import type {
   ArrowSpec,
   BattlefieldState,
@@ -51,6 +51,8 @@ export interface BoardCanvasRegion {
   state: BattlefieldState;
   /** This player's deck playmat (normalized WebP data URL), rendered as the felt. */
   playmat?: string;
+  /** Render tuning for the playmat (opacity, texture, border). */
+  playmatSettings?: PlaymatSettings;
 }
 
 /** Canvas-local px == CSS px, so the parent can anchor React panels to each
@@ -258,9 +260,13 @@ export function BoardCanvas({
     playerId: r.playerId,
     isLocal: r.isLocal,
     playmat: r.playmat,
+    playmatSettings: r.playmatSettings,
   }));
   const playersKey = players
-    .map((p) => `${p.playerId}:${p.isLocal ? 1 : 0}:${p.playmat ? 1 : 0}`)
+    .map(
+      (p) =>
+        `${p.playerId}:${p.isLocal ? 1 : 0}:${p.playmat ? 1 : 0}:${JSON.stringify(p.playmatSettings ?? {})}`,
+    )
     .join(",");
   const opponentIds = regions.filter((r) => !r.isLocal).map((r) => r.playerId);
   // Stable content key so `reconfigure`'s identity doesn't churn when the parent

--- a/src/pixi/BoardCanvas.tsx
+++ b/src/pixi/BoardCanvas.tsx
@@ -49,9 +49,7 @@ export interface BoardCanvasRegion {
   playerId: string;
   isLocal: boolean;
   state: BattlefieldState;
-  /** This player's deck playmat (normalized WebP data URL), rendered as the felt. */
   playmat?: string;
-  /** Render tuning for the playmat (opacity, texture, border). */
   playmatSettings?: PlaymatSettings;
 }
 

--- a/src/pixi/BoardCanvas.tsx
+++ b/src/pixi/BoardCanvas.tsx
@@ -49,6 +49,8 @@ export interface BoardCanvasRegion {
   playerId: string;
   isLocal: boolean;
   state: BattlefieldState;
+  /** This player's deck playmat (normalized WebP data URL), rendered as the felt. */
+  playmat?: string;
 }
 
 /** Canvas-local px == CSS px, so the parent can anchor React panels to each
@@ -255,8 +257,11 @@ export function BoardCanvas({
   const players: BoardPlayerSpec[] = regions.map((r) => ({
     playerId: r.playerId,
     isLocal: r.isLocal,
+    playmat: r.playmat,
   }));
-  const playersKey = players.map((p) => `${p.playerId}:${p.isLocal ? 1 : 0}`).join(",");
+  const playersKey = players
+    .map((p) => `${p.playerId}:${p.isLocal ? 1 : 0}:${p.playmat ? 1 : 0}`)
+    .join(",");
   const opponentIds = regions.filter((r) => !r.isLocal).map((r) => r.playerId);
   // Stable content key so `reconfigure`'s identity doesn't churn when the parent
   // re-creates this array prop.

--- a/src/pixi/CardSprite.ts
+++ b/src/pixi/CardSprite.ts
@@ -545,9 +545,14 @@ export class CardSprite extends Container {
     const deckCard = asDeckCard(deck, this.card);
     const custom = this.isBattlefield && activeStyle !== "realistic";
     const faceIndex = this.previewFace ?? (this.card.isTransformed ? 1 : 0);
-    const tex = await useScryfallStore
-      .getState()
-      .getCardTexture(deckCard, custom ? "art" : "full", faceIndex);
+    let tex: Texture;
+    try {
+      tex = await useScryfallStore
+        .getState()
+        .getCardTexture(deckCard, custom ? "art" : "full", faceIndex);
+    } catch {
+      tex = Texture.EMPTY;
+    }
     if (this.destroyed || generation !== this.loadGeneration) return;
     if (tex !== Texture.EMPTY) {
       this.imageSpr.texture = tex;

--- a/src/pixi/GridLayout.ts
+++ b/src/pixi/GridLayout.ts
@@ -108,10 +108,7 @@ export const computeGridLayout = (
   const midCol = (cols - 1) / 2;
   // Card center for midCol: originX + midCol * cellW + cardW/2 = zoneCenterX
   const originX = zoneCenterX - midCol * cellW - cardW / 2;
-  // Top-anchor: cards pack from the top of the zone, leaving the bottom
-  // clear for the hand fan and UI overlays.  A small top margin keeps
-  // the first row from kissing the zone edge.
-  const topMargin = Math.min(GAP, Math.max(0, (usableH - gridH) / 2));
+  const topMargin = Math.max(0, (usableH - gridH) / 2);
   const originY = zone.y + topMargin;
 
   const cells: GridCell[] = new Array(cols * rows);

--- a/src/pixi/board/BoardRegion.ts
+++ b/src/pixi/board/BoardRegion.ts
@@ -1,4 +1,12 @@
-import { Container, Graphics, Text, type FederatedPointerEvent } from "pixi.js";
+import {
+  Container,
+  Graphics,
+  ImageSource,
+  Sprite,
+  Text,
+  Texture,
+  type FederatedPointerEvent,
+} from "pixi.js";
 import type { GameCard } from "@/types/manabrew";
 import { CardSprite } from "../CardSprite";
 import type { BattlefieldState, PlayZoneRect, ScreenPos } from "../types";
@@ -99,6 +107,9 @@ export class BoardRegion {
   private cardScale: number;
 
   private backgroundGfx: Graphics;
+  private playmatUrl: string | null = null;
+  private playmatSprite: Sprite | null = null;
+  private playmatMask: Graphics | null = null;
   private effects = new EffectsLayer();
   private gridSkeletonGfx: Graphics;
   private emptyText: Text;
@@ -973,6 +984,70 @@ export class BoardRegion {
       color: hexToNum(this.host.getTheme().gameTheme.canvas.background),
       alpha: this.dropActive ? BG_ALPHA_DROP : BG_ALPHA_IDLE,
     });
+    this.layoutPlaymat();
+  }
+
+  setPlaymat(url: string | undefined): void {
+    const next = url ?? null;
+    if (next === this.playmatUrl) return;
+    this.playmatUrl = next;
+    if (!next) {
+      this.destroyPlaymat();
+      return;
+    }
+    const img = new Image();
+    img.onload = () => {
+      if (this.host.isDestroyed() || this.playmatUrl !== next) return;
+      const texture = new Texture({ source: new ImageSource({ resource: img }) });
+      if (!this.playmatSprite) {
+        const sprite = new Sprite();
+        sprite.anchor.set(0.5);
+        sprite.eventMode = "none";
+        sprite.zIndex = -9;
+        this.container.addChild(sprite);
+        this.playmatSprite = sprite;
+      } else {
+        this.playmatSprite.texture?.destroy(true);
+      }
+      this.playmatSprite.texture = texture;
+      this.layoutPlaymat();
+    };
+    img.src = next;
+  }
+
+  private layoutPlaymat(): void {
+    const sprite = this.playmatSprite;
+    if (!sprite) return;
+    const felt = this.usableZone();
+    const tw = sprite.texture.width || 1;
+    const th = sprite.texture.height || 1;
+    sprite.scale.set(Math.max(felt.width / tw, felt.height / th));
+    sprite.x = felt.x + felt.width / 2;
+    sprite.y = felt.y + felt.height / 2;
+    sprite.alpha = this.dropActive ? BG_ALPHA_DROP : BG_ALPHA_IDLE;
+    if (!this.playmatMask) {
+      this.playmatMask = new Graphics();
+      this.container.addChild(this.playmatMask);
+      sprite.mask = this.playmatMask;
+    }
+    this.playmatMask.clear();
+    this.playmatMask.roundRect(felt.x, felt.y, felt.width, felt.height, TABLE_RADIUS);
+    this.playmatMask.fill({ color: 0xffffff });
+  }
+
+  private destroyPlaymat(): void {
+    if (this.playmatSprite) {
+      this.playmatSprite.mask = null;
+      this.container.removeChild(this.playmatSprite);
+      this.playmatSprite.texture?.destroy(true);
+      safeDestroy(this.playmatSprite);
+      this.playmatSprite = null;
+    }
+    if (this.playmatMask) {
+      this.container.removeChild(this.playmatMask);
+      safeDestroy(this.playmatMask);
+      this.playmatMask = null;
+    }
   }
 
   private layoutEmptyText(): void {
@@ -1263,6 +1338,7 @@ export class BoardRegion {
   }
 
   destroy(): void {
+    this.destroyPlaymat();
     this.effects.destroy();
     this.container.destroy({ children: true });
     this.entries.clear();

--- a/src/pixi/board/BoardRegion.ts
+++ b/src/pixi/board/BoardRegion.ts
@@ -1118,7 +1118,7 @@ export class BoardRegion {
 
     const tw = this.playmatSprite.texture.width || 1;
     const th = this.playmatSprite.texture.height || 1;
-    this.playmatSprite.scale.set(Math.max(felt.width / tw, felt.height / th));
+    this.playmatSprite.scale.set(felt.width / tw, felt.height / th);
     this.playmatSprite.x = felt.x + felt.width / 2;
     this.playmatSprite.y = felt.y + felt.height / 2;
 

--- a/src/pixi/board/BoardRegion.ts
+++ b/src/pixi/board/BoardRegion.ts
@@ -63,7 +63,7 @@ import {
 } from "../constants";
 import type { BlockingRect, RegionHost, SceneCombatStaging, SpriteEntry } from "./types";
 import { STRIP_BAND_PX, type RegionOrientation } from "./boardLayout";
-import { PlaymatLayer } from "./PlaymatLayer";
+import { PlaymatLayer, PLAYMAT_PADDING } from "./PlaymatLayer";
 
 type Point = ScreenPos;
 
@@ -621,7 +621,7 @@ export class BoardRegion {
 
   private applyOverflowStacking(topLevelCandidates: GameCard[]): void {
     if (topLevelCandidates.length === 0) return;
-    const zone = this.usableZone();
+    const zone = this.playArea();
     const grid = computeGridLayout(zone, 0, this.collectLocalBlockers(), this.cardScale);
     let freeCellCount = 0;
     for (const cell of grid.cells) {
@@ -680,7 +680,7 @@ export class BoardRegion {
 
   private computeBattlefieldGrid(cards: GameCard[]): Map<string, Point> {
     const positions = new Map<string, Point>();
-    const zone = this.usableZone();
+    const zone = this.playArea();
     const grid = computeGridLayout(zone, 0, this.collectLocalBlockers(), this.cardScale);
     this.gridInfo = grid;
 
@@ -825,7 +825,7 @@ export class BoardRegion {
   }
 
   private findFirstFreeBattlefieldSlot(): Point {
-    const zone = this.usableZone();
+    const zone = this.playArea();
     const grid =
       this.gridInfo ?? computeGridLayout(zone, 0, this.collectLocalBlockers(), this.cardScale);
     const occupied = new Set<string>();
@@ -963,6 +963,17 @@ export class BoardRegion {
     const reserve = this.host.getHandReserveBottom();
     if (reserve <= 0) return zone;
     return { ...zone, height: Math.max(0, zone.height - reserve) };
+  }
+
+  private playArea(): PlayZoneRect {
+    const z = this.usableZone();
+    const pad = Math.min(z.width, z.height) * PLAYMAT_PADDING;
+    return {
+      x: z.x + pad,
+      y: z.y + pad,
+      width: Math.max(1, z.width - pad * 2),
+      height: Math.max(1, z.height - pad * 2),
+    };
   }
 
   redrawBackground(): void {
@@ -1226,12 +1237,7 @@ export class BoardRegion {
   }
 
   drawDropGrid(localX: number, localY: number): void {
-    const grid = computeGridLayout(
-      this.usableZone(),
-      0,
-      this.collectLocalBlockers(),
-      this.cardScale,
-    );
+    const grid = computeGridLayout(this.playArea(), 0, this.collectLocalBlockers(), this.cardScale);
     const color = hexToNum(this.host.getTheme().gameTheme.activeAction.active);
     const gfx = this.gridSkeletonGfx;
     gfx.clear();
@@ -1260,7 +1266,7 @@ export class BoardRegion {
   drawDropField(): void {
     // Instants/sorceries go to the stack, not a cell — no drop slot to capture.
     this.lastDropCell = null;
-    const zone = this.usableZone();
+    const zone = this.playArea();
     const color = hexToNum(this.host.getTheme().gameTheme.arrow.friendlyTarget);
     const pad = GAP * 2;
     const gfx = this.gridSkeletonGfx;

--- a/src/pixi/board/BoardRegion.ts
+++ b/src/pixi/board/BoardRegion.ts
@@ -1118,7 +1118,7 @@ export class BoardRegion {
 
     const tw = this.playmatSprite.texture.width || 1;
     const th = this.playmatSprite.texture.height || 1;
-    this.playmatSprite.scale.set(Math.max(felt.width / tw, felt.height / th));
+    this.playmatSprite.scale.set(Math.min(felt.width / tw, felt.height / th));
     this.playmatSprite.x = felt.x + felt.width / 2;
     this.playmatSprite.y = felt.y + felt.height / 2;
 

--- a/src/pixi/board/BoardRegion.ts
+++ b/src/pixi/board/BoardRegion.ts
@@ -1118,7 +1118,7 @@ export class BoardRegion {
 
     const tw = this.playmatSprite.texture.width || 1;
     const th = this.playmatSprite.texture.height || 1;
-    this.playmatSprite.scale.set(felt.width / tw, felt.height / th);
+    this.playmatSprite.scale.set(Math.max(felt.width / tw, felt.height / th));
     this.playmatSprite.x = felt.x + felt.width / 2;
     this.playmatSprite.y = felt.y + felt.height / 2;
 

--- a/src/pixi/board/BoardRegion.ts
+++ b/src/pixi/board/BoardRegion.ts
@@ -1,14 +1,5 @@
-import {
-  Container,
-  Graphics,
-  ImageSource,
-  Sprite,
-  Text,
-  Texture,
-  TilingSprite,
-  type FederatedPointerEvent,
-} from "pixi.js";
-import type { GameCard } from "@/types/manabrew";
+import { Container, Graphics, Text, type FederatedPointerEvent } from "pixi.js";
+import type { GameCard, PlaymatSettings } from "@/types/manabrew";
 import { CardSprite } from "../CardSprite";
 import type { BattlefieldState, PlayZoneRect, ScreenPos } from "../types";
 import {
@@ -72,6 +63,7 @@ import {
 } from "../constants";
 import type { BlockingRect, RegionHost, SceneCombatStaging, SpriteEntry } from "./types";
 import { STRIP_BAND_PX, type RegionOrientation } from "./boardLayout";
+import { PlaymatLayer } from "./PlaymatLayer";
 
 type Point = ScreenPos;
 
@@ -80,73 +72,6 @@ interface BoardRegionOptions {
 }
 
 const ENTRANCE_LAND_PX = 8;
-
-const PLAYMAT_ALPHA_IDLE = 0.62;
-const PLAYMAT_ALPHA_DROP = 0.18;
-const PLAYMAT_FABRIC_ALPHA = 0.5;
-const PLAYMAT_VIGNETTE_ALPHA = 0.7;
-const PLAYMAT_TINT = 0xe4e4e4;
-const PLAYMAT_FABRIC_TILE_SCALE = 0.6;
-
-/** A tileable woven-cloth tile on a white base (white = identity under MULTIPLY,
- *  so only the darker threads register as cloth grain over the playmat art). */
-let fabricTextureCache: Texture | null = null;
-function getFabricTexture(): Texture {
-  if (fabricTextureCache) return fabricTextureCache;
-  const tile = 64;
-  const cell = 8;
-  const canvas = document.createElement("canvas");
-  canvas.width = tile;
-  canvas.height = tile;
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return Texture.EMPTY;
-  ctx.fillStyle = "#ffffff";
-  ctx.fillRect(0, 0, tile, tile);
-  for (let y = 0; y < tile; y += cell) {
-    for (let x = 0; x < tile; x += cell) {
-      const over = (x / cell + y / cell) % 2 === 0;
-      ctx.fillStyle = over ? "rgba(0,0,0,0.05)" : "rgba(0,0,0,0.11)";
-      ctx.fillRect(x, y, cell, cell);
-    }
-  }
-  ctx.strokeStyle = "rgba(0,0,0,0.07)";
-  ctx.lineWidth = 1;
-  for (let i = 0; i <= tile; i += cell) {
-    ctx.beginPath();
-    ctx.moveTo(i + 0.5, 0);
-    ctx.lineTo(i + 0.5, tile);
-    ctx.stroke();
-    ctx.beginPath();
-    ctx.moveTo(0, i + 0.5);
-    ctx.lineTo(tile, i + 0.5);
-    ctx.stroke();
-  }
-  fabricTextureCache = Texture.from(canvas);
-  return fabricTextureCache;
-}
-
-/** Radial darkening overlay — transparent center fading to near-black at the
- *  corners — so the playmat sinks into the table instead of reading as a hard
- *  stretched rectangle. */
-let vignetteTextureCache: Texture | null = null;
-function getVignetteTexture(): Texture {
-  if (vignetteTextureCache) return vignetteTextureCache;
-  const size = 256;
-  const canvas = document.createElement("canvas");
-  canvas.width = size;
-  canvas.height = size;
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return Texture.EMPTY;
-  const c = size / 2;
-  const gradient = ctx.createRadialGradient(c, c, size * 0.3, c, c, size * 0.62);
-  gradient.addColorStop(0, "rgba(0,0,0,0)");
-  gradient.addColorStop(0.75, "rgba(0,0,0,0.35)");
-  gradient.addColorStop(1, "rgba(0,0,0,0.92)");
-  ctx.fillStyle = gradient;
-  ctx.fillRect(0, 0, size, size);
-  vignetteTextureCache = Texture.from(canvas);
-  return vignetteTextureCache;
-}
 
 /** Keyed by the card object. The engine mints fresh `GameCard` objects per state
  *  update, so a real change recomputes; the many re-layout passes that reuse the
@@ -175,13 +100,7 @@ export class BoardRegion {
   private cardScale: number;
 
   private backgroundGfx: Graphics;
-  private playmatUrl: string | null = null;
-  private playmatLayer: Container | null = null;
-  private playmatSprite: Sprite | null = null;
-  private fabricSprite: TilingSprite | null = null;
-  private vignetteSprite: Sprite | null = null;
-  private playmatImageTexture: Texture | null = null;
-  private playmatMask: Graphics | null = null;
+  private playmat = new PlaymatLayer();
   private effects = new EffectsLayer();
   private gridSkeletonGfx: Graphics;
   private emptyText: Text;
@@ -224,6 +143,9 @@ export class BoardRegion {
     this.backgroundGfx = new Graphics();
     this.backgroundGfx.zIndex = -10;
     this.container.addChild(this.backgroundGfx);
+
+    this.playmat.container.zIndex = -9;
+    this.container.addChild(this.playmat.container);
 
     // Above the felt, below the cards.
     this.effects.container.zIndex = 0;
@@ -1056,105 +978,16 @@ export class BoardRegion {
       color: hexToNum(this.host.getTheme().gameTheme.canvas.background),
       alpha: this.dropActive ? BG_ALPHA_DROP : BG_ALPHA_IDLE,
     });
-    this.layoutPlaymat();
+    this.playmat.layout(this.usableZone(), { dropActive: this.dropActive });
   }
 
   setPlaymat(url: string | undefined): void {
-    const next = url ?? null;
-    if (next === this.playmatUrl) return;
-    this.playmatUrl = next;
-    if (!next) {
-      this.destroyPlaymat();
-      return;
-    }
-    const img = new Image();
-    img.onload = () => {
-      if (this.host.isDestroyed() || this.playmatUrl !== next) return;
-      this.ensurePlaymatLayer();
-      this.playmatImageTexture?.destroy(true);
-      this.playmatImageTexture = new Texture({ source: new ImageSource({ resource: img }) });
-      this.playmatSprite!.texture = this.playmatImageTexture;
-      this.layoutPlaymat();
-    };
-    img.src = next;
+    this.playmat.setImage(url);
+    this.playmat.layout(this.usableZone(), { dropActive: this.dropActive });
   }
 
-  private ensurePlaymatLayer(): void {
-    if (this.playmatLayer) return;
-    const layer = new Container();
-    layer.zIndex = -9;
-    layer.eventMode = "none";
-
-    const image = new Sprite();
-    image.anchor.set(0.5);
-    image.tint = PLAYMAT_TINT;
-
-    const fabric = new TilingSprite({ texture: getFabricTexture() });
-    fabric.tileScale.set(PLAYMAT_FABRIC_TILE_SCALE);
-    fabric.alpha = PLAYMAT_FABRIC_ALPHA;
-    fabric.blendMode = "multiply";
-
-    const vignette = new Sprite(getVignetteTexture());
-    vignette.alpha = PLAYMAT_VIGNETTE_ALPHA;
-
-    layer.addChild(image, fabric, vignette);
-    this.container.addChild(layer);
-
-    const mask = new Graphics();
-    this.container.addChild(mask);
-    layer.mask = mask;
-
-    this.playmatLayer = layer;
-    this.playmatSprite = image;
-    this.fabricSprite = fabric;
-    this.vignetteSprite = vignette;
-    this.playmatMask = mask;
-  }
-
-  private layoutPlaymat(): void {
-    const layer = this.playmatLayer;
-    if (!layer || !this.playmatSprite || !this.fabricSprite || !this.vignetteSprite) return;
-    const felt = this.usableZone();
-
-    const tw = this.playmatSprite.texture.width || 1;
-    const th = this.playmatSprite.texture.height || 1;
-    this.playmatSprite.scale.set(Math.max(felt.width / tw, felt.height / th));
-    this.playmatSprite.x = felt.x + felt.width / 2;
-    this.playmatSprite.y = felt.y + felt.height / 2;
-
-    for (const overlay of [this.fabricSprite, this.vignetteSprite]) {
-      overlay.x = felt.x;
-      overlay.y = felt.y;
-      overlay.width = felt.width;
-      overlay.height = felt.height;
-    }
-
-    if (this.playmatMask) {
-      this.playmatMask.clear();
-      this.playmatMask.roundRect(felt.x, felt.y, felt.width, felt.height, TABLE_RADIUS);
-      this.playmatMask.fill({ color: 0xffffff });
-    }
-
-    layer.alpha = this.dropActive ? PLAYMAT_ALPHA_DROP : PLAYMAT_ALPHA_IDLE;
-  }
-
-  private destroyPlaymat(): void {
-    if (this.playmatLayer) {
-      this.playmatLayer.mask = null;
-      this.container.removeChild(this.playmatLayer);
-      safeDestroy(this.playmatLayer);
-      this.playmatLayer = null;
-    }
-    if (this.playmatMask) {
-      this.container.removeChild(this.playmatMask);
-      safeDestroy(this.playmatMask);
-      this.playmatMask = null;
-    }
-    this.playmatImageTexture?.destroy(true);
-    this.playmatImageTexture = null;
-    this.playmatSprite = null;
-    this.fabricSprite = null;
-    this.vignetteSprite = null;
+  setPlaymatSettings(settings: PlaymatSettings | undefined): void {
+    this.playmat.setSettings(settings);
   }
 
   private layoutEmptyText(): void {
@@ -1445,7 +1278,7 @@ export class BoardRegion {
   }
 
   destroy(): void {
-    this.destroyPlaymat();
+    this.playmat.destroy();
     this.effects.destroy();
     this.container.destroy({ children: true });
     this.entries.clear();

--- a/src/pixi/board/BoardRegion.ts
+++ b/src/pixi/board/BoardRegion.ts
@@ -1118,7 +1118,7 @@ export class BoardRegion {
 
     const tw = this.playmatSprite.texture.width || 1;
     const th = this.playmatSprite.texture.height || 1;
-    this.playmatSprite.scale.set(Math.min(felt.width / tw, felt.height / th));
+    this.playmatSprite.scale.set(Math.max(felt.width / tw, felt.height / th));
     this.playmatSprite.x = felt.x + felt.width / 2;
     this.playmatSprite.y = felt.y + felt.height / 2;
 

--- a/src/pixi/board/BoardRegion.ts
+++ b/src/pixi/board/BoardRegion.ts
@@ -5,6 +5,7 @@ import {
   Sprite,
   Text,
   Texture,
+  TilingSprite,
   type FederatedPointerEvent,
 } from "pixi.js";
 import type { GameCard } from "@/types/manabrew";
@@ -80,6 +81,73 @@ interface BoardRegionOptions {
 
 const ENTRANCE_LAND_PX = 8;
 
+const PLAYMAT_ALPHA_IDLE = 0.62;
+const PLAYMAT_ALPHA_DROP = 0.18;
+const PLAYMAT_FABRIC_ALPHA = 0.5;
+const PLAYMAT_VIGNETTE_ALPHA = 0.7;
+const PLAYMAT_TINT = 0xe4e4e4;
+const PLAYMAT_FABRIC_TILE_SCALE = 0.6;
+
+/** A tileable woven-cloth tile on a white base (white = identity under MULTIPLY,
+ *  so only the darker threads register as cloth grain over the playmat art). */
+let fabricTextureCache: Texture | null = null;
+function getFabricTexture(): Texture {
+  if (fabricTextureCache) return fabricTextureCache;
+  const tile = 64;
+  const cell = 8;
+  const canvas = document.createElement("canvas");
+  canvas.width = tile;
+  canvas.height = tile;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return Texture.EMPTY;
+  ctx.fillStyle = "#ffffff";
+  ctx.fillRect(0, 0, tile, tile);
+  for (let y = 0; y < tile; y += cell) {
+    for (let x = 0; x < tile; x += cell) {
+      const over = (x / cell + y / cell) % 2 === 0;
+      ctx.fillStyle = over ? "rgba(0,0,0,0.05)" : "rgba(0,0,0,0.11)";
+      ctx.fillRect(x, y, cell, cell);
+    }
+  }
+  ctx.strokeStyle = "rgba(0,0,0,0.07)";
+  ctx.lineWidth = 1;
+  for (let i = 0; i <= tile; i += cell) {
+    ctx.beginPath();
+    ctx.moveTo(i + 0.5, 0);
+    ctx.lineTo(i + 0.5, tile);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(0, i + 0.5);
+    ctx.lineTo(tile, i + 0.5);
+    ctx.stroke();
+  }
+  fabricTextureCache = Texture.from(canvas);
+  return fabricTextureCache;
+}
+
+/** Radial darkening overlay — transparent center fading to near-black at the
+ *  corners — so the playmat sinks into the table instead of reading as a hard
+ *  stretched rectangle. */
+let vignetteTextureCache: Texture | null = null;
+function getVignetteTexture(): Texture {
+  if (vignetteTextureCache) return vignetteTextureCache;
+  const size = 256;
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return Texture.EMPTY;
+  const c = size / 2;
+  const gradient = ctx.createRadialGradient(c, c, size * 0.3, c, c, size * 0.62);
+  gradient.addColorStop(0, "rgba(0,0,0,0)");
+  gradient.addColorStop(0.75, "rgba(0,0,0,0.35)");
+  gradient.addColorStop(1, "rgba(0,0,0,0.92)");
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, size, size);
+  vignetteTextureCache = Texture.from(canvas);
+  return vignetteTextureCache;
+}
+
 /** Keyed by the card object. The engine mints fresh `GameCard` objects per state
  *  update, so a real change recomputes; the many re-layout passes that reuse the
  *  same objects (resize, blockers, combat staging) hit the cache. */
@@ -108,7 +176,11 @@ export class BoardRegion {
 
   private backgroundGfx: Graphics;
   private playmatUrl: string | null = null;
+  private playmatLayer: Container | null = null;
   private playmatSprite: Sprite | null = null;
+  private fabricSprite: TilingSprite | null = null;
+  private vignetteSprite: Sprite | null = null;
+  private playmatImageTexture: Texture | null = null;
   private playmatMask: Graphics | null = null;
   private effects = new EffectsLayer();
   private gridSkeletonGfx: Graphics;
@@ -998,56 +1070,91 @@ export class BoardRegion {
     const img = new Image();
     img.onload = () => {
       if (this.host.isDestroyed() || this.playmatUrl !== next) return;
-      const texture = new Texture({ source: new ImageSource({ resource: img }) });
-      if (!this.playmatSprite) {
-        const sprite = new Sprite();
-        sprite.anchor.set(0.5);
-        sprite.eventMode = "none";
-        sprite.zIndex = -9;
-        this.container.addChild(sprite);
-        this.playmatSprite = sprite;
-      } else {
-        this.playmatSprite.texture?.destroy(true);
-      }
-      this.playmatSprite.texture = texture;
+      this.ensurePlaymatLayer();
+      this.playmatImageTexture?.destroy(true);
+      this.playmatImageTexture = new Texture({ source: new ImageSource({ resource: img }) });
+      this.playmatSprite!.texture = this.playmatImageTexture;
       this.layoutPlaymat();
     };
     img.src = next;
   }
 
+  private ensurePlaymatLayer(): void {
+    if (this.playmatLayer) return;
+    const layer = new Container();
+    layer.zIndex = -9;
+    layer.eventMode = "none";
+
+    const image = new Sprite();
+    image.anchor.set(0.5);
+    image.tint = PLAYMAT_TINT;
+
+    const fabric = new TilingSprite({ texture: getFabricTexture() });
+    fabric.tileScale.set(PLAYMAT_FABRIC_TILE_SCALE);
+    fabric.alpha = PLAYMAT_FABRIC_ALPHA;
+    fabric.blendMode = "multiply";
+
+    const vignette = new Sprite(getVignetteTexture());
+    vignette.alpha = PLAYMAT_VIGNETTE_ALPHA;
+
+    layer.addChild(image, fabric, vignette);
+    this.container.addChild(layer);
+
+    const mask = new Graphics();
+    this.container.addChild(mask);
+    layer.mask = mask;
+
+    this.playmatLayer = layer;
+    this.playmatSprite = image;
+    this.fabricSprite = fabric;
+    this.vignetteSprite = vignette;
+    this.playmatMask = mask;
+  }
+
   private layoutPlaymat(): void {
-    const sprite = this.playmatSprite;
-    if (!sprite) return;
+    const layer = this.playmatLayer;
+    if (!layer || !this.playmatSprite || !this.fabricSprite || !this.vignetteSprite) return;
     const felt = this.usableZone();
-    const tw = sprite.texture.width || 1;
-    const th = sprite.texture.height || 1;
-    sprite.scale.set(Math.max(felt.width / tw, felt.height / th));
-    sprite.x = felt.x + felt.width / 2;
-    sprite.y = felt.y + felt.height / 2;
-    sprite.alpha = this.dropActive ? BG_ALPHA_DROP : BG_ALPHA_IDLE;
-    if (!this.playmatMask) {
-      this.playmatMask = new Graphics();
-      this.container.addChild(this.playmatMask);
-      sprite.mask = this.playmatMask;
+
+    const tw = this.playmatSprite.texture.width || 1;
+    const th = this.playmatSprite.texture.height || 1;
+    this.playmatSprite.scale.set(Math.max(felt.width / tw, felt.height / th));
+    this.playmatSprite.x = felt.x + felt.width / 2;
+    this.playmatSprite.y = felt.y + felt.height / 2;
+
+    for (const overlay of [this.fabricSprite, this.vignetteSprite]) {
+      overlay.x = felt.x;
+      overlay.y = felt.y;
+      overlay.width = felt.width;
+      overlay.height = felt.height;
     }
-    this.playmatMask.clear();
-    this.playmatMask.roundRect(felt.x, felt.y, felt.width, felt.height, TABLE_RADIUS);
-    this.playmatMask.fill({ color: 0xffffff });
+
+    if (this.playmatMask) {
+      this.playmatMask.clear();
+      this.playmatMask.roundRect(felt.x, felt.y, felt.width, felt.height, TABLE_RADIUS);
+      this.playmatMask.fill({ color: 0xffffff });
+    }
+
+    layer.alpha = this.dropActive ? PLAYMAT_ALPHA_DROP : PLAYMAT_ALPHA_IDLE;
   }
 
   private destroyPlaymat(): void {
-    if (this.playmatSprite) {
-      this.playmatSprite.mask = null;
-      this.container.removeChild(this.playmatSprite);
-      this.playmatSprite.texture?.destroy(true);
-      safeDestroy(this.playmatSprite);
-      this.playmatSprite = null;
+    if (this.playmatLayer) {
+      this.playmatLayer.mask = null;
+      this.container.removeChild(this.playmatLayer);
+      safeDestroy(this.playmatLayer);
+      this.playmatLayer = null;
     }
     if (this.playmatMask) {
       this.container.removeChild(this.playmatMask);
       safeDestroy(this.playmatMask);
       this.playmatMask = null;
     }
+    this.playmatImageTexture?.destroy(true);
+    this.playmatImageTexture = null;
+    this.playmatSprite = null;
+    this.fabricSprite = null;
+    this.vignetteSprite = null;
   }
 
   private layoutEmptyText(): void {

--- a/src/pixi/board/BoardScene.ts
+++ b/src/pixi/board/BoardScene.ts
@@ -1,5 +1,5 @@
 import { Application, Container, Graphics, Text, type FederatedPointerEvent } from "pixi.js";
-import type { GameCard } from "@/types/manabrew";
+import type { GameCard, PlaymatSettings } from "@/types/manabrew";
 import {
   CardSprite,
   setCardSpriteTheme,
@@ -62,6 +62,7 @@ export interface BoardPlayerSpec {
   playerId: string;
   isLocal: boolean;
   playmat?: string;
+  playmatSettings?: PlaymatSettings;
 }
 
 interface RegionRecord {
@@ -198,6 +199,7 @@ export class BoardScene {
         existing.zone = zone;
         existing.region.setZone(zone, orientation);
         existing.region.setCardScale(cardScale);
+        existing.region.setPlaymatSettings(spec.playmatSettings);
         existing.region.setPlaymat(spec.playmat);
         continue;
       }
@@ -208,6 +210,7 @@ export class BoardScene {
         cardScale,
         { orientation },
       );
+      region.setPlaymatSettings(spec.playmatSettings);
       region.setPlaymat(spec.playmat);
       region.container.zIndex = spec.isLocal ? 100 : 50;
       region.setAutoSort(this.autoSort);

--- a/src/pixi/board/BoardScene.ts
+++ b/src/pixi/board/BoardScene.ts
@@ -61,6 +61,7 @@ import type {
 export interface BoardPlayerSpec {
   playerId: string;
   isLocal: boolean;
+  playmat?: string;
 }
 
 interface RegionRecord {
@@ -197,6 +198,7 @@ export class BoardScene {
         existing.zone = zone;
         existing.region.setZone(zone, orientation);
         existing.region.setCardScale(cardScale);
+        existing.region.setPlaymat(spec.playmat);
         continue;
       }
       const region = new BoardRegion(
@@ -206,6 +208,7 @@ export class BoardScene {
         cardScale,
         { orientation },
       );
+      region.setPlaymat(spec.playmat);
       region.container.zIndex = spec.isLocal ? 100 : 50;
       region.setAutoSort(this.autoSort);
       this.regions.set(spec.playerId, { region, zone, isLocal: spec.isLocal });

--- a/src/pixi/board/PlaymatLayer.ts
+++ b/src/pixi/board/PlaymatLayer.ts
@@ -45,7 +45,7 @@ function hue2rgb(p: number, q: number, t: number): number {
  *  Applied at render time so it holds for every deck. */
 function clampColor(hex: string, lMin: number, lMax: number, sMax: number): string {
   const match = /^#?([0-9a-fA-F]{6})$/.exec(hex.trim());
-  if (!match) return hex;
+  if (!match) return "#000000";
   const int = parseInt(match[1], 16);
   const r = ((int >> 16) & 255) / 255;
   const g = ((int >> 8) & 255) / 255;

--- a/src/pixi/board/PlaymatLayer.ts
+++ b/src/pixi/board/PlaymatLayer.ts
@@ -27,6 +27,9 @@ const clamp01 = (v: number): number => Math.max(0, Math.min(1, v));
 const BORDER_LIGHTNESS_MIN = 0.04;
 const BORDER_LIGHTNESS_MAX = 0.42;
 const BORDER_SATURATION_MAX = 0.5;
+const BACKGROUND_LIGHTNESS_MIN = 0.03;
+const BACKGROUND_LIGHTNESS_MAX = 0.4;
+const BACKGROUND_SATURATION_MAX = 0.5;
 
 function hue2rgb(p: number, q: number, t: number): number {
   if (t < 0) t += 1;
@@ -37,10 +40,10 @@ function hue2rgb(p: number, q: number, t: number): number {
   return p;
 }
 
-/** Clamp a border color's lightness and saturation so the frame stays muted.
- *  A too-bright or saturated border pulls focus from the cards, which must always
- *  be the foreground. Applied at render time so it holds for every deck. */
-export function clampBorderColor(hex: string): string {
+/** Clamp a color's lightness and saturation into a muted range (hue preserved).
+ *  Keeps the playmat firmly in the background so the cards stay the foreground.
+ *  Applied at render time so it holds for every deck. */
+function clampColor(hex: string, lMin: number, lMax: number, sMax: number): string {
   const match = /^#?([0-9a-fA-F]{6})$/.exec(hex.trim());
   if (!match) return hex;
   const int = parseInt(match[1], 16);
@@ -60,8 +63,8 @@ export function clampBorderColor(hex: string): string {
     else h = (r - g) / d + 4;
     h /= 6;
   }
-  const cl = Math.min(BORDER_LIGHTNESS_MAX, Math.max(BORDER_LIGHTNESS_MIN, l));
-  const cs = Math.min(BORDER_SATURATION_MAX, s);
+  const cl = Math.min(lMax, Math.max(lMin, l));
+  const cs = Math.min(sMax, s);
   let cr: number;
   let cg: number;
   let cb: number;
@@ -80,6 +83,12 @@ export function clampBorderColor(hex: string): string {
       .padStart(2, "0");
   return `#${toHex(cr)}${toHex(cg)}${toHex(cb)}`;
 }
+
+export const clampBorderColor = (hex: string): string =>
+  clampColor(hex, BORDER_LIGHTNESS_MIN, BORDER_LIGHTNESS_MAX, BORDER_SATURATION_MAX);
+
+export const clampPlaymatColor = (hex: string): string =>
+  clampColor(hex, BACKGROUND_LIGHTNESS_MIN, BACKGROUND_LIGHTNESS_MAX, BACKGROUND_SATURATION_MAX);
 
 /** A tileable woven-cloth tile on a white base (white = identity under MULTIPLY,
  *  so only the darker threads register as cloth grain over the playmat art). */
@@ -237,7 +246,7 @@ export class PlaymatLayer {
     this.colorFill.clear();
     if (this.settings.color) {
       this.colorFill.rect(rect.x, rect.y, rect.width, rect.height);
-      this.colorFill.fill({ color: hexToNum(this.settings.color) });
+      this.colorFill.fill({ color: hexToNum(clampPlaymatColor(this.settings.color)) });
     }
 
     const tw = this.image.texture.width || 1;

--- a/src/pixi/board/PlaymatLayer.ts
+++ b/src/pixi/board/PlaymatLayer.ts
@@ -17,8 +17,6 @@ export const DEFAULT_PLAYMAT_SETTINGS: Required<PlaymatSettings> = {
 };
 
 const PLAYMAT_DROP_DIM = 0.29;
-/** Fraction of the felt's shorter side the mat is inset from the field edges.
- *  Exported so panel placement (GameBoard) can align to the same inset. */
 export const PLAYMAT_PADDING = 0.04;
 const PLAYMAT_VIGNETTE_ALPHA = 0.7;
 const PLAYMAT_TINT = 0xe4e4e4;
@@ -43,9 +41,6 @@ function hue2rgb(p: number, q: number, t: number): number {
   return p;
 }
 
-/** Clamp a color's lightness and saturation into a muted range (hue preserved).
- *  Keeps the playmat firmly in the background so the cards stay the foreground.
- *  Applied at render time so it holds for every deck. */
 function clampColor(hex: string, lMin: number, lMax: number, sMax: number): string {
   const match = /^#?([0-9a-fA-F]{6})$/.exec(hex.trim());
   if (!match) return "#000000";
@@ -93,8 +88,6 @@ export const clampBorderColor = (hex: string): string =>
 export const clampPlaymatColor = (hex: string): string =>
   clampColor(hex, BACKGROUND_LIGHTNESS_MIN, BACKGROUND_LIGHTNESS_MAX, BACKGROUND_SATURATION_MAX);
 
-/** A tileable woven-cloth tile on a white base (white = identity under MULTIPLY,
- *  so only the darker threads register as cloth grain over the playmat art). */
 let fabricTextureCache: Texture | null = null;
 function getFabricTexture(): Texture {
   if (fabricTextureCache) return fabricTextureCache;
@@ -130,9 +123,6 @@ function getFabricTexture(): Texture {
   return fabricTextureCache;
 }
 
-/** Radial darkening overlay — transparent center fading to near-black at the
- *  corners — so the playmat sinks into the table instead of reading as a hard
- *  stretched rectangle. */
 let vignetteTextureCache: Texture | null = null;
 function getVignetteTexture(): Texture {
   if (vignetteTextureCache) return vignetteTextureCache;
@@ -153,11 +143,6 @@ function getVignetteTexture(): Texture {
   return vignetteTextureCache;
 }
 
-/** Renders a deck's playmat — cover-fit art + woven cloth + edge vignette +
- *  optional border — clipped to the felt's rounded rect. Shared by the in-game
- *  battlefield (`BoardRegion`) and the deck-editor preview so the two match
- *  pixel-for-pixel. The owner adds `container` to its scene and drives it via
- *  `setImage` / `setSettings` / `layout`. */
 export class PlaymatLayer {
   readonly container: Container;
   private content: Container;
@@ -192,10 +177,6 @@ export class PlaymatLayer {
     this.content.addChild(this.colorFill, this.image, this.fabric, this.vignette);
 
     this.mask = new Graphics();
-    // The border is intentionally NOT a child of `content`: a Graphics mask clips
-    // through the (1-bit, non-antialiased) stencil buffer, so its rounded corners
-    // are aliased and would chop the stroke. Drawn unmasked and on top, the stroke
-    // keeps Pixi's crisp antialiased corners and covers the content's clipped edge.
     this.border = new Graphics();
     this.container.addChild(this.content, this.mask, this.border);
     this.content.mask = this.mask;
@@ -246,7 +227,6 @@ export class PlaymatLayer {
     this.rect = rect;
     this.dropActive = opts.dropActive;
 
-    // Inset the mat so it doesn't crowd the field edges (the felt margin shows).
     const pad = Math.min(rect.width, rect.height) * PLAYMAT_PADDING;
     const r = {
       x: rect.x + pad,

--- a/src/pixi/board/PlaymatLayer.ts
+++ b/src/pixi/board/PlaymatLayer.ts
@@ -120,11 +120,15 @@ export class PlaymatLayer {
     this.fabric.blendMode = "multiply";
     this.vignette = new Sprite(getVignetteTexture());
     this.vignette.alpha = PLAYMAT_VIGNETTE_ALPHA;
-    this.border = new Graphics();
-    this.content.addChild(this.colorFill, this.image, this.fabric, this.vignette, this.border);
+    this.content.addChild(this.colorFill, this.image, this.fabric, this.vignette);
 
     this.mask = new Graphics();
-    this.container.addChild(this.content, this.mask);
+    // The border is intentionally NOT a child of `content`: a Graphics mask clips
+    // through the (1-bit, non-antialiased) stencil buffer, so its rounded corners
+    // are aliased and would chop the stroke. Drawn unmasked and on top, the stroke
+    // keeps Pixi's crisp antialiased corners and covers the content's clipped edge.
+    this.border = new Graphics();
+    this.container.addChild(this.content, this.mask, this.border);
     this.content.mask = this.mask;
     this.applySettings();
   }
@@ -228,6 +232,7 @@ export class PlaymatLayer {
 
     const opacity = clamp01(this.settings.opacity);
     this.content.alpha = opts.dropActive ? opacity * PLAYMAT_DROP_DIM : opacity;
+    this.border.alpha = this.content.alpha;
   }
 
   destroy(): void {

--- a/src/pixi/board/PlaymatLayer.ts
+++ b/src/pixi/board/PlaymatLayer.ts
@@ -11,6 +11,8 @@ export const DEFAULT_PLAYMAT_SETTINGS: Required<PlaymatSettings> = {
   borderWidth: 2,
   borderColor: "#000000",
   fit: "cover",
+  offsetX: 0.5,
+  offsetY: 0.5,
 };
 
 const PLAYMAT_DROP_DIM = 0.29;
@@ -163,15 +165,24 @@ export class PlaymatLayer {
     const th = this.image.texture.height || 1;
     const sx = rect.width / tw;
     const sy = rect.height / th;
+    const cx = rect.x + rect.width / 2;
+    const cy = rect.y + rect.height / 2;
     if (this.settings.fit === "stretch") {
       this.image.scale.set(sx, sy);
+      this.image.x = cx;
+      this.image.y = cy;
     } else if (this.settings.fit === "fit") {
       this.image.scale.set(Math.min(sx, sy));
+      this.image.x = cx;
+      this.image.y = cy;
     } else {
-      this.image.scale.set(Math.max(sx, sy));
+      const scale = Math.max(sx, sy);
+      this.image.scale.set(scale);
+      const ox = clamp01(this.settings.offsetX);
+      const oy = clamp01(this.settings.offsetY);
+      this.image.x = cx + (0.5 - ox) * (tw * scale - rect.width);
+      this.image.y = cy + (0.5 - oy) * (th * scale - rect.height);
     }
-    this.image.x = rect.x + rect.width / 2;
-    this.image.y = rect.y + rect.height / 2;
 
     for (const overlay of [this.fabric, this.vignette]) {
       overlay.x = rect.x;

--- a/src/pixi/board/PlaymatLayer.ts
+++ b/src/pixi/board/PlaymatLayer.ts
@@ -1,0 +1,201 @@
+import { Container, Graphics, ImageSource, Sprite, Texture, TilingSprite } from "pixi.js";
+import type { PlaymatSettings } from "@/types/manabrew";
+import type { PlayZoneRect } from "../types";
+import { TABLE_RADIUS } from "../constants";
+import { hexToNum } from "../colorUtils";
+import { safeDestroy } from "./pixiHelpers";
+
+export const DEFAULT_PLAYMAT_SETTINGS: Required<PlaymatSettings> = {
+  opacity: 0.62,
+  texture: 0.5,
+  borderWidth: 0,
+  borderColor: "#000000",
+};
+
+const PLAYMAT_DROP_DIM = 0.29;
+const PLAYMAT_VIGNETTE_ALPHA = 0.7;
+const PLAYMAT_TINT = 0xe4e4e4;
+const PLAYMAT_FABRIC_TILE_SCALE = 0.6;
+const PLAYMAT_FABRIC_MAX_ALPHA = 0.75;
+
+const clamp01 = (v: number): number => Math.max(0, Math.min(1, v));
+
+/** A tileable woven-cloth tile on a white base (white = identity under MULTIPLY,
+ *  so only the darker threads register as cloth grain over the playmat art). */
+let fabricTextureCache: Texture | null = null;
+function getFabricTexture(): Texture {
+  if (fabricTextureCache) return fabricTextureCache;
+  const tile = 64;
+  const cell = 8;
+  const canvas = document.createElement("canvas");
+  canvas.width = tile;
+  canvas.height = tile;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return Texture.EMPTY;
+  ctx.fillStyle = "#ffffff";
+  ctx.fillRect(0, 0, tile, tile);
+  for (let y = 0; y < tile; y += cell) {
+    for (let x = 0; x < tile; x += cell) {
+      const over = (x / cell + y / cell) % 2 === 0;
+      ctx.fillStyle = over ? "rgba(0,0,0,0.05)" : "rgba(0,0,0,0.11)";
+      ctx.fillRect(x, y, cell, cell);
+    }
+  }
+  ctx.strokeStyle = "rgba(0,0,0,0.07)";
+  ctx.lineWidth = 1;
+  for (let i = 0; i <= tile; i += cell) {
+    ctx.beginPath();
+    ctx.moveTo(i + 0.5, 0);
+    ctx.lineTo(i + 0.5, tile);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(0, i + 0.5);
+    ctx.lineTo(tile, i + 0.5);
+    ctx.stroke();
+  }
+  fabricTextureCache = Texture.from(canvas);
+  return fabricTextureCache;
+}
+
+/** Radial darkening overlay — transparent center fading to near-black at the
+ *  corners — so the playmat sinks into the table instead of reading as a hard
+ *  stretched rectangle. */
+let vignetteTextureCache: Texture | null = null;
+function getVignetteTexture(): Texture {
+  if (vignetteTextureCache) return vignetteTextureCache;
+  const size = 256;
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return Texture.EMPTY;
+  const c = size / 2;
+  const gradient = ctx.createRadialGradient(c, c, size * 0.3, c, c, size * 0.62);
+  gradient.addColorStop(0, "rgba(0,0,0,0)");
+  gradient.addColorStop(0.75, "rgba(0,0,0,0.35)");
+  gradient.addColorStop(1, "rgba(0,0,0,0.92)");
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, size, size);
+  vignetteTextureCache = Texture.from(canvas);
+  return vignetteTextureCache;
+}
+
+/** Renders a deck's playmat — cover-fit art + woven cloth + edge vignette +
+ *  optional border — clipped to the felt's rounded rect. Shared by the in-game
+ *  battlefield (`BoardRegion`) and the deck-editor preview so the two match
+ *  pixel-for-pixel. The owner adds `container` to its scene and drives it via
+ *  `setImage` / `setSettings` / `layout`. */
+export class PlaymatLayer {
+  readonly container: Container;
+  private content: Container;
+  private image: Sprite;
+  private fabric: TilingSprite;
+  private vignette: Sprite;
+  private border: Graphics;
+  private mask: Graphics;
+  private imageTexture: Texture | null = null;
+  private url: string | null = null;
+  private settings: Required<PlaymatSettings> = { ...DEFAULT_PLAYMAT_SETTINGS };
+  private rect: PlayZoneRect | null = null;
+  private dropActive = false;
+
+  constructor() {
+    this.container = new Container();
+    this.container.eventMode = "none";
+    this.container.visible = false;
+
+    this.content = new Container();
+    this.image = new Sprite();
+    this.image.anchor.set(0.5);
+    this.image.tint = PLAYMAT_TINT;
+    this.fabric = new TilingSprite({ texture: getFabricTexture() });
+    this.fabric.tileScale.set(PLAYMAT_FABRIC_TILE_SCALE);
+    this.fabric.blendMode = "multiply";
+    this.vignette = new Sprite(getVignetteTexture());
+    this.vignette.alpha = PLAYMAT_VIGNETTE_ALPHA;
+    this.border = new Graphics();
+    this.content.addChild(this.image, this.fabric, this.vignette, this.border);
+
+    this.mask = new Graphics();
+    this.container.addChild(this.content, this.mask);
+    this.content.mask = this.mask;
+    this.applySettings();
+  }
+
+  setImage(url: string | undefined): void {
+    const next = url ?? null;
+    if (next === this.url) return;
+    this.url = next;
+    if (!next) {
+      this.imageTexture?.destroy(true);
+      this.imageTexture = null;
+      this.container.visible = false;
+      return;
+    }
+    const img = new Image();
+    img.onload = () => {
+      if (this.url !== next) return;
+      this.imageTexture?.destroy(true);
+      this.imageTexture = new Texture({ source: new ImageSource({ resource: img }) });
+      this.image.texture = this.imageTexture;
+      this.container.visible = true;
+      if (this.rect) this.layout(this.rect, { dropActive: this.dropActive });
+    };
+    img.src = next;
+  }
+
+  setSettings(settings: PlaymatSettings | undefined): void {
+    this.settings = { ...DEFAULT_PLAYMAT_SETTINGS, ...(settings ?? {}) };
+    this.applySettings();
+    if (this.rect) this.layout(this.rect, { dropActive: this.dropActive });
+  }
+
+  private applySettings(): void {
+    this.fabric.alpha = clamp01(this.settings.texture) * PLAYMAT_FABRIC_MAX_ALPHA;
+  }
+
+  layout(rect: PlayZoneRect, opts: { dropActive: boolean }): void {
+    this.rect = rect;
+    this.dropActive = opts.dropActive;
+
+    const tw = this.image.texture.width || 1;
+    const th = this.image.texture.height || 1;
+    this.image.scale.set(Math.max(rect.width / tw, rect.height / th));
+    this.image.x = rect.x + rect.width / 2;
+    this.image.y = rect.y + rect.height / 2;
+
+    for (const overlay of [this.fabric, this.vignette]) {
+      overlay.x = rect.x;
+      overlay.y = rect.y;
+      overlay.width = rect.width;
+      overlay.height = rect.height;
+    }
+
+    this.mask.clear();
+    this.mask.roundRect(rect.x, rect.y, rect.width, rect.height, TABLE_RADIUS);
+    this.mask.fill({ color: 0xffffff });
+
+    this.border.clear();
+    const bw = this.settings.borderWidth;
+    if (bw > 0) {
+      this.border.roundRect(
+        rect.x + bw / 2,
+        rect.y + bw / 2,
+        rect.width - bw,
+        rect.height - bw,
+        Math.max(0, TABLE_RADIUS - bw / 2),
+      );
+      this.border.stroke({ width: bw, color: hexToNum(this.settings.borderColor) });
+    }
+
+    const opacity = clamp01(this.settings.opacity);
+    this.content.alpha = opts.dropActive ? opacity * PLAYMAT_DROP_DIM : opacity;
+  }
+
+  destroy(): void {
+    this.content.mask = null;
+    safeDestroy(this.container);
+    this.imageTexture?.destroy(true);
+    this.imageTexture = null;
+  }
+}

--- a/src/pixi/board/PlaymatLayer.ts
+++ b/src/pixi/board/PlaymatLayer.ts
@@ -17,6 +17,7 @@ export const DEFAULT_PLAYMAT_SETTINGS: Required<PlaymatSettings> = {
 };
 
 const PLAYMAT_DROP_DIM = 0.29;
+const PLAYMAT_PADDING = 0.04;
 const PLAYMAT_VIGNETTE_ALPHA = 0.7;
 const PLAYMAT_TINT = 0xe4e4e4;
 const PLAYMAT_FABRIC_TILE_SCALE = 0.6;
@@ -243,18 +244,27 @@ export class PlaymatLayer {
     this.rect = rect;
     this.dropActive = opts.dropActive;
 
+    // Inset the mat so it doesn't crowd the field edges (the felt margin shows).
+    const pad = Math.min(rect.width, rect.height) * PLAYMAT_PADDING;
+    const r = {
+      x: rect.x + pad,
+      y: rect.y + pad,
+      width: Math.max(1, rect.width - pad * 2),
+      height: Math.max(1, rect.height - pad * 2),
+    };
+
     this.colorFill.clear();
     if (this.settings.color) {
-      this.colorFill.rect(rect.x, rect.y, rect.width, rect.height);
+      this.colorFill.rect(r.x, r.y, r.width, r.height);
       this.colorFill.fill({ color: hexToNum(clampPlaymatColor(this.settings.color)) });
     }
 
     const tw = this.image.texture.width || 1;
     const th = this.image.texture.height || 1;
-    const sx = rect.width / tw;
-    const sy = rect.height / th;
-    const cx = rect.x + rect.width / 2;
-    const cy = rect.y + rect.height / 2;
+    const sx = r.width / tw;
+    const sy = r.height / th;
+    const cx = r.x + r.width / 2;
+    const cy = r.y + r.height / 2;
     if (this.settings.fit === "stretch") {
       this.image.scale.set(sx, sy);
       this.image.x = cx;
@@ -268,29 +278,29 @@ export class PlaymatLayer {
       this.image.scale.set(scale);
       const ox = clamp01(this.settings.offsetX);
       const oy = clamp01(this.settings.offsetY);
-      this.image.x = cx + (0.5 - ox) * (tw * scale - rect.width);
-      this.image.y = cy + (0.5 - oy) * (th * scale - rect.height);
+      this.image.x = cx + (0.5 - ox) * (tw * scale - r.width);
+      this.image.y = cy + (0.5 - oy) * (th * scale - r.height);
     }
 
     for (const overlay of [this.fabric, this.vignette]) {
-      overlay.x = rect.x;
-      overlay.y = rect.y;
-      overlay.width = rect.width;
-      overlay.height = rect.height;
+      overlay.x = r.x;
+      overlay.y = r.y;
+      overlay.width = r.width;
+      overlay.height = r.height;
     }
 
     this.mask.clear();
-    this.mask.roundRect(rect.x, rect.y, rect.width, rect.height, TABLE_RADIUS);
+    this.mask.roundRect(r.x, r.y, r.width, r.height, TABLE_RADIUS);
     this.mask.fill({ color: 0xffffff });
 
     this.border.clear();
     const bw = this.settings.borderWidth;
     if (bw > 0) {
       this.border.roundRect(
-        rect.x + bw / 2,
-        rect.y + bw / 2,
-        rect.width - bw,
-        rect.height - bw,
+        r.x + bw / 2,
+        r.y + bw / 2,
+        r.width - bw,
+        r.height - bw,
         Math.max(0, TABLE_RADIUS - bw / 2),
       );
       this.border.stroke({

--- a/src/pixi/board/PlaymatLayer.ts
+++ b/src/pixi/board/PlaymatLayer.ts
@@ -17,7 +17,9 @@ export const DEFAULT_PLAYMAT_SETTINGS: Required<PlaymatSettings> = {
 };
 
 const PLAYMAT_DROP_DIM = 0.29;
-const PLAYMAT_PADDING = 0.04;
+/** Fraction of the felt's shorter side the mat is inset from the field edges.
+ *  Exported so panel placement (GameBoard) can align to the same inset. */
+export const PLAYMAT_PADDING = 0.04;
 const PLAYMAT_VIGNETTE_ALPHA = 0.7;
 const PLAYMAT_TINT = 0xe4e4e4;
 const PLAYMAT_FABRIC_TILE_SCALE = 0.6;

--- a/src/pixi/board/PlaymatLayer.ts
+++ b/src/pixi/board/PlaymatLayer.ts
@@ -24,6 +24,63 @@ const PLAYMAT_FABRIC_MAX_ALPHA = 0.75;
 
 const clamp01 = (v: number): number => Math.max(0, Math.min(1, v));
 
+const BORDER_LIGHTNESS_MIN = 0.04;
+const BORDER_LIGHTNESS_MAX = 0.42;
+const BORDER_SATURATION_MAX = 0.5;
+
+function hue2rgb(p: number, q: number, t: number): number {
+  if (t < 0) t += 1;
+  if (t > 1) t -= 1;
+  if (t < 1 / 6) return p + (q - p) * 6 * t;
+  if (t < 1 / 2) return q;
+  if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+  return p;
+}
+
+/** Clamp a border color's lightness and saturation so the frame stays muted.
+ *  A too-bright or saturated border pulls focus from the cards, which must always
+ *  be the foreground. Applied at render time so it holds for every deck. */
+export function clampBorderColor(hex: string): string {
+  const match = /^#?([0-9a-fA-F]{6})$/.exec(hex.trim());
+  if (!match) return hex;
+  const int = parseInt(match[1], 16);
+  const r = ((int >> 16) & 255) / 255;
+  const g = ((int >> 8) & 255) / 255;
+  const b = (int & 255) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  const d = max - min;
+  let h = 0;
+  let s = 0;
+  if (d !== 0) {
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    if (max === r) h = (g - b) / d + (g < b ? 6 : 0);
+    else if (max === g) h = (b - r) / d + 2;
+    else h = (r - g) / d + 4;
+    h /= 6;
+  }
+  const cl = Math.min(BORDER_LIGHTNESS_MAX, Math.max(BORDER_LIGHTNESS_MIN, l));
+  const cs = Math.min(BORDER_SATURATION_MAX, s);
+  let cr: number;
+  let cg: number;
+  let cb: number;
+  if (cs === 0) {
+    cr = cg = cb = cl;
+  } else {
+    const q = cl < 0.5 ? cl * (1 + cs) : cl + cs - cl * cs;
+    const p = 2 * cl - q;
+    cr = hue2rgb(p, q, h + 1 / 3);
+    cg = hue2rgb(p, q, h);
+    cb = hue2rgb(p, q, h - 1 / 3);
+  }
+  const toHex = (v: number) =>
+    Math.round(clamp01(v) * 255)
+      .toString(16)
+      .padStart(2, "0");
+  return `#${toHex(cr)}${toHex(cg)}${toHex(cb)}`;
+}
+
 /** A tileable woven-cloth tile on a white base (white = identity under MULTIPLY,
  *  so only the darker threads register as cloth grain over the playmat art). */
 let fabricTextureCache: Texture | null = null;
@@ -227,7 +284,10 @@ export class PlaymatLayer {
         rect.height - bw,
         Math.max(0, TABLE_RADIUS - bw / 2),
       );
-      this.border.stroke({ width: bw, color: hexToNum(this.settings.borderColor) });
+      this.border.stroke({
+        width: bw,
+        color: hexToNum(clampBorderColor(this.settings.borderColor)),
+      });
     }
 
     const opacity = clamp01(this.settings.opacity);

--- a/src/pixi/board/PlaymatLayer.ts
+++ b/src/pixi/board/PlaymatLayer.ts
@@ -8,8 +8,9 @@ import { safeDestroy } from "./pixiHelpers";
 export const DEFAULT_PLAYMAT_SETTINGS: Required<PlaymatSettings> = {
   opacity: 0.62,
   texture: 0.5,
-  borderWidth: 0,
+  borderWidth: 2,
   borderColor: "#000000",
+  fit: "cover",
 };
 
 const PLAYMAT_DROP_DIM = 0.29;
@@ -160,7 +161,15 @@ export class PlaymatLayer {
 
     const tw = this.image.texture.width || 1;
     const th = this.image.texture.height || 1;
-    this.image.scale.set(Math.max(rect.width / tw, rect.height / th));
+    const sx = rect.width / tw;
+    const sy = rect.height / th;
+    if (this.settings.fit === "stretch") {
+      this.image.scale.set(sx, sy);
+    } else if (this.settings.fit === "fit") {
+      this.image.scale.set(Math.min(sx, sy));
+    } else {
+      this.image.scale.set(Math.max(sx, sy));
+    }
     this.image.x = rect.x + rect.width / 2;
     this.image.y = rect.y + rect.height / 2;
 

--- a/src/pixi/board/PlaymatLayer.ts
+++ b/src/pixi/board/PlaymatLayer.ts
@@ -13,6 +13,7 @@ export const DEFAULT_PLAYMAT_SETTINGS: Required<PlaymatSettings> = {
   fit: "cover",
   offsetX: 0.5,
   offsetY: 0.5,
+  color: "",
 };
 
 const PLAYMAT_DROP_DIM = 0.29;
@@ -91,6 +92,7 @@ function getVignetteTexture(): Texture {
 export class PlaymatLayer {
   readonly container: Container;
   private content: Container;
+  private colorFill: Graphics;
   private image: Sprite;
   private fabric: TilingSprite;
   private vignette: Sprite;
@@ -108,16 +110,18 @@ export class PlaymatLayer {
     this.container.visible = false;
 
     this.content = new Container();
+    this.colorFill = new Graphics();
     this.image = new Sprite();
     this.image.anchor.set(0.5);
     this.image.tint = PLAYMAT_TINT;
+    this.image.visible = false;
     this.fabric = new TilingSprite({ texture: getFabricTexture() });
     this.fabric.tileScale.set(PLAYMAT_FABRIC_TILE_SCALE);
     this.fabric.blendMode = "multiply";
     this.vignette = new Sprite(getVignetteTexture());
     this.vignette.alpha = PLAYMAT_VIGNETTE_ALPHA;
     this.border = new Graphics();
-    this.content.addChild(this.image, this.fabric, this.vignette, this.border);
+    this.content.addChild(this.colorFill, this.image, this.fabric, this.vignette, this.border);
 
     this.mask = new Graphics();
     this.container.addChild(this.content, this.mask);
@@ -132,7 +136,9 @@ export class PlaymatLayer {
     if (!next) {
       this.imageTexture?.destroy(true);
       this.imageTexture = null;
-      this.container.visible = false;
+      this.image.visible = false;
+      this.updateVisibility();
+      if (this.rect) this.layout(this.rect, { dropActive: this.dropActive });
       return;
     }
     const img = new Image();
@@ -141,7 +147,8 @@ export class PlaymatLayer {
       this.imageTexture?.destroy(true);
       this.imageTexture = new Texture({ source: new ImageSource({ resource: img }) });
       this.image.texture = this.imageTexture;
-      this.container.visible = true;
+      this.image.visible = true;
+      this.updateVisibility();
       if (this.rect) this.layout(this.rect, { dropActive: this.dropActive });
     };
     img.src = next;
@@ -150,7 +157,12 @@ export class PlaymatLayer {
   setSettings(settings: PlaymatSettings | undefined): void {
     this.settings = { ...DEFAULT_PLAYMAT_SETTINGS, ...(settings ?? {}) };
     this.applySettings();
+    this.updateVisibility();
     if (this.rect) this.layout(this.rect, { dropActive: this.dropActive });
+  }
+
+  private updateVisibility(): void {
+    this.container.visible = !!this.url || !!this.settings.color;
   }
 
   private applySettings(): void {
@@ -160,6 +172,12 @@ export class PlaymatLayer {
   layout(rect: PlayZoneRect, opts: { dropActive: boolean }): void {
     this.rect = rect;
     this.dropActive = opts.dropActive;
+
+    this.colorFill.clear();
+    if (this.settings.color) {
+      this.colorFill.rect(rect.x, rect.y, rect.width, rect.height);
+      this.colorFill.fill({ color: hexToNum(this.settings.color) });
+    }
 
     const tw = this.image.texture.width || 1;
     const th = this.image.texture.height || 1;

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -81,6 +81,7 @@ export interface SetDeckSelectionParams {
   deckName: string;
   deck: Deck;
   commanderName: string | null;
+  avatar?: string;
 }
 
 export interface StartServerGameParams {

--- a/src/platform/web.ts
+++ b/src/platform/web.ts
@@ -838,6 +838,7 @@ class WebServerApi implements IServerApi {
       deck_name: params.deckName,
       deck: params.deck,
       commander_name: params.commanderName,
+      avatar: params.avatar ?? null,
     });
   }
 

--- a/src/stores/useDeckStore.ts
+++ b/src/stores/useDeckStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { persist, devtools } from "zustand/middleware";
-import type { Deck, DeckCard, DeckFormatId } from "@/types/manabrew";
+import type { Deck, DeckCard, DeckFormatId, PlaymatSettings } from "@/types/manabrew";
 import type { ScryfallCard } from "@/types/scryfall";
 import { STORAGE_KEYS, DEFAULT_DECK_NAME } from "@/lib/constants";
 import { getFormat, canBePartners, canHaveAnyNumberOf, copyLimitFromText } from "@/lib/formats";
@@ -184,6 +184,7 @@ interface DeckState {
   updateDeckLabelColor: (label: string, color?: string) => void;
   setCoverCard: (name: string | undefined, face?: 0 | 1) => void;
   setPlaymat: (dataUrl: string | undefined) => void;
+  setPlaymatSettings: (settings: PlaymatSettings | undefined) => void;
   setStackPositions: (positions: Record<string, { x: number; y: number }>) => void;
 }
 
@@ -701,6 +702,10 @@ export const useDeckStore = create<DeckState>()(
         setPlaymat: (dataUrl) =>
           set((state) => ({
             currentDeck: { ...state.currentDeck, playmat: dataUrl },
+          })),
+        setPlaymatSettings: (settings) =>
+          set((state) => ({
+            currentDeck: { ...state.currentDeck, playmatSettings: settings },
           })),
         setStackPositions: (positions) =>
           set((state) => ({

--- a/src/stores/useDeckStore.ts
+++ b/src/stores/useDeckStore.ts
@@ -183,6 +183,7 @@ interface DeckState {
   removeDeckLabel: (label: string) => void;
   updateDeckLabelColor: (label: string, color?: string) => void;
   setCoverCard: (name: string | undefined, face?: 0 | 1) => void;
+  setPlaymat: (dataUrl: string | undefined) => void;
   setStackPositions: (positions: Record<string, { x: number; y: number }>) => void;
 }
 
@@ -696,6 +697,10 @@ export const useDeckStore = create<DeckState>()(
               coverCardName: name,
               coverCardFace: name !== undefined ? (face ?? 0) : undefined,
             },
+          })),
+        setPlaymat: (dataUrl) =>
+          set((state) => ({
+            currentDeck: { ...state.currentDeck, playmat: dataUrl },
           })),
         setStackPositions: (positions) =>
           set((state) => ({

--- a/src/stores/usePreferencesStore.ts
+++ b/src/stores/usePreferencesStore.ts
@@ -24,8 +24,6 @@ interface PreferencesState {
   setServerUsername: (username: string) => void;
   setServerPassword: (password: string) => void;
 
-  // Global player avatar shown on the player panel — a normalized WebP data URL.
-  // Broadcast to opponents at game start via PlayerDeckInfo.avatar.
   customAvatar?: string;
   setCustomAvatar: (dataUrl: string | undefined) => void;
 

--- a/src/stores/usePreferencesStore.ts
+++ b/src/stores/usePreferencesStore.ts
@@ -24,6 +24,11 @@ interface PreferencesState {
   setServerUsername: (username: string) => void;
   setServerPassword: (password: string) => void;
 
+  // Global player avatar shown on the player panel — a normalized WebP data URL.
+  // Broadcast to opponents at game start via PlayerDeckInfo.avatar.
+  customAvatar?: string;
+  setCustomAvatar: (dataUrl: string | undefined) => void;
+
   zonePanelOrder: ZonePanelItem[];
   setZonePanelOrder: (order: ZonePanelItem[]) => void;
 
@@ -69,6 +74,7 @@ const PERSISTED_PREFERENCE_KEYS = [
   "serverPort",
   "serverUsername",
   "serverPassword",
+  "customAvatar",
   "zonePanelOrder",
   "boardArrangement",
   "battlefieldAutoSort",
@@ -120,6 +126,9 @@ export const usePreferencesStore = create<PreferencesState>()(
           setServerPort: (serverPort) => set({ serverPort }),
           setServerUsername: (serverUsername) => set({ serverUsername }),
           setServerPassword: (serverPassword) => set({ serverPassword }),
+
+          customAvatar: undefined,
+          setCustomAvatar: (customAvatar) => set({ customAvatar }),
 
           zonePanelOrder: ["library", "graveyard", "exile"],
           setZonePanelOrder: (zonePanelOrder) => set({ zonePanelOrder }),

--- a/src/stores/useServerStore.ts
+++ b/src/stores/useServerStore.ts
@@ -5,6 +5,7 @@ import { getPlatform } from "@/platform";
 import { attachDraftPeer, detachDraftPeer } from "@/game/draftPeer";
 import { teardownHost as teardownDraftHost } from "@/game/draftHost";
 import { useMultiplayerDraftStore } from "@/stores/useMultiplayerDraftStore";
+import { usePreferencesStore } from "@/stores/usePreferencesStore";
 import { SERVER_ERROR_CODE, USER_FACING_ERROR_MESSAGES } from "@/types/server";
 import type {
   RoomInfo,
@@ -246,6 +247,7 @@ export const useServerStore = create<ServerState>()(
           deckName,
           deck,
           commanderName: commanderName ?? null,
+          avatar: usePreferencesStore.getState().customAvatar,
         });
       },
 

--- a/src/types/manabrew.ts
+++ b/src/types/manabrew.ts
@@ -118,6 +118,10 @@ export interface PlaymatSettings {
   borderColor?: string;
   /** Image placement mode. */
   fit?: PlaymatFit;
+  /** Cover focal point, 0..1 (like CSS object-position). Only used when `fit === "cover"`;
+   *  0.5/0.5 is centered. Drag-set in the editor to choose which part of the image shows. */
+  offsetX?: number;
+  offsetY?: number;
 }
 
 export interface Deck {

--- a/src/types/manabrew.ts
+++ b/src/types/manabrew.ts
@@ -122,6 +122,9 @@ export interface PlaymatSettings {
    *  0.5/0.5 is centered. Drag-set in the editor to choose which part of the image shows. */
   offsetX?: number;
   offsetY?: number;
+  /** Solid playmat color (hex) drawn behind the image; with no image it is the whole
+   *  playmat. Empty string means none. */
+  color?: string;
 }
 
 export interface Deck {

--- a/src/types/manabrew.ts
+++ b/src/types/manabrew.ts
@@ -102,6 +102,17 @@ export interface DeckLabel {
   color?: string;
 }
 
+export interface PlaymatSettings {
+  /** 0..1 — overall playmat opacity over the felt. */
+  opacity?: number;
+  /** 0..1 — woven-cloth texture strength. */
+  texture?: number;
+  /** Border thickness in px (0 = no border). */
+  borderWidth?: number;
+  /** Border color as a hex string. */
+  borderColor?: string;
+}
+
 export interface Deck {
   id?: string;
   name: string;
@@ -139,6 +150,9 @@ export interface Deck {
   /** Custom battlefield playmat for this deck — a normalized WebP data URL. Distinct from
    *  coverCardName (card art for thumbnails); broadcast to opponents via PlayerDeckInfo.deck. */
   playmat?: string;
+  /** How the playmat is rendered on the battlefield (opacity, cloth texture, border).
+   *  Tuned in the deck editor; broadcast alongside `playmat`. */
+  playmatSettings?: PlaymatSettings;
   /** Saved stack-view section positions (section ID → {x, y} in pixels). */
   stackPositions?: Record<string, { x: number; y: number }>;
   /** Cached token cards referenced by cards in this deck. */

--- a/src/types/manabrew.ts
+++ b/src/types/manabrew.ts
@@ -136,6 +136,9 @@ export interface Deck {
   coverCardName?: string;
   /** Which face of a double-faced cover card to use: 0 = front (default), 1 = back. */
   coverCardFace?: 0 | 1;
+  /** Custom battlefield playmat for this deck — a normalized WebP data URL. Distinct from
+   *  coverCardName (card art for thumbnails); broadcast to opponents via PlayerDeckInfo.deck. */
+  playmat?: string;
   /** Saved stack-view section positions (section ID → {x, y} in pixels). */
   stackPositions?: Record<string, { x: number; y: number }>;
   /** Cached token cards referenced by cards in this deck. */

--- a/src/types/manabrew.ts
+++ b/src/types/manabrew.ts
@@ -102,6 +102,11 @@ export interface DeckLabel {
   color?: string;
 }
 
+/** How the playmat image is scaled into the battlefield region. `cover` fills and
+ *  crops overflow, `fit` shows the whole image with margins, `stretch` fills exactly
+ *  by distorting the aspect ratio. */
+export type PlaymatFit = "cover" | "fit" | "stretch";
+
 export interface PlaymatSettings {
   /** 0..1 — overall playmat opacity over the felt. */
   opacity?: number;
@@ -111,6 +116,8 @@ export interface PlaymatSettings {
   borderWidth?: number;
   /** Border color as a hex string. */
   borderColor?: string;
+  /** Image placement mode. */
+  fit?: PlaymatFit;
 }
 
 export interface Deck {

--- a/src/types/manabrew.ts
+++ b/src/types/manabrew.ts
@@ -102,28 +102,16 @@ export interface DeckLabel {
   color?: string;
 }
 
-/** How the playmat image is scaled into the battlefield region. `cover` fills and
- *  crops overflow, `fit` shows the whole image with margins, `stretch` fills exactly
- *  by distorting the aspect ratio. */
 export type PlaymatFit = "cover" | "fit" | "stretch";
 
 export interface PlaymatSettings {
-  /** 0..1 — overall playmat opacity over the felt. */
   opacity?: number;
-  /** 0..1 — woven-cloth texture strength. */
   texture?: number;
-  /** Border thickness in px (0 = no border). */
   borderWidth?: number;
-  /** Border color as a hex string. */
   borderColor?: string;
-  /** Image placement mode. */
   fit?: PlaymatFit;
-  /** Cover focal point, 0..1 (like CSS object-position). Only used when `fit === "cover"`;
-   *  0.5/0.5 is centered. Drag-set in the editor to choose which part of the image shows. */
   offsetX?: number;
   offsetY?: number;
-  /** Solid playmat color (hex) drawn behind the image; with no image it is the whole
-   *  playmat. Empty string means none. */
   color?: string;
 }
 
@@ -161,11 +149,7 @@ export interface Deck {
   coverCardName?: string;
   /** Which face of a double-faced cover card to use: 0 = front (default), 1 = back. */
   coverCardFace?: 0 | 1;
-  /** Custom battlefield playmat for this deck — a normalized WebP data URL. Distinct from
-   *  coverCardName (card art for thumbnails); broadcast to opponents via PlayerDeckInfo.deck. */
   playmat?: string;
-  /** How the playmat is rendered on the battlefield (opacity, cloth texture, border).
-   *  Tuned in the deck editor; broadcast alongside `playmat`. */
   playmatSettings?: PlaymatSettings;
   /** Saved stack-view section positions (section ID → {x, y} in pixels). */
   stackPositions?: Record<string, { x: number; y: number }>;

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -78,6 +78,7 @@ export interface PlayerDeckInfo {
   deck_name: string;
   deck: Deck;
   commander_name?: string;
+  avatar?: string;
 }
 
 export interface PlayerInfo {

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -78,6 +78,8 @@ export interface PlayerDeckInfo {
   deck_name: string;
   deck: Deck;
   commander_name?: string;
+  /** Player's global avatar (normalized WebP data URL), broadcast to everyone at
+   *  game start. The deck's own playmat cosmetic rides along inside `deck`. */
   avatar?: string;
 }
 

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -78,8 +78,6 @@ export interface PlayerDeckInfo {
   deck_name: string;
   deck: Deck;
   commander_name?: string;
-  /** Player's global avatar (normalized WebP data URL), broadcast to everyone at
-   *  game start. The deck's own playmat cosmetic rides along inside `deck`. */
   avatar?: string;
 }
 

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -1,5 +1,7 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
+import { toast } from "sonner";
 import { usePreferencesStore, type ZonePanelItem } from "@/stores/usePreferencesStore";
+import { normalizeToWebp, ImageTooLargeError, AVATAR_IMAGE_BUDGET } from "@/lib/imageEncode";
 import { BattlefieldStylePreview } from "@/components/game/BattlefieldStylePreview";
 import { isFeatureEnabled } from "@/featureFlags";
 import { THEME_PRESETS, type ThemeColors } from "@/themes";
@@ -362,6 +364,20 @@ export default function Settings() {
   const DEFAULT_GAME_THEME_COLOR_MAP = getDefaultGameThemeColorMap();
 
   const zoneOrder = prefs.zonePanelOrder;
+  const avatarInputRef = useRef<HTMLInputElement>(null);
+
+  async function onAvatarPick(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+    try {
+      prefs.setCustomAvatar(await normalizeToWebp(file, AVATAR_IMAGE_BUDGET));
+    } catch (err) {
+      toast.error(
+        err instanceof ImageTooLargeError ? err.message : "Couldn't use that image as an avatar",
+      );
+    }
+  }
 
   function setZoneSlot(index: number, value: ZonePanelItem) {
     const next = [...zoneOrder] as ZonePanelItem[];
@@ -568,6 +584,51 @@ export default function Settings() {
           <h2 className="text-lg font-semibold">Preferences</h2>
 
           <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <div className="rounded-lg border bg-card/40 p-4 space-y-2">
+              <Label>Player Avatar</Label>
+              <div className="flex items-center gap-4">
+                <div className="flex size-16 shrink-0 items-center justify-center overflow-hidden rounded-full border bg-muted">
+                  {prefs.customAvatar ? (
+                    <img
+                      src={prefs.customAvatar}
+                      alt="Your avatar"
+                      className="size-full object-cover"
+                    />
+                  ) : (
+                    <span className="text-xs text-muted-foreground">None</span>
+                  )}
+                </div>
+                <div className="flex flex-col gap-2">
+                  <input
+                    ref={avatarInputRef}
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={onAvatarPick}
+                  />
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => avatarInputRef.current?.click()}
+                  >
+                    {prefs.customAvatar ? "Replace" : "Upload"}
+                  </Button>
+                  {prefs.customAvatar && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => prefs.setCustomAvatar(undefined)}
+                    >
+                      Remove
+                    </Button>
+                  )}
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Shown on your player panel and to opponents when a game starts.
+              </p>
+            </div>
+
             <div className="rounded-lg border bg-card/40 p-4 space-y-2">
               <Label>Battlefield Zone Column Order</Label>
               <div className="grid grid-cols-3 gap-2">


### PR DESCRIPTION
## Summary

- Adds **custom playmats** (per-deck battlefield background, set in the deck editor) and **custom avatars** (global player portrait, set in Preferences).
- Both are normalized to bounded **WebP data URLs** client-side, then broadcast to every player at game start so each client renders everyone's cosmetics.
- Playmat travels on the `Deck` (already inside `GameStarted.player_decks[].deck`); avatar is a new `PlayerDeckInfo`/`SetDeckSelection` field. Server sanitizes both to bounded WebP before forwarding.

## Why

Players want to personalize their side of the table. Per-deck playmats let a deck carry its own theme; a global avatar identifies the player across games. Broadcasting on game start means cosmetics are visible to opponents without any extra asset hosting.

## Test plan

- `yarn tsc` clean; `yarn eslint` clean on all touched TS files.
- `cargo check`/`build` green for `manabrew-protocol`, `manabrew-server`, `manabot`, `self-hosted-node`, and the Tauri (`manabrew`) crate; `cargo fmt --check` clean. No new clippy warnings introduced.
- Image pipeline: any uploaded format is re-encoded to WebP via `normalizeToWebp` with a quality ladder + size caps (avatar 512px/256KB, playmat 1024px/512KB); oversized images are rejected with a toast.
- Server-side guard (`lobby::sanitize_cosmetic`) drops any cosmetic that isn't a `data:image/webp;base64,` under the length cap, for both `avatar` and `deck.playmat`.
- ⚠️ Not yet exercised in a live multiplayer game — compile/typecheck only. Reconnect/spectator replay carries cosmetics automatically since they live in `GameStarted.player_decks`, but that path wasn't separately verified.

## Demo

_No screenshots yet — not run against a live game. Happy to add before/after captures._

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
