### PR TITLE
fix(ci): bump Cargo.lock via release-please config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
     outputs:
       release_created: ${{ steps.rp.outputs.release_created }}
       tag_name: ${{ steps.rp.outputs.tag_name }}
+      pr_branch: ${{ steps.rp.outputs.pr && fromJSON(steps.rp.outputs.pr).headBranchName || '' }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: rp
@@ -55,3 +56,37 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
         run: gh workflow run release-artifacts.yml --ref "$TAG"
+
+  # release-please bumps the crate version in src-tauri/Cargo.toml but cannot
+  # update the workspace Cargo.lock, so the lockfile's `manabrew` entry goes
+  # stale and the next `cargo` run dirties the tree. main is protected, so the
+  # fix rides along inside the release PR: re-sync Cargo.lock on that branch
+  # (pushed with GITHUB_TOKEN, which does not retrigger workflows) so it merges
+  # with the version bump. release-please force-pushes its branch each run, so
+  # this re-applies every time it refreshes the PR.
+  sync-lockfile:
+    name: Sync Cargo.lock in the release PR
+    needs: release-please
+    if: needs.release-please.outputs.pr_branch != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.pr_branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Re-sync Cargo.lock with the bumped versions
+        run: cargo metadata --format-version 1 >/dev/null
+      - name: Commit the lockfile if it changed
+        env:
+          BRANCH: ${{ needs.release-please.outputs.pr_branch }}
+        run: |
+          if git diff --quiet -- Cargo.lock; then
+            echo "Cargo.lock already in sync."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Cargo.lock
+          git commit -m "chore: sync Cargo.lock"
+          git push origin "HEAD:$BRANCH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
     outputs:
       release_created: ${{ steps.rp.outputs.release_created }}
       tag_name: ${{ steps.rp.outputs.tag_name }}
-      pr_branch: ${{ steps.rp.outputs.pr && fromJSON(steps.rp.outputs.pr).headBranchName || '' }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: rp
@@ -56,37 +55,3 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
         run: gh workflow run release-artifacts.yml --ref "$TAG"
-
-  # release-please bumps the crate version in src-tauri/Cargo.toml but cannot
-  # update the workspace Cargo.lock, so the lockfile's `manabrew` entry goes
-  # stale and the next `cargo` run dirties the tree. main is protected, so the
-  # fix rides along inside the release PR: re-sync Cargo.lock on that branch
-  # (pushed with GITHUB_TOKEN, which does not retrigger workflows) so it merges
-  # with the version bump. release-please force-pushes its branch each run, so
-  # this re-applies every time it refreshes the PR.
-  sync-lockfile:
-    name: Sync Cargo.lock in the release PR
-    needs: release-please
-    if: needs.release-please.outputs.pr_branch != ''
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.release-please.outputs.pr_branch }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Re-sync Cargo.lock with the bumped versions
-        run: cargo metadata --format-version 1 >/dev/null
-      - name: Commit the lockfile if it changed
-        env:
-          BRANCH: ${{ needs.release-please.outputs.pr_branch }}
-        run: |
-          if git diff --quiet -- Cargo.lock; then
-            echo "Cargo.lock already in sync."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Cargo.lock
-          git commit -m "chore: sync Cargo.lock"
-          git push origin "HEAD:$BRANCH"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3626,7 +3626,7 @@ dependencies = [
 
 [[package]]
 name = "manabrew"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "forge-carddb",
  "forge-cardset-archive",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -36,6 +36,11 @@
           "type": "toml",
           "path": "src-tauri/Cargo.toml",
           "jsonpath": "$.package.version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name.value=='manabrew')].version"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Add a `Cargo.lock` entry to `release-please-config.json`'s `extra-files` so release-please bumps the `manabrew` package version directly in the lockfile, inside the release PR.
- Remove the separate `sync-lockfile` CI job (and its `pr_branch` output) that checked out the release PR branch and pushed a second `chore: sync Cargo.lock` commit.

## Why

release-please bumps `src-tauri/Cargo.toml` but, with the `simple` release type, doesn't touch the workspace `Cargo.lock`, so the `manabrew` entry drifts and the next `cargo` run dirties the tree. The original fix did this in a follow-up workflow job that pushed an extra commit onto the release branch — noisy and easy to break. This moves the whole thing into the release-please config where the other version bumps already live.

## How it works (and one non-obvious detail)

release-please's `type: "toml"` updater (`GenericToml`) locates the value with jsonpath-plus and replaces it **surgically** via `replaceTomlValue` — the same primitive the built-in `CargoLock` updater uses, which "preserves formatting and comments". So only the version line changes; the rest of `Cargo.lock` stays byte-identical.

The non-obvious bit: that updater parses TOML with a **tagged** parser, so each scalar becomes `{ start, end, value }`. A naive filter `?(@.name=='manabrew')` therefore matches **nothing**. The filter has to reach the wrapped value:

```
$.package[?(@.name.value=='manabrew')].version
```

> ⚠️ This leans on release-please's internal tagged-value representation (`.value`). It's stable (the same parser has backed cargo updates since 2021) but undocumented — if a future release-please changes it, the filter would silently stop matching and the lockfile would drift again. Worth a glance on release-please major bumps.

## Test plan

Simulated release-please's exact update path locally against the real `Cargo.lock` (parse with the tagged parser → jsonpath-plus pointer → `replaceTomlValue`):

- `?(@.name=='manabrew')` → 0 matches (proves the naive form is broken).
- `?(@.name.value=='manabrew')` → pointer `/package/<idx>/version`; applying the bump changes **exactly one line** (manabrew's `version`), lockfile otherwise byte-identical.

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main