### PR TITLE
ci: PR comment commands to trigger builds and reruns

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -24,28 +24,25 @@ permissions:
   issues: write
   contents: read
 
+concurrency:
+  group: pr-commands-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
   command:
     if: >-
       github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/') &&
+      (startsWith(github.event.comment.body, '/build') || startsWith(github.event.comment.body, '/rerun')) &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     steps:
-      - name: Acknowledge the comment
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api -X POST \
-            "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
-            -f content=eyes >/dev/null
-
       - name: Parse command
         id: parse
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          cmd=$(printf '%s' "$COMMENT_BODY" | head -n1 | tr '[:upper:]' '[:lower:]' | xargs)
+          cmd=$(printf '%s' "$COMMENT_BODY" | head -n1 | tr '[:upper:]' '[:lower:]' \
+                  | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
           action=""
           workflow=""
           inputs=""
@@ -73,6 +70,15 @@ jobs:
             echo "inputs=$inputs"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Acknowledge the comment
+        if: steps.parse.outputs.match == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X POST \
+            "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content=eyes >/dev/null
+
       - name: Resolve PR branch
         id: pr
         if: steps.parse.outputs.match == 'true'
@@ -84,12 +90,12 @@ jobs:
           if [ "$(jq -r .isCrossRepository <<<"$data")" = "true" ]; then
             gh pr comment "${{ github.event.issue.number }}" --repo "${{ github.repository }}" \
               --body "⚠️ On-demand CI commands are not available for fork PRs."
-            exit 1
+            exit 0
           fi
           echo "branch=$(jq -r .headRefName <<<"$data")" >> "$GITHUB_OUTPUT"
 
       - name: Run command
-        if: steps.parse.outputs.match == 'true'
+        if: steps.parse.outputs.match == 'true' && steps.pr.outputs.branch != ''
         env:
           # A fine-grained PAT (actions:write) makes a workflow_dispatch reliably
           # spawn a run; the default GITHUB_TOKEN is used as a fallback.
@@ -114,9 +120,13 @@ jobs:
                 --body "❌ No recent run of \`$WORKFLOW\` found on \`$BRANCH\` to re-run."
               exit 1
             fi
-            gh run rerun "$run_id" --repo "$REPO"
+            if ! gh run rerun "$run_id" --repo "$REPO"; then
+              gh pr comment "$ISSUE" --repo "$REPO" \
+                --body "❌ Could not re-run the latest \`$WORKFLOW\` run — it may still be in progress."
+              exit 1
+            fi
             gh pr comment "$ISSUE" --repo "$REPO" \
-              --body "🔁 Re-running \`$WORKFLOW\` on \`$BRANCH\`. [View runs]($ACTIONS_URL/$WORKFLOW)"
+              --body "🔁 Re-running the latest \`$WORKFLOW\` run on \`$BRANCH\`. [View runs]($ACTIONS_URL/$WORKFLOW)"
           fi
           gh api -X POST \
             "repos/$REPO/issues/comments/${{ github.event.comment.id }}/reactions" \

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -1,0 +1,123 @@
+name: PR commands
+
+# Slash-command handler for pull-request comments. A trusted commenter can
+# trigger on-demand installer builds or re-run a workflow on the PR branch
+# without opening the Actions UI. See README → "On-demand CI commands".
+#
+# Security model:
+#   - issue_comment workflows always run from the DEFAULT branch's copy of this
+#     file, so a PR cannot edit the gate below and have the edit take effect.
+#   - The job only runs for commenters with write access (author_association is
+#     set server-side by GitHub and cannot be spoofed).
+#   - Fork PRs are rejected: their branch does not exist in this repo, and we do
+#     not want to run privileged commands against untrusted heads.
+#   - The comment body is only ever read through an env var, never interpolated
+#     into a shell command, to avoid script injection.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  command:
+    if: >-
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Acknowledge the comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X POST \
+            "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content=eyes >/dev/null
+
+      - name: Parse command
+        id: parse
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          cmd=$(printf '%s' "$COMMENT_BODY" | head -n1 | tr '[:upper:]' '[:lower:]' | xargs)
+          action=""
+          workflow=""
+          inputs=""
+          case "$cmd" in
+            "/build mac" | "/build macos")
+              action=dispatch; workflow=release-artifacts.yml
+              inputs="-f build_macos=true -f build_windows=false" ;;
+            "/build win" | "/build windows")
+              action=dispatch; workflow=release-artifacts.yml
+              inputs="-f build_macos=false -f build_windows=true" ;;
+            "/build all" | "/build both")
+              action=dispatch; workflow=release-artifacts.yml
+              inputs="-f build_macos=true -f build_windows=true" ;;
+            "/rerun "*)
+              action=rerun; workflow="${cmd#/rerun }.yml" ;;
+            *)
+              echo "No matching command for: $cmd"
+              echo "match=false" >> "$GITHUB_OUTPUT"
+              exit 0 ;;
+          esac
+          {
+            echo "match=true"
+            echo "action=$action"
+            echo "workflow=$workflow"
+            echo "inputs=$inputs"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Resolve PR branch
+        id: pr
+        if: steps.parse.outputs.match == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          data=$(gh pr view "${{ github.event.issue.number }}" --repo "${{ github.repository }}" \
+                   --json headRefName,isCrossRepository)
+          if [ "$(jq -r .isCrossRepository <<<"$data")" = "true" ]; then
+            gh pr comment "${{ github.event.issue.number }}" --repo "${{ github.repository }}" \
+              --body "⚠️ On-demand CI commands are not available for fork PRs."
+            exit 1
+          fi
+          echo "branch=$(jq -r .headRefName <<<"$data")" >> "$GITHUB_OUTPUT"
+
+      - name: Run command
+        if: steps.parse.outputs.match == 'true'
+        env:
+          # A fine-grained PAT (actions:write) makes a workflow_dispatch reliably
+          # spawn a run; the default GITHUB_TOKEN is used as a fallback.
+          GH_TOKEN: ${{ secrets.WORKFLOW_DISPATCH_PAT || secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+          ACTION: ${{ steps.parse.outputs.action }}
+          WORKFLOW: ${{ steps.parse.outputs.workflow }}
+          INPUTS: ${{ steps.parse.outputs.inputs }}
+          BRANCH: ${{ steps.pr.outputs.branch }}
+          ACTIONS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/workflows
+        run: |
+          if [ "$ACTION" = "dispatch" ]; then
+            gh workflow run "$WORKFLOW" --repo "$REPO" --ref "$BRANCH" $INPUTS
+            gh pr comment "$ISSUE" --repo "$REPO" \
+              --body "🚀 Dispatched \`$WORKFLOW\` on \`$BRANCH\`. [View runs]($ACTIONS_URL/$WORKFLOW)"
+          else
+            run_id=$(gh run list --repo "$REPO" --workflow "$WORKFLOW" --branch "$BRANCH" \
+                       --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+            if [ -z "$run_id" ]; then
+              gh pr comment "$ISSUE" --repo "$REPO" \
+                --body "❌ No recent run of \`$WORKFLOW\` found on \`$BRANCH\` to re-run."
+              exit 1
+            fi
+            gh run rerun "$run_id" --repo "$REPO"
+            gh pr comment "$ISSUE" --repo "$REPO" \
+              --body "🔁 Re-running \`$WORKFLOW\` on \`$BRANCH\`. [View runs]($ACTIONS_URL/$WORKFLOW)"
+          fi
+          gh api -X POST \
+            "repos/$REPO/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content=rocket >/dev/null

--- a/README.md
+++ b/README.md
@@ -381,9 +381,10 @@ comment. Post one of these as a comment on the PR:
 | `/build all` _(or `/build both`)_    | Build both installers                                                                                  |
 | `/rerun <workflow>`                  | Re-run the latest run of a workflow on the PR branch — e.g. `/rerun regression`, `/rerun build-checks` |
 
-The bot reacts 👀 when it picks the command up and replies with a link to the
-run. Commands are ignored for anyone without write access and for PRs opened
-from forks. Built installers are uploaded to the Actions run (30-day retention).
+Put the command on the **first line** of the comment, on its own. The bot reacts
+👀 when it picks the command up and replies with a link to the run. Commands are
+ignored for anyone without write access and for PRs opened from forks. Built
+installers are uploaded to the Actions run (30-day retention).
 
 ### AI-Assisted Development
 

--- a/README.md
+++ b/README.md
@@ -369,6 +369,22 @@ Before opening a PR, read [CONTRIBUTING.md](./CONTRIBUTING.md). In short:
 - run `yarn lint:all` before asking for review;
 - do not bundle card images or secrets.
 
+### On-demand CI commands
+
+Maintainers (and anyone with write access) can drive CI from a pull-request
+comment. Post one of these as a comment on the PR:
+
+| Comment                              | Effect                                                                                                 |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| `/build mac` _(or `/build macos`)_   | Build the macOS `.dmg` from the PR branch                                                              |
+| `/build windows` _(or `/build win`)_ | Build the Windows `.exe` / `.msi` from the PR branch                                                   |
+| `/build all` _(or `/build both`)_    | Build both installers                                                                                  |
+| `/rerun <workflow>`                  | Re-run the latest run of a workflow on the PR branch — e.g. `/rerun regression`, `/rerun build-checks` |
+
+The bot reacts 👀 when it picks the command up and replies with a link to the
+run. Commands are ignored for anyone without write access and for PRs opened
+from forks. Built installers are uploaded to the Actions run (30-day retention).
+
 ### AI-Assisted Development
 
 This repository welcomes the use of AI assistance for mechanical porting, parity


### PR DESCRIPTION
## Summary

- Add `.github/workflows/pr-commands.yml`: an `issue_comment` handler that lets a trusted commenter trigger installer builds and workflow re-runs from a PR comment.
- Document the commands in the README under Contributing → "On-demand CI commands".

### Trigger sentences

Post one of these as a comment on a PR:

| Comment | Effect |
| --- | --- |
| `/build mac` _(or `/build macos`)_ | Build the macOS `.dmg` from the PR branch |
| `/build windows` _(or `/build win`)_ | Build the Windows `.exe` / `.msi` from the PR branch |
| `/build all` _(or `/build both`)_ | Build both installers |
| `/rerun <workflow>` | Re-run the latest run of a workflow on the PR branch — e.g. `/rerun regression`, `/rerun build-checks`, `/rerun deploy` |

`/build *` dispatches `release-artifacts.yml` on the PR branch with the matching `build_macos` / `build_windows` inputs (reusing its existing `workflow_dispatch` gate). `/rerun <name>` re-runs the most recent run of `<name>.yml` for the PR branch via `gh run rerun`, so it works for push/PR-triggered workflows too — not just dispatch-enabled ones.

## Why

Today installer builds only happen on merge to `main` (via the PR checkboxes), on `v*` tags, or by hand in the Actions UI. There is no way to produce a `.dmg` / `.exe` for an **open** PR, or to re-kick a flaky check, without leaving the review. These comment commands close that gap.

## How it stays safe on a public repo

- **Write-access gate:** the job only runs when `comment.author_association` is `OWNER` / `MEMBER` / `COLLABORATOR`. That field is set server-side by GitHub and cannot be spoofed, so a drive-by commenter gets nothing (default-deny).
- **Runs from `main`:** `issue_comment` workflows always execute the default-branch copy of the YAML, so a PR cannot weaken the gate and have the edit take effect before it's merged.
- **Forks rejected:** the handler exits on `isCrossRepository` — privileged commands never run against an untrusted head.
- **No script injection:** the comment body is read only through an env var, never interpolated into a shell command.
- **Token scoping:** dispatch uses `WORKFLOW_DISPATCH_PAT` if present (a fine-grained `actions: write` PAT makes `workflow_dispatch` reliably spawn a run), falling back to `GITHUB_TOKEN`.

## Test plan

- `python`/prettier: YAML + README pass `prettier --check`.
- Manual verification after merge (the handler must be on `main` to take effect, since `issue_comment` runs the default-branch copy): comment `/build mac` on a same-repo PR → 👀 reaction, dispatched-run reply; comment from a no-access account → ignored; comment on a fork PR → rejected reply.

> [!NOTE]
> Optional follow-up: add a fine-grained `WORKFLOW_DISPATCH_PAT` repo secret (`actions: write` + `contents: read`, this repo only) so `/build *` dispatches are 100% reliable. Without it the workflow falls back to `GITHUB_TOKEN`.

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
