### PR TITLE
fix(build): copy release-please manifest into web build context

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -39,7 +39,8 @@ COPY tree-sitter-forge-card-script/ ./tree-sitter-forge-card-script/
 COPY scripts/ ./scripts/
 COPY src/ ./src/
 COPY public/ ./public/
-COPY index.html tsconfig*.json vite.config.ts ./
+# .release-please-manifest.json is read by vite.config.ts to stamp the app version.
+COPY index.html tsconfig*.json vite.config.ts .release-please-manifest.json ./
 # These four dirs feed the rkyv cardset archive build — keep in sync with the
 # source list in `scripts/build-wasm.mjs`. Omitting `editions`/`blockdata` is
 # silent: the archive builder emits an empty editions vec for a missing dir, so


### PR DESCRIPTION
## Summary

- Add `.release-please-manifest.json` to the curated `COPY` list in `Dockerfile.web`.

## Why

PR #268 made `vite.config.ts` read `.release-please-manifest.json` at config-load time to stamp the app version. The Tauri build and CI run from a full repo checkout so the file is present, but `Dockerfile.web` copies only a curated set of files into the build context and didn't include the manifest. As a result `yarn build:web` → `vite build` failed with `ENOENT` on the missing manifest, breaking the production web deploy.

Kept it fail-fast (no silent fallback in `vite.config.ts`): the manifest is a real build input and should be present, so the fix is to put it in the context rather than mask a missing/wrong version.

## Test plan

- Verified `Dockerfile.web` line 42 previously copied `index.html tsconfig*.json vite.config.ts` but not the manifest, matching the `ENOENT` point in the deploy log (build dies at the `yarn build:web` step that runs `vite build`).
- Confirmed `.release-please-manifest.json` is git-tracked and not excluded by `.dockerignore` (no dotfile/JSON glob there), so the `COPY` resolves.

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main