### PR TITLE
feat(ui): show app version and update check in about

### DIFF
--- a/src/components/AboutContent.tsx
+++ b/src/components/AboutContent.tsx
@@ -2,6 +2,7 @@ import { BookOpen, Globe } from "lucide-react";
 import { OnboardingGuide } from "@/components/OnboardingGuide";
 import { DiscordCallout } from "@/components/DiscordCallout";
 import { LinkCallout } from "@/components/LinkCallout";
+import { VersionInfo } from "@/components/VersionInfo";
 import { DOCS_URL, WEBSITE_URL } from "@/lib/constants";
 
 export function AboutContent() {
@@ -23,6 +24,7 @@ export function AboutContent() {
           description="Guides, formats, and self-hosting at docs.manabrew.app."
         />
       </div>
+      <VersionInfo />
     </div>
   );
 }

--- a/src/components/AboutContent.tsx
+++ b/src/components/AboutContent.tsx
@@ -2,7 +2,6 @@ import { BookOpen, Globe } from "lucide-react";
 import { OnboardingGuide } from "@/components/OnboardingGuide";
 import { DiscordCallout } from "@/components/DiscordCallout";
 import { LinkCallout } from "@/components/LinkCallout";
-import { VersionInfo } from "@/components/VersionInfo";
 import { DOCS_URL, WEBSITE_URL } from "@/lib/constants";
 
 export function AboutContent() {
@@ -24,7 +23,6 @@ export function AboutContent() {
           description="Guides, formats, and self-hosting at docs.manabrew.app."
         />
       </div>
-      <VersionInfo />
     </div>
   );
 }

--- a/src/components/VersionInfo.tsx
+++ b/src/components/VersionInfo.tsx
@@ -1,0 +1,68 @@
+import { CircleCheck, Download, Loader2, RefreshCw, Tag } from "lucide-react";
+import { useLatestRelease } from "@/hooks/useLatestRelease";
+import { APP_VERSION, GITHUB_RELEASES_URL } from "@/lib/constants";
+
+export function VersionInfo() {
+  const { status, latest, check } = useLatestRelease();
+
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-wrap items-center justify-between gap-3 rounded-lg border border-border bg-card/40 px-4 py-3">
+      <div className="flex items-center gap-3">
+        <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-primary/15 text-primary">
+          <Tag className="size-4" />
+        </span>
+        <div className="leading-tight">
+          <span className="block text-sm font-semibold text-foreground">Manabrew</span>
+          <span className="block text-xs text-muted-foreground">Version {APP_VERSION}</span>
+        </div>
+      </div>
+
+      {status === "checking" && (
+        <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <Loader2 className="size-3.5 animate-spin" />
+          Checking for updates…
+        </span>
+      )}
+
+      {status === "current" && (
+        <span className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+          <CircleCheck className="size-4 text-primary" />
+          Up to date
+        </span>
+      )}
+
+      {status === "outdated" && latest && (
+        <a
+          href={latest.htmlUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="flex items-center gap-1.5 rounded-md border border-primary/40 bg-primary/15 px-3 py-1.5 text-xs font-semibold text-primary transition-colors hover:border-primary/60 hover:bg-primary/25"
+        >
+          <Download className="size-3.5" />
+          Update available — {latest.version}
+        </a>
+      )}
+
+      {status === "error" && (
+        <span className="flex items-center gap-3 text-xs text-muted-foreground">
+          <a
+            href={GITHUB_RELEASES_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="text-primary hover:underline"
+          >
+            Releases on GitHub
+          </a>
+          <button
+            type="button"
+            onClick={check}
+            className="flex items-center gap-1 text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <RefreshCw className="size-3.5" />
+            Retry
+          </button>
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useLatestRelease.ts
+++ b/src/hooks/useLatestRelease.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useState } from "react";
+import { APP_VERSION, GITHUB_LATEST_RELEASE_API } from "@/lib/constants";
+import { isNewerVersion, normalizeVersion } from "@/lib/version";
+import { platformFetch } from "@/lib/platformFetch";
+
+interface GithubRelease {
+  tag_name: string;
+  name: string | null;
+  html_url: string;
+  prerelease: boolean;
+  draft: boolean;
+}
+
+export interface LatestRelease {
+  version: string;
+  htmlUrl: string;
+  isNewer: boolean;
+}
+
+export type ReleaseStatus = "checking" | "current" | "outdated" | "error";
+
+export interface UseLatestReleaseResult {
+  status: ReleaseStatus;
+  latest: LatestRelease | null;
+  check: () => void;
+}
+
+function fetchLatest(): Promise<LatestRelease> {
+  return platformFetch(GITHUB_LATEST_RELEASE_API, {
+    headers: { Accept: "application/vnd.github+json" },
+  }).then(async (res) => {
+    if (!res.ok) throw new Error(`GitHub responded ${res.status}`);
+    const data = (await res.json()) as GithubRelease;
+    const version = normalizeVersion(data.tag_name);
+    return { version, htmlUrl: data.html_url, isNewer: isNewerVersion(version, APP_VERSION) };
+  });
+}
+
+export function useLatestRelease(): UseLatestReleaseResult {
+  const [status, setStatus] = useState<ReleaseStatus>("checking");
+  const [latest, setLatest] = useState<LatestRelease | null>(null);
+  const [nonce, setNonce] = useState(0);
+
+  const check = useCallback(() => {
+    setStatus("checking");
+    setLatest(null);
+    setNonce((n) => n + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchLatest()
+      .then((release) => {
+        if (cancelled) return;
+        setLatest(release);
+        setStatus(release.isNewer ? "outdated" : "current");
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setLatest(null);
+        setStatus("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [nonce]);
+
+  return { status, latest, check };
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -12,9 +12,16 @@ export const ROUTES = {
 // ─── External Links ──────────────────────────────────────────────────────────
 
 export const GITHUB_REPO_URL = "https://github.com/witchesofthehill/manabrew";
+export const GITHUB_RELEASES_URL = `${GITHUB_REPO_URL}/releases`;
+export const GITHUB_LATEST_RELEASE_API =
+  "https://api.github.com/repos/witchesofthehill/manabrew/releases/latest";
 export const DISCORD_INVITE_URL = "https://discord.gg/NqrKpbhtcd";
 export const WEBSITE_URL = "https://manabrew.app";
 export const DOCS_URL = "https://docs.manabrew.app";
+
+// ─── App Version ─────────────────────────────────────────────────────────────
+
+export const APP_VERSION = __APP_VERSION__;
 
 // ─── Storage Keys ────────────────────────────────────────────────────────────
 

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,25 @@
+export function normalizeVersion(raw: string): string {
+  return raw.trim().replace(/^v/i, "");
+}
+
+export function compareVersions(a: string, b: string): number {
+  const pa = normalizeVersion(a).split(/[.+-]/);
+  const pb = normalizeVersion(b).split(/[.+-]/);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const na = Number.parseInt(pa[i] ?? "0", 10);
+    const nb = Number.parseInt(pb[i] ?? "0", 10);
+    if (Number.isNaN(na) || Number.isNaN(nb)) {
+      const sa = pa[i] ?? "";
+      const sb = pb[i] ?? "";
+      if (sa === sb) continue;
+      return sa < sb ? -1 : 1;
+    }
+    if (na !== nb) return na < nb ? -1 : 1;
+  }
+  return 0;
+}
+
+export function isNewerVersion(latest: string, current: string): boolean {
+  return compareVersions(latest, current) > 0;
+}

--- a/src/views/About.tsx
+++ b/src/views/About.tsx
@@ -1,5 +1,6 @@
 import { AboutContent } from "@/components/AboutContent";
 import { BreweryBackdrop } from "@/components/BreweryBackdrop";
+import { VersionInfo } from "@/components/VersionInfo";
 
 export default function About() {
   return (
@@ -14,6 +15,7 @@ export default function About() {
             </p>
           </header>
           <AboutContent />
+          <VersionInfo />
         </div>
       </div>
     </div>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -13,6 +13,8 @@ interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
 
+declare const __APP_VERSION__: string;
+
 // `unplugin-icons` with `compiler: 'raw'` exports the plain SVG string
 // as the default import for any `~icons/<set>/<name>` module. Declare
 // this here instead of pulling in `unplugin-icons/types/react`, which

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import { readFileSync } from "fs";
 import { defineConfig } from "vite";
 import type { Plugin } from "vite";
 import react from "@vitejs/plugin-react";
@@ -6,6 +7,16 @@ import tailwindcss from "@tailwindcss/vite";
 import Icons from "unplugin-icons/vite";
 
 const host = process.env.TAURI_DEV_HOST;
+
+// release-please's authoritative version. It bumps this manifest plus the
+// extra-files (package.json, src-tauri/tauri.conf.json, Cargo.toml) in the
+// same release commit, then tags vX.Y.Z — so the manifest always matches the
+// shipped release tag, even if package.json is hand-edited out of sync.
+const appVersion = (
+  JSON.parse(readFileSync(path.resolve(__dirname, ".release-please-manifest.json"), "utf-8")) as {
+    ".": string;
+  }
+)["."];
 
 const COEP = process.env.TAURI_ENV_PLATFORM ? "require-corp" : "credentialless";
 
@@ -37,6 +48,9 @@ export default defineConfig({
     },
   },
   clearScreen: false,
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+  },
   server: {
     port: 1420,
     strictPort: true,


### PR DESCRIPTION
## Summary

- Add a standalone `VersionInfo` component to the About screen that displays the running app version.
- Check GitHub releases for a newer build and surface an "Update available" link (or "Up to date").
- Inject the version at build time from `.release-please-manifest.json` so it always matches the shipped `vX.Y.Z` release tag.

## Why

The app had no visible version number, and no way to tell users a newer release exists. Since releases are published on GitHub via release-please, we can read the manifest version for display and compare it against the latest GitHub release.

Version sourcing is deliberately wired to release-please's source of truth (`.release-please-manifest.json`), not `package.json` — release-please treats `package.json`/`tauri.conf.json`/`Cargo.toml` as outputs it overwrites, and `package.json` had already drifted (`0.4.2`) from the actual last release (`0.4.0`). Reading the manifest keeps the displayed version equal to the shipped tag and immune to hand-edits. Tag comparison strips the `v` prefix to match `include-v-in-tag: true`.

## Test plan

- `npx prettier --check`, `npx eslint`, `npx tsc -b` — clean on all touched files (pre-existing `@/protocol/*` and `Game.tsx` errors on the branch are unrelated).
- Verified live: `GET /repos/witchesofthehill/manabrew/releases/latest` returns `v0.4.0` (non-draft, non-prerelease) → normalized `0.4.0` == `APP_VERSION` → renders "Up to date". A future `v0.5.0` release would render "Update available — 0.5.0".
- Confirmed `.release-please-manifest.json` resolves to `0.4.0` at build time.

## Demo

_About screen now shows a "Manabrew · Version 0.4.0" row with update status. (Add screenshot.)_

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main