### PR TITLE
feat(ui): add custom default playmat in settings

### DIFF
--- a/src/components/editor/DeckHero.tsx
+++ b/src/components/editor/DeckHero.tsx
@@ -23,6 +23,8 @@ export function DeckHero({ onBack }: { onBack?: () => void }) {
   const isReadOnly = useDeckStore((s) => s.isReadOnly);
   const setDeckName = useDeckStore((s) => s.setDeckName);
   const setDeckFormat = useDeckStore((s) => s.setDeckFormat);
+  const setPlaymat = useDeckStore((s) => s.setPlaymat);
+  const setPlaymatSettings = useDeckStore((s) => s.setPlaymatSettings);
 
   const [editingName, setEditingName] = useState(false);
   const [nameInput, setNameInput] = useState(currentDeck.name);
@@ -101,7 +103,15 @@ export function DeckHero({ onBack }: { onBack?: () => void }) {
         </div>
       )}
 
-      {editorOpen && <PlaymatEditorModal onClose={() => setEditorOpen(false)} />}
+      {editorOpen && (
+        <PlaymatEditorModal
+          onClose={() => setEditorOpen(false)}
+          playmat={playmat}
+          storedSettings={currentDeck.playmatSettings}
+          setPlaymat={setPlaymat}
+          setPlaymatSettings={setPlaymatSettings}
+        />
+      )}
 
       <div className={cn("relative flex flex-col gap-1.5 px-5 pb-4", onBack ? "pt-16" : "pt-10")}>
         <div className="flex flex-wrap items-center gap-1.5">

--- a/src/components/editor/PlaymatEditorModal.tsx
+++ b/src/components/editor/PlaymatEditorModal.tsx
@@ -4,7 +4,6 @@ import { Modal } from "@/components/game/modals/Modal";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { ImagePlus, Trash2 } from "lucide-react";
-import { useDeckStore } from "@/stores/useDeckStore";
 import {
   DEFAULT_PLAYMAT_SETTINGS,
   clampBorderColor,
@@ -17,12 +16,23 @@ import type { PlaymatSettings } from "@/protocol/game";
 
 const HEX_RE = /^#[0-9a-fA-F]{6}$/;
 
-export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
-  const playmat = useDeckStore((s) => s.currentDeck.playmat);
-  const storedSettings = useDeckStore((s) => s.currentDeck.playmatSettings);
-  const setPlaymat = useDeckStore((s) => s.setPlaymat);
-  const setPlaymatSettings = useDeckStore((s) => s.setPlaymatSettings);
+interface PlaymatEditorModalProps {
+  onClose: () => void;
+  title?: string;
+  playmat: string | undefined;
+  storedSettings: PlaymatSettings | undefined;
+  setPlaymat: (dataUrl: string | undefined) => void;
+  setPlaymatSettings: (settings: PlaymatSettings | undefined) => void;
+}
 
+export function PlaymatEditorModal({
+  onClose,
+  title = "Customize Playmat",
+  playmat,
+  storedSettings,
+  setPlaymat,
+  setPlaymatSettings,
+}: PlaymatEditorModalProps) {
   const [settings, setSettings] = useState<Required<PlaymatSettings>>({
     ...DEFAULT_PLAYMAT_SETTINGS,
     ...(storedSettings ?? {}),
@@ -70,7 +80,7 @@ export function PlaymatEditorModal({ onClose }: { onClose: () => void }) {
 
   return (
     <Modal onClose={onClose} maxWidth="max-w-2xl">
-      <Modal.Header>Customize Playmat</Modal.Header>
+      <Modal.Header>{title}</Modal.Header>
       <Modal.Body>
         <div className="space-y-4">
           <div className="flex flex-col items-center gap-1">

--- a/src/components/game/GameBoard.tsx
+++ b/src/components/game/GameBoard.tsx
@@ -545,6 +545,8 @@ export function GameBoard({
       hostileTargeting,
     });
     const myDeck = gameDecks[me.id];
+    // Local/AI/hotseat decks skip setDeckSelection, so the default playmat is
+    // resolved here too; multiplayer decks already carry it from the relay.
     const myDeckHasPlaymat = !!myDeck?.playmat || !!myDeck?.playmatSettings?.color;
     return [
       {

--- a/src/components/game/GameBoard.tsx
+++ b/src/components/game/GameBoard.tsx
@@ -522,6 +522,8 @@ export function GameBoard({
 
   const gameDecks = useGameStore((s) => s.gameDecks);
   const myAvatar = usePreferencesStore((s) => s.customAvatar);
+  const defaultPlaymat = usePreferencesStore((s) => s.defaultPlaymat);
+  const defaultPlaymatSettings = usePreferencesStore((s) => s.defaultPlaymatSettings);
   const playerDecks = useServerStore((s) => s.playerDecks);
 
   const avatarByPlayerId = useMemo(() => {
@@ -542,13 +544,15 @@ export function GameBoard({
       selectableCardIds: selectableBattlefieldCardIds,
       hostileTargeting,
     });
+    const myDeck = gameDecks[me.id];
+    const myDeckHasPlaymat = !!myDeck?.playmat || !!myDeck?.playmatSettings?.color;
     return [
       {
         playerId: me.id,
         isLocal: true,
         state: pixiBattlefield,
-        playmat: gameDecks[me.id]?.playmat,
-        playmatSettings: gameDecks[me.id]?.playmatSettings,
+        playmat: myDeckHasPlaymat ? myDeck?.playmat : defaultPlaymat,
+        playmatSettings: myDeckHasPlaymat ? myDeck?.playmatSettings : defaultPlaymatSettings,
       },
       ...opponents.map((op) => ({
         playerId: op.id,
@@ -569,6 +573,8 @@ export function GameBoard({
     selectableBattlefieldCardIds,
     hostileTargeting,
     gameDecks,
+    defaultPlaymat,
+    defaultPlaymatSettings,
   ]);
 
   const selfPanelLeftPx = (unifiedLayout?.self?.x ?? 0) + 8;

--- a/src/stores/usePreferencesStore.ts
+++ b/src/stores/usePreferencesStore.ts
@@ -3,6 +3,7 @@ import { persist, devtools } from "zustand/middleware";
 import { getServerConnectionDefaults } from "@/config/webRuntimeConfig";
 import { STORAGE_KEYS } from "@/lib/constants";
 import type { BoardArrangement } from "@/pixi/board/boardLayout";
+import type { PlaymatSettings } from "@/protocol/game";
 
 export type ZonePanelItem = "library" | "graveyard" | "exile";
 export type CardPreviewMode = "hover" | "shift" | "alt" | "ctrl";
@@ -26,6 +27,11 @@ interface PreferencesState {
 
   customAvatar?: string;
   setCustomAvatar: (dataUrl: string | undefined) => void;
+
+  defaultPlaymat?: string;
+  defaultPlaymatSettings?: PlaymatSettings;
+  setDefaultPlaymat: (dataUrl: string | undefined) => void;
+  setDefaultPlaymatSettings: (settings: PlaymatSettings | undefined) => void;
 
   zonePanelOrder: ZonePanelItem[];
   setZonePanelOrder: (order: ZonePanelItem[]) => void;
@@ -73,6 +79,8 @@ const PERSISTED_PREFERENCE_KEYS = [
   "serverUsername",
   "serverPassword",
   "customAvatar",
+  "defaultPlaymat",
+  "defaultPlaymatSettings",
   "zonePanelOrder",
   "boardArrangement",
   "battlefieldAutoSort",
@@ -127,6 +135,11 @@ export const usePreferencesStore = create<PreferencesState>()(
 
           customAvatar: undefined,
           setCustomAvatar: (customAvatar) => set({ customAvatar }),
+
+          defaultPlaymat: undefined,
+          defaultPlaymatSettings: undefined,
+          setDefaultPlaymat: (defaultPlaymat) => set({ defaultPlaymat }),
+          setDefaultPlaymatSettings: (defaultPlaymatSettings) => set({ defaultPlaymatSettings }),
 
           zonePanelOrder: ["library", "graveyard", "exile"],
           setZonePanelOrder: (zonePanelOrder) => set({ zonePanelOrder }),

--- a/src/stores/useServerStore.ts
+++ b/src/stores/useServerStore.ts
@@ -259,11 +259,19 @@ export const useServerStore = create<ServerState>()(
       async setDeckSelection(deckName, deck, commanderName) {
         const platform = getPlatform();
         if (!platform.server) return;
+        const prefs = usePreferencesStore.getState();
+        const deckHasPlaymat = !!deck.playmat || !!deck.playmatSettings?.color;
         await platform.server.setDeckSelection({
           deckName,
-          deck,
+          deck: deckHasPlaymat
+            ? deck
+            : {
+                ...deck,
+                playmat: prefs.defaultPlaymat,
+                playmatSettings: prefs.defaultPlaymatSettings,
+              },
           commanderName: commanderName ?? null,
-          avatar: usePreferencesStore.getState().customAvatar,
+          avatar: prefs.customAvatar,
         });
       },
 

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -3,6 +3,7 @@ import { toast } from "sonner";
 import { usePreferencesStore, type ZonePanelItem } from "@/stores/usePreferencesStore";
 import { normalizeToWebp, ImageTooLargeError, AVATAR_IMAGE_BUDGET } from "@/lib/imageEncode";
 import { BattlefieldStylePreview } from "@/components/game/BattlefieldStylePreview";
+import { PlaymatEditorModal } from "@/components/editor/PlaymatEditorModal";
 import { isFeatureEnabled } from "@/featureFlags";
 import { THEME_PRESETS, type ThemeColors } from "@/themes";
 import { useServerStore } from "@/stores/useServerStore";
@@ -365,6 +366,8 @@ export default function Settings() {
 
   const zoneOrder = prefs.zonePanelOrder;
   const avatarInputRef = useRef<HTMLInputElement>(null);
+  const [playmatEditorOpen, setPlaymatEditorOpen] = useState(false);
+  const hasDefaultPlaymat = !!prefs.defaultPlaymat || !!prefs.defaultPlaymatSettings?.color;
 
   async function onAvatarPick(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
@@ -626,6 +629,49 @@ export default function Settings() {
               </div>
               <p className="text-xs text-muted-foreground">
                 Shown on your player panel and to opponents when a game starts.
+              </p>
+            </div>
+
+            <div className="rounded-lg border bg-card/40 p-4 space-y-2">
+              <Label>Default Playmat</Label>
+              <div className="flex items-center gap-4">
+                <div className="flex h-16 w-24 shrink-0 items-center justify-center overflow-hidden rounded-md border bg-muted">
+                  {prefs.defaultPlaymat ? (
+                    <img
+                      src={prefs.defaultPlaymat}
+                      alt="Your default playmat"
+                      className="size-full object-cover"
+                    />
+                  ) : prefs.defaultPlaymatSettings?.color ? (
+                    <span
+                      className="size-full"
+                      style={{ backgroundColor: prefs.defaultPlaymatSettings.color }}
+                      aria-hidden
+                    />
+                  ) : (
+                    <span className="text-xs text-muted-foreground">None</span>
+                  )}
+                </div>
+                <div className="flex flex-col gap-2">
+                  <Button variant="outline" size="sm" onClick={() => setPlaymatEditorOpen(true)}>
+                    {hasDefaultPlaymat ? "Customize" : "Set playmat"}
+                  </Button>
+                  {hasDefaultPlaymat && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => {
+                        prefs.setDefaultPlaymat(undefined);
+                        prefs.setDefaultPlaymatSettings(undefined);
+                      }}
+                    >
+                      Remove
+                    </Button>
+                  )}
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Used in games when the deck you&apos;re playing has no custom playmat of its own.
               </p>
             </div>
 
@@ -904,6 +950,16 @@ export default function Settings() {
             </div>
           </div>
           {/* end preferences grid */}
+          {playmatEditorOpen && (
+            <PlaymatEditorModal
+              onClose={() => setPlaymatEditorOpen(false)}
+              title="Default Playmat"
+              playmat={prefs.defaultPlaymat}
+              storedSettings={prefs.defaultPlaymatSettings}
+              setPlaymat={prefs.setDefaultPlaymat}
+              setPlaymatSettings={prefs.setDefaultPlaymatSettings}
+            />
+          )}
         </section>
       )}
 


### PR DESCRIPTION
## Summary

- Add a **Default Playmat** preference in Settings → Preferences, with the same rich editor used for per-deck playmats (upload, drag-reposition, opacity, cloth texture, border, fit, background color).
- In a game, the local player's playmat resolves to the deck's custom playmat when set, otherwise this default.
- Refactor `PlaymatEditorModal` to be controlled (value + setters via props) so it can be driven by either the deck store (deck editor) or the preferences store (Settings).

## Why

Yesterday's release (#263) added per-deck custom playmats. Players asked for a single default playmat that applies whenever the deck they're playing doesn't define its own — without having to set one on every deck.

The default is a **local preference** (stored in `usePreferencesStore`, persisted), mirroring how `customAvatar` works: it applies to your own board view and is not part of shared deck data. Per-deck playmats still take precedence; the default only fills in when a deck has neither a playmat image nor a background color.

## Test plan

- `npx prettier --check`, `npx eslint`, `npx tsc -b` — clean on all touched files (pre-existing `@/protocol/*` / `Game.tsx` errors are unrelated and not present on `main`).
- Manual: Settings → Preferences → Default Playmat → Set playmat opens the editor; upload/customize/remove all persist. Starting a game with a deck that has no playmat shows the default; a deck with its own playmat still wins.
- No protocol change — reuses the existing `PlaymatSettings` DTO, so no regeneration needed.

## Demo

_Settings now has a "Default Playmat" card next to Player Avatar; opens the shared playmat editor. (Add screenshot.)_

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main