### PR TITLE
[codex] fix dev Scryfall image loading

### DIFF
--- a/src/api/scryfall.ts
+++ b/src/api/scryfall.ts
@@ -9,7 +9,11 @@ import {
 } from "@/types/scryfall";
 import { platformFetch } from "@/lib/platformFetch";
 import { getPlatformType } from "@/platform";
-import { loadScryfallImage } from "@/lib/scryfallImageSource";
+import {
+  loadScryfallImage,
+  resolveScryfallImageUrl,
+  shouldUseAnonymousImage,
+} from "@/lib/scryfallImageSource";
 import {
   enqueueCardLookup,
   matchesIdentifier,
@@ -213,10 +217,10 @@ export async function fetchCardsBySet(setCode: string): Promise<ScryfallCard[]> 
 
 export async function fetchImageElement(url: string): Promise<HTMLImageElement> {
   const onDesktop = getPlatformType() === "tauri";
-  const src = onDesktop ? await loadScryfallImage(url) : url;
+  const src = onDesktop ? await loadScryfallImage(url) : resolveScryfallImageUrl(url);
   return new Promise((resolve, reject) => {
     const img = new Image();
-    if (!onDesktop) img.crossOrigin = "anonymous";
+    if (shouldUseAnonymousImage(src)) img.crossOrigin = "anonymous";
     img.onload = () => resolve(img);
     img.onerror = () => reject(new Error(`Failed to load image: ${url}`));
     img.src = src;

--- a/src/components/ScryfallImg.tsx
+++ b/src/components/ScryfallImg.tsx
@@ -1,9 +1,17 @@
 import { forwardRef } from "react";
 import { useScryfallImageSrc } from "@/hooks/useScryfallImageSrc";
+import { shouldUseAnonymousImage } from "@/lib/scryfallImageSource";
 
 export const ScryfallImg = forwardRef<HTMLImageElement, React.ImgHTMLAttributes<HTMLImageElement>>(
-  function ScryfallImg({ src, ...props }, ref) {
+  function ScryfallImg({ src, crossOrigin, ...props }, ref) {
     const resolved = useScryfallImageSrc(typeof src === "string" ? src : undefined);
-    return <img ref={ref} src={typeof src === "string" ? resolved : src} {...props} />;
+    return (
+      <img
+        ref={ref}
+        crossOrigin={crossOrigin ?? (shouldUseAnonymousImage(resolved) ? "anonymous" : undefined)}
+        src={typeof src === "string" ? resolved : src}
+        {...props}
+      />
+    );
   },
 );

--- a/src/hooks/useScryfallImageSrc.ts
+++ b/src/hooks/useScryfallImageSrc.ts
@@ -4,6 +4,7 @@ import {
   isScryfallImageUrl,
   loadScryfallImage,
   peekScryfallImage,
+  resolveScryfallImageUrl,
 } from "@/lib/scryfallImageSource";
 
 export function useScryfallImageSrc(url: string | undefined): string | undefined {
@@ -21,5 +22,5 @@ export function useScryfallImageSrc(url: string | undefined): string | undefined
       active = false;
     };
   }, [url, eligible]);
-  return eligible ? peekScryfallImage(url!) : url;
+  return eligible ? peekScryfallImage(url!) : url ? resolveScryfallImageUrl(url) : url;
 }

--- a/src/lib/scryfallImageSource.ts
+++ b/src/lib/scryfallImageSource.ts
@@ -6,9 +6,35 @@ const SCRYFALL_IMAGE_HOSTS = new Set([
   "svgs.scryfall.io",
 ]);
 
+const DEV_IMAGE_PROXIES: Record<string, string> = {
+  "cards.scryfall.io": "/scryfall-card-images",
+  "backs.scryfall.io": "/scryfall-back-images",
+  "svgs.scryfall.io": "/scryfall-symbols",
+};
+
 export function isScryfallImageUrl(url: string): boolean {
   try {
     return SCRYFALL_IMAGE_HOSTS.has(new URL(url).hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function resolveScryfallImageUrl(url: string): string {
+  if (!import.meta.env.DEV) return url;
+  try {
+    const parsed = new URL(url);
+    const prefix = DEV_IMAGE_PROXIES[parsed.hostname];
+    return prefix ? `${prefix}${parsed.pathname}${parsed.search}` : url;
+  } catch {
+    return url;
+  }
+}
+
+export function shouldUseAnonymousImage(url: string | undefined): boolean {
+  if (!url || typeof window === "undefined") return false;
+  try {
+    return new URL(url, window.location.href).origin !== window.location.origin;
   } catch {
     return false;
   }

--- a/src/stores/useScryfallStore.ts
+++ b/src/stores/useScryfallStore.ts
@@ -11,7 +11,11 @@ import {
   getRulings,
 } from "@/api/scryfall";
 import { getPlatformType } from "@/platform";
-import { loadScryfallImage } from "@/lib/scryfallImageSource";
+import {
+  loadScryfallImage,
+  resolveScryfallImageUrl,
+  shouldUseAnonymousImage,
+} from "@/lib/scryfallImageSource";
 import type {
   ScryfallCard,
   ScryfallImageUris,
@@ -407,7 +411,9 @@ export const useScryfallStore = create<ScryfallState>()(
             void loadScryfallImage(uris.normal).catch(() => {});
           } else {
             const img = new Image();
-            img.src = uris.normal;
+            const src = resolveScryfallImageUrl(uris.normal);
+            if (shouldUseAnonymousImage(src)) img.crossOrigin = "anonymous";
+            img.src = src;
           }
         }
       },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -55,6 +55,16 @@ export default defineConfig({
         changeOrigin: true,
         rewrite: (p) => p.replace(/^\/spellbook-api/, ""),
       },
+      "/scryfall-card-images": {
+        target: "https://cards.scryfall.io",
+        changeOrigin: true,
+        rewrite: (p) => p.replace(/^\/scryfall-card-images/, ""),
+      },
+      "/scryfall-back-images": {
+        target: "https://backs.scryfall.io",
+        changeOrigin: true,
+        rewrite: (p) => p.replace(/^\/scryfall-back-images/, ""),
+      },
       "/scryfall-symbols": {
         target: "https://svgs.scryfall.io",
         changeOrigin: true,


### PR DESCRIPTION
## Summary

- Add Vite dev proxies for Scryfall image CDN hosts used by card faces and card backs.
- Resolve Scryfall image URLs through the same-origin dev proxy in web dev builds.
- Only set `crossOrigin="anonymous"` when the resolved image URL is actually cross-origin, and apply that consistently across `<ScryfallImg>`, Pixi image loading, and Scryfall prefetching.

## Why

In web dev, some card images intermittently failed to render from `http://localhost:1420` with browser CORS errors against `https://cards.scryfall.io/...`. The visible symptom depended on which card/image path loaded first and what Chrome reused from cache, so disabling cache sometimes made the same card appear again.

Evidence gathered while debugging Hallowed Fountain:

- The affected Hallowed Fountain image URL was `https://cards.scryfall.io/border_crop/front/e/0/e056b55f-82ed-4fe0-ab0c-bb20fa4a218a.jpg?1759144845`.
- A normal image-style request without an `Origin` header returned the JPEG successfully.
- Loading the same upstream URL in CORS mode via `crossOrigin="anonymous"` failed; in the browser/CDP repro it produced an HTML/404-style response instead of a usable image.
- Loading the same image through the local Vite proxy succeeded when `crossOrigin` was not set, producing a same-origin image URL like `/scryfall-card-images/border_crop/front/e/0/e056b55f-82ed-4fe0-ab0c-bb20fa4a218a.jpg?1759144845`.

The root issue was that dev-web image callers were not using one consistent request mode. Some paths requested Scryfall images directly with CORS, others behaved like plain images, and cached responses could make failures look card-count-dependent or intermittent. This PR makes dev-web image loads same-origin through Vite and avoids forcing CORS mode for those proxied URLs.

## Test plan

- `yarn typecheck` passes, with existing `ts-rs` serde-attribute warnings.
- `yarn lint:all` was run. Frontend lint, prettier, and typecheck passed; the command then failed in the Rust phase because `origin/main` currently references missing file `manabrew-rs/crates/self-hosted-node/examples/graal_smoke.rs` from `manabrew-rs/crates/self-hosted-node/Cargo.toml`.
- Manually verified with a temporary local debug preset containing 60 Hallowed Fountains: Hallowed Fountain rendered in hand and on the board. The temporary deck was removed before this commit.
- Verified the proxied Hallowed Fountain image loads in Chrome without `crossOrigin` and resolves to a valid image.

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
