### PR TITLE
fix(ui) allow targeting opponent public zones

### DIFF
--- a/src/components/game/GameBoard.tsx
+++ b/src/components/game/GameBoard.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { CardDto, PlayerDto } from "@/protocol/game";
 import type { Prompt } from "@/protocol";
-import type { BoardTargetBuckets } from "@/lib/boardTargets";
+import { validCardIdsInCards, type BoardTargetBuckets } from "@/lib/boardTargets";
 import { type ZonePanelItem } from "@/stores/usePreferencesStore";
 import { BoardCanvas, type BoardCanvasLayout, type BoardCanvasRegion } from "@/pixi/BoardCanvas";
 import { BoardArrowsCanvas } from "@/pixi/BoardArrowsCanvas";
@@ -254,11 +254,13 @@ export function GameBoard({
     ?.filter((a) => a.type === "activateAbility")
     .map((a) => a.cardId);
   const hostileTargeting = boardTargetsPrompt?.input.hostile ?? false;
-  const targetZoneCardIds = (zone: string): string[] =>
-    boardTargets?.zone?.zone === zone ? boardTargets.zone.validCardIds : [];
-  const commandTargetIds = targetZoneCardIds("Command");
-  const graveyardTargetIds = targetZoneCardIds("Graveyard");
-  const exileTargetIds = targetZoneCardIds("Exile");
+  const targetZoneCardIds = (zone: string, cards?: CardDto[]): string[] =>
+    boardTargets?.zone?.zone === zone
+      ? validCardIdsInCards(boardTargets.zone.validCardIds, cards)
+      : [];
+  const commandTargetIds = targetZoneCardIds("Command", myCommandZone);
+  const graveyardTargetIds = targetZoneCardIds("Graveyard", graveyard);
+  const exileTargetIds = targetZoneCardIds("Exile", exile);
   const commandPlayableIds = myCommandZone
     ?.filter((card) => playableIds.has(card.id))
     .map((card) => card.id);
@@ -798,6 +800,9 @@ export function GameBoard({
       {unifiedLayout?.opponents.map(({ playerId, rect, orientation }, i) => {
         const op = opponents.find((o) => o.id === playerId);
         if (!op) return null;
+        const opCommandTargetIds = targetZoneCardIds("Command", op.commandZone);
+        const opGraveyardTargetIds = targetZoneCardIds("Graveyard", op.graveyard);
+        const opExileTargetIds = targetZoneCardIds("Exile", op.exile);
         const scale = `scale(${UNIFIED_OPPONENT_PANEL_SCALE})`;
         const pad = Math.min(rect.width, rect.height) * PLAYMAT_PADDING;
         const panelStyle: React.CSSProperties =
@@ -850,12 +855,51 @@ export function GameBoard({
               exile={op.exile}
               onOpenCommandZone={
                 (op.commandZone?.length ?? 0) > 0
-                  ? () => onOpenZone(`${op.name}'s Command Zone`, op.commandZone!)
+                  ? () => {
+                      if (isTargetingPrompt && opCommandTargetIds.length > 0) {
+                        onOpenZone(
+                          `${op.name}'s Command Zone`,
+                          op.commandZone!,
+                          onTargetFromZone,
+                          opCommandTargetIds,
+                          hostileTargeting,
+                        );
+                        return;
+                      }
+                      onOpenZone(`${op.name}'s Command Zone`, op.commandZone!);
+                    }
                   : undefined
               }
-              onOpenGraveyard={() => onOpenZone(`${op.name}'s Graveyard`, op.graveyard)}
-              onOpenExile={() => onOpenZone(`${op.name}'s Exile`, op.exile)}
+              onOpenGraveyard={() => {
+                if (isTargetingPrompt && opGraveyardTargetIds.length > 0) {
+                  onOpenZone(
+                    `${op.name}'s Graveyard`,
+                    op.graveyard,
+                    onTargetFromZone,
+                    opGraveyardTargetIds,
+                    hostileTargeting,
+                  );
+                  return;
+                }
+                onOpenZone(`${op.name}'s Graveyard`, op.graveyard);
+              }}
+              onOpenExile={() => {
+                if (isTargetingPrompt && opExileTargetIds.length > 0) {
+                  onOpenZone(
+                    `${op.name}'s Exile`,
+                    op.exile,
+                    onTargetFromZone,
+                    opExileTargetIds,
+                    hostileTargeting,
+                  );
+                  return;
+                }
+                onOpenZone(`${op.name}'s Exile`, op.exile);
+              }}
               onHoverCard={(card, e) => onHoverCard(card, e, { useAnchor: true })}
+              hasTargetInGraveyard={isTargetingPrompt && opGraveyardTargetIds.length > 0}
+              hasTargetInExile={isTargetingPrompt && opExileTargetIds.length > 0}
+              targetHostile={hostileTargeting}
               zonePanelOrder={zonePanelOrder}
             />
           </div>

--- a/src/lib/boardTargets.ts
+++ b/src/lib/boardTargets.ts
@@ -13,6 +13,12 @@ export interface BoardTargetBuckets {
   zone: { zone: string; cards: CardDto[]; validCardIds: string[] } | null;
 }
 
+export function validCardIdsInCards(validCardIds: string[], cards?: CardDto[]): string[] {
+  if (!cards?.length) return [];
+  const cardIds = new Set(cards.map((card) => card.id));
+  return validCardIds.filter((id) => cardIds.has(id));
+}
+
 function findInZones(gv: GameViewDto, id: string): { zone: string; card: CardDto } | null {
   for (const p of gv.players) {
     const zones: [string, CardDto[] | undefined][] = [

--- a/src/views/Game.tsx
+++ b/src/views/Game.tsx
@@ -1,7 +1,7 @@
 import { useGameStore } from "@/stores/useGameStore";
 import { asDeckCard } from "@/lib/decks";
 import { GAME_CARD_DEFAULTS } from "@/lib/gameCard";
-import { partitionBoardTargets } from "@/lib/boardTargets";
+import { partitionBoardTargets, validCardIdsInCards } from "@/lib/boardTargets";
 import { useGameUIStore } from "@/stores/useGameUIStore";
 import { usePreferencesStore } from "@/stores/usePreferencesStore";
 import { useAutoResolvePrompt } from "@/components/prompts/internal/useAutoResolvePrompt";
@@ -913,7 +913,12 @@ export default function Game({ exitTo }: GameProps = {}) {
       closeZoneViewer();
       return;
     }
-    openZoneViewer({ ...vz, clickableCardIds: boardTargets.zone.validCardIds });
+    const clickableCardIds = validCardIdsInCards(boardTargets.zone.validCardIds, vz.cards);
+    if (clickableCardIds.length === 0) {
+      closeZoneViewer();
+      return;
+    }
+    openZoneViewer({ ...vz, clickableCardIds });
   }, [boardTargets, openZoneViewer, closeZoneViewer]);
 
   // Generic sticky-viewer close: a viewer bound to a prompt type stays open


### PR DESCRIPTION
## Summary

- Allow opponent command, graveyard, and exile panels to open in targeting mode when they contain valid targets.
- Filter target ids against the currently opened zone viewer's card list so same-zone target prompts only highlight cards present in that viewer.

## Why

Fixes #281.

Keen-Eyed Curator can target a card from any graveyard, but opponent public zones were opened as read-only viewers. The prompt already had the valid card ids; the board UI was not routing opponent public-zone opens through the targeting callback.

## Test plan

- `yarn lint`
- `git diff --cached --check`

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
