### PR TITLE
fix(build): build website docker stage with yarn

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -85,14 +85,14 @@ FROM node:20-slim AS website
 # The site imports assets and theme data via relative paths that escape
 # website/ (../images, ../public, ../src) — keep the same directory layout here.
 WORKDIR /repo/website
-COPY website/package.json website/package-lock.json ./
-RUN npm ci
+COPY website/package.json website/yarn.lock ./
+RUN corepack enable && yarn install --frozen-lockfile
 COPY images/ /repo/images/
 COPY public/manabrew_brewery_1.png /repo/public/manabrew_brewery_1.png
 COPY src/themes/ /repo/src/themes/
 COPY src/assets/manaBrew.png /repo/src/assets/manaBrew.png
 COPY website/ ./
-RUN npm run build
+RUN yarn build
 
 # --- Runtime: Caddy serves the built dist directly, reverse-proxies the
 # relay + parity hostnames, and terminates Let's Encrypt TLS for all

--- a/deploy.sh
+++ b/deploy.sh
@@ -127,7 +127,7 @@ while IFS= read -r file; do
             CARDDATA_CHANGED=true ;;
     esac
     case "$file" in
-        src/*|public/*|scripts/build-wasm.mjs|scripts/ensure-wasm.mjs|package.json|package-lock.json|vite.config.ts|tsconfig*.json|index.html|website/*)
+        src/*|public/*|scripts/build-wasm.mjs|scripts/ensure-wasm.mjs|package.json|yarn.lock|vite.config.ts|tsconfig*.json|index.html|website/*)
             WEB_CHANGED=true ;;
         manabrew-rs/crates/wasm/*)
             WEB_CHANGED=true ;;


### PR DESCRIPTION
## Summary

PR #265 migrated the website from npm to yarn (removed `website/package-lock.json`, added `website/yarn.lock`), but `Dockerfile.web`'s `website` stage still ran `COPY website/package-lock.json` + `npm ci`. The prod wasm deploy that ran right after the #265 merge failed with:

```
ERROR: failed to calculate checksum of ref ...: "/website/package-lock.json": not found
```

This switches the `website` stage to yarn, mirroring the existing `builder` stage (`corepack enable && yarn install --frozen-lockfile`, then `yarn build`). Also repoints `deploy.sh`'s `WEB_CHANGED` glob at `yarn.lock` (the root `package-lock.json` it referenced no longer exists either).

## Why

The deploy is broken on `main` — every wasm deploy fails at the website Docker stage until the Dockerfile matches the lockfile that #265 shipped.

## Test plan

- Validated the website stage `COPY` sources now exist on `main` (`website/yarn.lock` present, `website/package-lock.json` gone).
- No Docker available locally to run the full multi-stage build; the change is a 1:1 mirror of the already-working `builder` stage's yarn invocation.

## Build artifacts

- [ ] Build macOS .dmg
- [ ] Build Windows .exe