### PR TITLE
feat(ui): combat clarity polish + horizontal-card & commander fixes

### DIFF
--- a/src/components/game/GameBoard.tsx
+++ b/src/components/game/GameBoard.tsx
@@ -895,7 +895,7 @@ export function GameBoard({
         topCard: top(myCommandZone!),
         onOpen: openCommandZone,
         highlightColor: (commandPlayableIds?.length ?? 0) > 0 ? active : undefined,
-        commander: true,
+        commander: playerColors.self,
       });
     }
 
@@ -904,7 +904,7 @@ export function GameBoard({
       isTargetingPrompt && boardTargets?.zone?.zone === zone
         ? validCardIdsInCards(boardTargets.zone.validCardIds, cards)
         : [];
-    for (const op of opponents) {
+    for (const [oppIndex, op] of opponents.entries()) {
       const gyTargets = opZoneTargetIds("Graveyard", op.graveyard);
       const exTargets = opZoneTargetIds("Exile", op.exile);
       const cmdTargets = opZoneTargetIds("Command", op.commandZone);
@@ -939,7 +939,7 @@ export function GameBoard({
           topCard: top(op.commandZone),
           onOpen: () => openOpZone(`${op.name}'s Command Zone`, op.commandZone, cmdTargets),
           highlightColor: cmdTargets.length > 0 ? targetColor : undefined,
-          commander: true,
+          commander: playerColors[OPPONENT_SEATS[oppIndex] ?? "opponent1"],
         });
       }
       byPlayer[op.id] = tiles;
@@ -950,6 +950,7 @@ export function GameBoard({
     me.libraryCount,
     opponents,
     gameTheme,
+    playerColors,
     myCommandZone,
     commandPlayableIds,
     graveyard,

--- a/src/components/game/game.types.ts
+++ b/src/components/game/game.types.ts
@@ -10,6 +10,13 @@ export interface CombatAssignment {
   attackerId: string;
 }
 
+export interface CombatPairing {
+  key: string;
+  attacker: string;
+  defender: string;
+  count: number;
+}
+
 export type FlashItem =
   | { kind: "card"; cardId: string; cardName: string; setCode: string }
   | { kind: "turn"; playerId: string; playerName: string };
@@ -65,6 +72,7 @@ export interface MainActionOverlayProps {
   blockRestrictionHint?: string | null;
   attackerIds: string[];
   blockAssignments: CombatAssignment[];
+  combatPairings: CombatPairing[];
   onDeclareBlockers: (assignments: CombatAssignment[]) => void;
   damageOrderCount: number;
   damageOrderTotal: number;

--- a/src/components/game/panels/CombatInfo.tsx
+++ b/src/components/game/panels/CombatInfo.tsx
@@ -1,12 +1,13 @@
 import { CombatSummarySection } from "../CombatSummarySection";
 import type { CardDto } from "@/protocol/game";
-import type { PromptActionType, CombatAssignment } from "../game.types";
+import type { PromptActionType, CombatAssignment, CombatPairing } from "../game.types";
 
 interface CombatInfoProps {
   promptType?: PromptActionType;
   attackerIds: string[];
   pendingAttackers: string[];
   blockAssignments: CombatAssignment[];
+  combatPairings: CombatPairing[];
   resolveCardName: (cardId: string) => string;
   resolveCard: (cardId: string) => CardDto | undefined;
 }
@@ -16,17 +17,38 @@ export function CombatInfo({
   attackerIds,
   pendingAttackers,
   blockAssignments,
+  combatPairings,
   resolveCardName,
   resolveCard,
 }: CombatInfoProps) {
   return (
-    <CombatSummarySection
-      promptType={promptType}
-      attackerIds={attackerIds}
-      pendingAttackers={pendingAttackers}
-      blockAssignments={blockAssignments}
-      resolveCardName={resolveCardName}
-      resolveCard={resolveCard}
-    />
+    <>
+      {combatPairings.length > 0 && (
+        <div className="flex flex-col gap-1 rounded-lg bg-destructive/10 p-2">
+          {combatPairings.map((p) => (
+            <div key={p.key} className="flex items-center gap-1.5 text-xs">
+              <span className="min-w-0 truncate font-semibold">{p.attacker}</span>
+              <span className="shrink-0 text-muted-foreground">
+                {p.attacker === "You" ? "attack" : "attacks"}
+              </span>
+              <span className="min-w-0 truncate font-semibold text-destructive">{p.defender}</span>
+              {p.count > 1 && (
+                <span className="ml-auto shrink-0 rounded bg-destructive/15 px-1 text-[10px] font-bold text-destructive">
+                  ×{p.count}
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+      <CombatSummarySection
+        promptType={promptType}
+        attackerIds={attackerIds}
+        pendingAttackers={pendingAttackers}
+        blockAssignments={blockAssignments}
+        resolveCardName={resolveCardName}
+        resolveCard={resolveCard}
+      />
+    </>
   );
 }

--- a/src/components/game/panels/MainActionOverlay.tsx
+++ b/src/components/game/panels/MainActionOverlay.tsx
@@ -56,6 +56,7 @@ export function MainActionOverlay({
   blockRestrictionHint,
   attackerIds,
   blockAssignments,
+  combatPairings,
   onDeclareBlockers,
   damageOrderCount,
   damageOrderTotal,
@@ -216,6 +217,7 @@ export function MainActionOverlay({
               attackerIds={attackerIds}
               pendingAttackers={pendingAttackers}
               blockAssignments={blockAssignments}
+              combatPairings={combatPairings}
               resolveCardName={resolveCardName}
               resolveCard={resolveCard}
             />

--- a/src/pixi/BoardCanvas.tsx
+++ b/src/pixi/BoardCanvas.tsx
@@ -376,6 +376,9 @@ export function BoardCanvas({
       lastRegionStateRef.current.set(r.playerId, r.state);
       scene.updateRegionState(r.playerId, r.state);
     }
+    const liveIds = new Set<string>();
+    for (const r of regions) for (const c of r.state.cards) liveIds.add(c.id);
+    scene.pruneCardPositions(liveIds);
   }, [scene, regions]);
 
   useEffect(() => {

--- a/src/pixi/CardSprite.ts
+++ b/src/pixi/CardSprite.ts
@@ -327,8 +327,11 @@ export class CardSprite extends Container {
   private hoverDebugGfx: Graphics;
   private _imageLoaded = false;
   private readonly isBattlefield: boolean;
-  private readonly cw: number;
-  private readonly ch: number;
+  private cw: number;
+  private ch: number;
+  /** Fired when the card's frame orientation flips (horizontal layout resolved
+   *  from Scryfall after construction) so the hand can re-rotate it. */
+  onReorient?: () => void;
   private previewFace: 0 | 1 | null = null;
   private loadGeneration = 0;
 
@@ -542,6 +545,37 @@ export class CardSprite extends Container {
     return this.cw > this.ch;
   }
 
+  /** Recompute the frame orientation (now that the Scryfall layout may have
+   *  loaded) and re-lay the dimension-dependent geometry if it changed. The
+   *  image fit + frame are repainted by the caller (`loadImage`). */
+  private reapplyOrientation(): void {
+    const horizontal = this.isHorizontal();
+    const cw = horizontal ? CARD_H : CARD_W;
+    const ch = horizontal ? CARD_W : CARD_H;
+    if (cw === this.cw && ch === this.ch) return;
+    this.cw = cw;
+    this.ch = ch;
+    this.placeholderGfx.clear();
+    this.placeholderGfx.roundRect(0, 0, cw, ch, CARD_RADIUS);
+    this.placeholderGfx.fill({
+      color: hexToNum(activeTheme.gameTheme.cardPlaceholder.fill),
+      alpha: 0.8,
+    });
+    this.placeholderGfx.stroke({
+      color: hexToNum(activeTheme.gameTheme.cardPlaceholder.stroke),
+      width: 1,
+    });
+    const neutral = hexToNum(activeTheme.gameTheme.canvas.neutral);
+    for (const m of [this.imageMask, this.frameMask, this.edgeGlowMask]) {
+      m.clear();
+      m.roundRect(0, 0, cw, ch, CARD_RADIUS).fill(neutral);
+    }
+    this.nameText.position.set(cw / 2, ch / 2);
+    this.foilStar.x = cw - 3;
+    this.pivot.set(cw / 2, ch / 2);
+    this.onReorient?.();
+  }
+
   private fitImageToSlot(): void {
     if (this.isHorizontal()) {
       this.imageSpr.anchor.set(0.5, 0.5);
@@ -573,6 +607,7 @@ export class CardSprite extends Container {
       tex = Texture.EMPTY;
     }
     if (this.destroyed || generation !== this.loadGeneration) return;
+    this.reapplyOrientation();
     if (tex !== Texture.EMPTY) {
       this.imageSpr.texture = tex;
       if (custom) this.fitArtCover();

--- a/src/pixi/CardSprite.ts
+++ b/src/pixi/CardSprite.ts
@@ -329,8 +329,6 @@ export class CardSprite extends Container {
   private readonly isBattlefield: boolean;
   private cw: number;
   private ch: number;
-  /** Fired when the card's frame orientation flips (horizontal layout resolved
-   *  from Scryfall after construction) so the hand can re-rotate it. */
   onReorient?: () => void;
   private previewFace: 0 | 1 | null = null;
   private loadGeneration = 0;
@@ -545,9 +543,7 @@ export class CardSprite extends Container {
     return this.cw > this.ch;
   }
 
-  /** Recompute the frame orientation (now that the Scryfall layout may have
-   *  loaded) and re-lay the dimension-dependent geometry if it changed. The
-   *  image fit + frame are repainted by the caller (`loadImage`). */
+  // Image fit + frame are left for the caller (`loadImage`) to repaint.
   private reapplyOrientation(): void {
     const horizontal = this.isHorizontal();
     const cw = horizontal ? CARD_H : CARD_W;

--- a/src/pixi/board/BoardRegion.ts
+++ b/src/pixi/board/BoardRegion.ts
@@ -486,6 +486,13 @@ export class BoardRegion {
       s.tickEffects(now);
       s.x = lerp(s.x, entry.targetX, BATTLEFIELD_LERP, SNAP_PX);
       s.y = lerp(s.y, entry.targetY, BATTLEFIELD_LERP, SNAP_PX);
+      const cp = this.localToCanvas(s.x, s.y);
+      this.host.recordCardExit(id, {
+        x: cp.x,
+        y: cp.y,
+        scaleX: s.scale.x,
+        scaleY: s.scale.y,
+      });
       if (entry.pendingEntrance) {
         const dx = s.x - entry.targetX;
         const dy = s.y - entry.targetY;
@@ -630,6 +637,7 @@ export class BoardRegion {
 
     for (const card of topLevelCards) {
       const center = positions.get(card.id) ?? { x: this.zoneCenterX(), y: this.zoneCenterY() };
+      const guest = this.combatRowAttackerIds.has(card.id);
       const childIds = effectiveChildren.get(card.id) ?? [];
       const attachments = childIds
         .map((id) => cardMap.get(id))
@@ -647,6 +655,7 @@ export class BoardRegion {
           topLeftY + totalOffset - stepsAbove * ATTACH_OFFSET_Y + (CARD_H * this.cardScale) / 2,
           i + 1,
           state,
+          guest,
         );
       }
 
@@ -656,6 +665,7 @@ export class BoardRegion {
         topLeftY + totalOffset + (CARD_H * this.cardScale) / 2,
         attachments.length + 1,
         state,
+        guest,
       );
     }
 
@@ -1237,7 +1247,7 @@ export class BoardRegion {
   private destroyEntry(id: string): void {
     const entry = this.entries.get(id);
     if (!entry) return;
-    this.container.removeChild(entry.sprite);
+    entry.sprite.parent?.removeChild(entry.sprite);
     if (entry.overlay) this.container.removeChild(entry.overlay);
     safeDestroy(entry.sprite);
     if (entry.overlay) safeDestroy(entry.overlay);
@@ -1250,6 +1260,7 @@ export class BoardRegion {
     centerY: number,
     zIndex: number,
     state: BattlefieldState,
+    guest = false,
   ): void {
     this.ensureBattlefieldEntry(card);
     const entry = this.entries.get(card.id)!;
@@ -1257,6 +1268,8 @@ export class BoardRegion {
       entry.exiting = false;
       entry.sprite.alpha = 1;
     }
+    const parent = guest ? this.host.getCombatGuestLayer() : this.container;
+    if (entry.sprite.parent !== parent) parent.addChild(entry.sprite);
     entry.targetX = centerX;
     entry.targetY = centerY;
     entry.targetZIndex = zIndex;
@@ -1685,6 +1698,10 @@ export class BoardRegion {
   }
 
   destroy(): void {
+    for (const entry of this.entries.values()) {
+      entry.sprite.parent?.removeChild(entry.sprite);
+      safeDestroy(entry.sprite);
+    }
     this.playmat.destroy();
     this.effects.destroy();
     this.zoneTiles.destroy();

--- a/src/pixi/board/BoardRegion.ts
+++ b/src/pixi/board/BoardRegion.ts
@@ -1360,8 +1360,11 @@ export class BoardRegion {
   private playArea(): PlayZoneRect {
     const z = this.usableZone();
     const pad = Math.min(z.width, z.height) * PLAYMAT_PADDING;
+    // Opponent fields permanently reserve the inner-edge combat-row band so the
+    // three grid rows are sized once and never reflow when combat starts/ends;
+    // the row just shows/hides inside the reserved strip.
     const reserve =
-      this.combatRowAttackerIds.size > 0
+      this.mirrored || this.combatRowAttackerIds.size > 0
         ? CARD_H * this.cardScale + COMBAT_ROW_PAD_Y * 2 + COMBAT_STAGE_PADDING_PX
         : 0;
     return {

--- a/src/pixi/board/BoardRegion.ts
+++ b/src/pixi/board/BoardRegion.ts
@@ -1222,6 +1222,13 @@ export class BoardRegion {
     for (const [id, entry] of this.entries) {
       if (currentIds.has(id) || entry.exiting) continue;
       entry.exiting = true;
+      const c = this.localToCanvas(entry.sprite.x, entry.sprite.y);
+      this.host.recordCardExit(id, {
+        x: c.x,
+        y: c.y,
+        scaleX: entry.sprite.scale.x,
+        scaleY: entry.sprite.scale.y,
+      });
       if (entry.overlay) entry.overlay.visible = false;
       this.userPlacedCards.delete(id);
     }

--- a/src/pixi/board/BoardScene.ts
+++ b/src/pixi/board/BoardScene.ts
@@ -40,6 +40,7 @@ import {
   STACK_SEED_TTL_MS,
   TABLE_RADIUS,
   Z_STAGED_REGION,
+  Z_COMBAT_GUEST,
 } from "../constants";
 import { useGameDevStore } from "@/stores/useGameDevStore";
 import type {
@@ -161,6 +162,7 @@ export class BoardScene {
 
   private floaterLayer: Container;
   private floaters: { text: Text; age: number }[] = [];
+  private combatGuestLayer: Container;
 
   private declareBlockers = false;
   private blockDragBlockerId: string | null = null;
@@ -286,6 +288,11 @@ export class BoardScene {
     this.phaseStrip = new PhaseStripLayer(this.theme);
     this.phaseStrip.container.zIndex = 7000;
     this.root.addChild(this.phaseStrip.container);
+
+    this.combatGuestLayer = new Container();
+    this.combatGuestLayer.sortableChildren = true;
+    this.combatGuestLayer.zIndex = Z_COMBAT_GUEST;
+    this.root.addChild(this.combatGuestLayer);
 
     this.floaterLayer = new Container();
     this.floaterLayer.eventMode = "none";
@@ -737,6 +744,12 @@ export class BoardScene {
     this.refreshPhaseStripDim();
   }
 
+  pruneCardPositions(liveIds: ReadonlySet<string>): void {
+    for (const id of this.lastCardPositions.keys()) {
+      if (!liveIds.has(id)) this.lastCardPositions.delete(id);
+    }
+  }
+
   private refreshPhaseStripDim(): void {
     let active = false;
     for (const rec of this.regions.values()) {
@@ -962,6 +975,7 @@ export class BoardScene {
         ...(isLocal ? this.localBlockers() : []),
       ],
       getEntrySeed: (cardId) => this.entrySeedFor(playerId, isLocal, cardId),
+      getCombatGuestLayer: () => this.combatGuestLayer,
       recordCardExit: (cardId, seed) => this.lastCardPositions.set(cardId, seed),
       isSelected: (cardId) => (isLocal ? (this.selection?.has(cardId) ?? false) : false),
       rebuildOverlay: (entry, state) => {
@@ -1041,10 +1055,7 @@ export class BoardScene {
       if (live) return live;
     }
     const remembered = this.lastCardPositions.get(cardId);
-    if (remembered) {
-      this.lastCardPositions.delete(cardId);
-      return remembered;
-    }
+    if (remembered) return remembered;
     const stack = this.stackCardSeeds.get(cardId);
     if (stack) return { x: stack.x, y: stack.y, scaleX: stack.scale, scaleY: stack.scale };
     if (isLocal && this.hand) {

--- a/src/pixi/board/BoardScene.ts
+++ b/src/pixi/board/BoardScene.ts
@@ -98,6 +98,7 @@ export interface BoardPlayerSpec {
 const DELIMITER_EASE = { FACTOR: 0.25, SNAP: 0.0005 } as const;
 
 const GRIP_HIT_WIDTH_PX = 16;
+const ATTACK_ARROW_LANE_PX = 18;
 
 /* ─────────────────────────────────────────────────────────────────────────
  * DIVIDER + FOG — tweak these. The vertical divider bar and the fog-of-war
@@ -1403,10 +1404,27 @@ export class BoardScene {
       return [];
     const canvasRect = this.app.canvas.getBoundingClientRect();
     const resolved: ArrowDef[] = [];
+    // Lane attack arrows that converge on the same player so several attackers
+    // don't stack their heads on one avatar.
+    const attackTargetCounts = new Map<string, number>();
+    for (const s of this.arrowSpecs) {
+      if (s.type === "attack" && s.to.kind === "player") {
+        attackTargetCounts.set(s.to.id, (attackTargetCounts.get(s.to.id) ?? 0) + 1);
+      }
+    }
+    const attackTargetSeen = new Map<string, number>();
     for (const spec of this.arrowSpecs) {
       const from = this.resolveArrowEndpoint(spec.from, canvasRect);
       const to = this.resolveTargetEndpoint(spec.to, canvasRect);
       if (!from || !to) continue;
+      if (spec.type === "attack" && spec.to.kind === "player") {
+        const total = attackTargetCounts.get(spec.to.id) ?? 1;
+        if (total > 1) {
+          const idx = attackTargetSeen.get(spec.to.id) ?? 0;
+          attackTargetSeen.set(spec.to.id, idx + 1);
+          to.pos.x += (idx - (total - 1) / 2) * ATTACK_ARROW_LANE_PX;
+        }
+      }
       const pointer = this.theme.gameTheme.pointer;
       const color =
         spec.hostile == null

--- a/src/pixi/board/BoardScene.ts
+++ b/src/pixi/board/BoardScene.ts
@@ -1415,8 +1415,6 @@ export class BoardScene {
       return [];
     const canvasRect = this.app.canvas.getBoundingClientRect();
     const resolved: ArrowDef[] = [];
-    // Lane attack arrows that converge on the same player so several attackers
-    // don't stack their heads on one avatar.
     const attackTargetCounts = new Map<string, number>();
     for (const s of this.arrowSpecs) {
       if (s.type === "attack" && s.to.kind === "player") {

--- a/src/pixi/board/BoardScene.ts
+++ b/src/pixi/board/BoardScene.ts
@@ -176,6 +176,10 @@ export class BoardScene {
   private arrowSpecs: ArrowSpec[] = [];
   private castingArrow: { sourceCardId: string; hostile: boolean } | null = null;
   private stackCardSeeds = new Map<string, { x: number; y: number; scale: number; ts: number }>();
+  private lastCardPositions = new Map<
+    string,
+    { x: number; y: number; scaleX: number; scaleY: number }
+  >();
   private stackProvider: StackAnchorProvider | null = null;
 
   private hoveredCell: GridCell | null = null;
@@ -957,6 +961,7 @@ export class BoardScene {
         ...(isLocal ? this.localBlockers() : []),
       ],
       getEntrySeed: (cardId) => this.entrySeedFor(playerId, isLocal, cardId),
+      recordCardExit: (cardId, seed) => this.lastCardPositions.set(cardId, seed),
       isSelected: (cardId) => (isLocal ? (this.selection?.has(cardId) ?? false) : false),
       rebuildOverlay: (entry, state) => {
         if (isLocal) this.overlay?.rebuild(entry, state);
@@ -1033,13 +1038,18 @@ export class BoardScene {
     if (isLocal && this.hand) {
       const live = this.hand.getLiveSpriteTransform(cardId);
       if (live) return live;
-      const stack = this.stackCardSeeds.get(cardId);
-      if (stack) return { x: stack.x, y: stack.y, scaleX: stack.scale, scaleY: stack.scale };
-      const origin = this.hand.getOriginSeed();
-      return { x: origin.x, y: origin.y, scaleX: origin.scale, scaleY: origin.scale };
+    }
+    const remembered = this.lastCardPositions.get(cardId);
+    if (remembered) {
+      this.lastCardPositions.delete(cardId);
+      return remembered;
     }
     const stack = this.stackCardSeeds.get(cardId);
     if (stack) return { x: stack.x, y: stack.y, scaleX: stack.scale, scaleY: stack.scale };
+    if (isLocal && this.hand) {
+      const origin = this.hand.getOriginSeed();
+      return { x: origin.x, y: origin.y, scaleX: origin.scale, scaleY: origin.scale };
+    }
     const zone = this.regions.get(playerId)?.zone;
     const scale = this.cardScale;
     if (!zone) return { x: 0, y: 0, scaleX: scale, scaleY: scale };

--- a/src/pixi/board/BoardZoneTiles.ts
+++ b/src/pixi/board/BoardZoneTiles.ts
@@ -27,8 +27,9 @@ export interface ZoneTileSpec {
   back?: boolean;
   /** Highlight colour when the zone is playable/targetable (else none). */
   highlightColor?: string;
-  /** The command zone holding a commander — draws the commander helm badge. */
-  commander?: boolean;
+  /** The command zone holding a commander — draws the commander helm badge in
+   *  this player's seat colour so it's clear whose commander it is. */
+  commander?: string;
   onOpen?: () => void;
 }
 
@@ -310,13 +311,9 @@ export class BoardZoneTiles {
           tile.outline.circle(bcx, bcy, br);
           tile.outline.fill({ color: hexToNum(gt.canvas.shadow), alpha: 0.85 });
           tile.outline.circle(bcx, bcy, br);
-          tile.outline.stroke({
-            color: hexToNum(gt.badges.commanderDamage),
-            width: 1.5,
-            alpha: 0.9,
-          });
+          tile.outline.stroke({ color: hexToNum(spec.commander), width: 1.5, alpha: 0.9 });
           const bs = Math.round(br * 1.5);
-          applyIcon(tile.badge, "overlord-helm", gt.badges.commanderDamage, 64, bs, bs);
+          applyIcon(tile.badge, "overlord-helm", spec.commander, 64, bs, bs);
           tile.badge.position.set(bcx, bcy);
           tile.badge.visible = true;
         } else if (tile.badge) {

--- a/src/pixi/board/BoardZoneTiles.ts
+++ b/src/pixi/board/BoardZoneTiles.ts
@@ -27,8 +27,8 @@ export interface ZoneTileSpec {
   back?: boolean;
   /** Highlight colour when the zone is playable/targetable (else none). */
   highlightColor?: string;
-  /** The command zone holding a commander — draws the commander helm badge in
-   *  this player's seat colour so it's clear whose commander it is. */
+  /** Seat colour for the commander helm badge; absent when the zone holds no
+   *  commander. */
   commander?: string;
   onOpen?: () => void;
 }

--- a/src/pixi/board/HandController.ts
+++ b/src/pixi/board/HandController.ts
@@ -416,6 +416,7 @@ export class HandController {
     const sprite = new CardSprite(card, "hand");
     sprite.eventMode = "static";
     sprite.cursor = this.lastState?.playableIds?.has(card.id) ? "grab" : "default";
+    sprite.onReorient = () => this.relayout();
 
     sprite.on("pointerdown", (e: FederatedPointerEvent) => {
       e.stopPropagation();

--- a/src/pixi/board/types.ts
+++ b/src/pixi/board/types.ts
@@ -105,6 +105,12 @@ export interface RegionHost {
   /** Seed transform for a newly-entering battlefield sprite (mirror of a
    *  hand sprite / stack card / hand-fan origin). */
   getEntrySeed(cardId: string): { x: number; y: number; scaleX: number; scaleY: number };
+  /** Remember a card's last on-screen transform as it leaves a region, so a
+   *  respawn in another region (combat-row move) seeds there and glides in. */
+  recordCardExit(
+    cardId: string,
+    seed: { x: number; y: number; scaleX: number; scaleY: number },
+  ): void;
   isSelected(cardId: string): boolean;
   rebuildOverlay(entry: SpriteEntry, state: BattlefieldState): void;
   /** Wire pointer events (drag/tap/hover) on a new battlefield sprite. */

--- a/src/pixi/board/types.ts
+++ b/src/pixi/board/types.ts
@@ -105,6 +105,10 @@ export interface RegionHost {
   /** Seed transform for a newly-entering battlefield sprite (mirror of a
    *  hand sprite / stack card / hand-fan origin). */
   getEntrySeed(cardId: string): { x: number; y: number; scaleX: number; scaleY: number };
+  /** Unclipped scene layer for combat-row attackers that travelled in from
+   *  another field, so they glide across the board (past accordion masks)
+   *  instead of being clipped to a collapsed defender's band. */
+  getCombatGuestLayer(): Container;
   /** Remember a card's last on-screen transform as it leaves a region, so a
    *  respawn in another region (combat-row move) seeds there and glides in. */
   recordCardExit(

--- a/src/pixi/constants.ts
+++ b/src/pixi/constants.ts
@@ -86,6 +86,10 @@ export const COMBAT_STAGE_SELF_EXTRA_PX = 18;
 export const COMBAT_BLOCKER_OVERLAP_FRAC = 0.4;
 export const COMBAT_ROW_STEP_FRAC = 1.12;
 export const Z_STAGED_REGION = 8000;
+// Combat-row attackers that travelled in from another player's field render in
+// an unclipped scene layer (above every region's accordion mask) so they glide
+// across the board into a collapsed defender's row instead of popping in.
+export const Z_COMBAT_GUEST = 8500;
 export const PHASE_STRIP_COMBAT_ALPHA = 0.25;
 export const COMBAT_DIM_ALPHA = 0.3;
 // Tint rather than alpha so overlapping stacked cards don't show through each

--- a/src/views/Game.tsx
+++ b/src/views/Game.tsx
@@ -7,6 +7,7 @@ import { usePreferencesStore } from "@/stores/usePreferencesStore";
 import { useAutoResolvePrompt } from "@/components/prompts/internal/useAutoResolvePrompt";
 import { useShallow } from "zustand/react/shallow";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
 import type { CardDto, PlayerDto, StackObjectDto } from "@/protocol/game";
 import { GameModals } from "@/components/game/GameModals";
 import { GameOverScreen } from "@/components/game/GameOverScreen";
@@ -1012,6 +1013,39 @@ export default function Game({ exitTo }: GameProps = {}) {
         .map((c) => ({ attackerId: c.id, defenderId: c.attackingPlayerId! })),
     [gameView?.battlefield],
   );
+
+  const combatPairings = useMemo(() => {
+    const names = new Map((gameView?.players ?? []).map((p) => [p.id, p.name]));
+    const pairs = new Map<string, { attacker: string; defender: string; count: number }>();
+    for (const c of gameView?.battlefield ?? []) {
+      if (!c.isAttacking || !c.attackingPlayerId) continue;
+      const key = `${c.controllerId}->${c.attackingPlayerId}`;
+      const existing = pairs.get(key);
+      if (existing) existing.count += 1;
+      else
+        pairs.set(key, {
+          attacker: names.get(c.controllerId) ?? "A player",
+          defender: names.get(c.attackingPlayerId) ?? "a player",
+          count: 1,
+        });
+    }
+    return pairs;
+  }, [gameView?.battlefield, gameView?.players]);
+  const combatSignature = useMemo(
+    () => [...combatPairings.keys()].sort().join("|"),
+    [combatPairings],
+  );
+  const prevCombatSignature = useRef("");
+  useEffect(() => {
+    if (combatSignature && combatSignature !== prevCombatSignature.current) {
+      for (const { attacker, defender, count } of combatPairings.values()) {
+        toast(`${attacker} attacks ${defender}`, {
+          description: `${count} ${count === 1 ? "attacker" : "attackers"}`,
+        });
+      }
+    }
+    prevCombatSignature.current = combatSignature;
+  }, [combatSignature, combatPairings]);
 
   const cardZoneTiles = useMemo(() => {
     const map = new Map<string, { playerId: string; key: string }>();

--- a/src/views/Game.tsx
+++ b/src/views/Game.tsx
@@ -7,7 +7,6 @@ import { usePreferencesStore } from "@/stores/usePreferencesStore";
 import { useAutoResolvePrompt } from "@/components/prompts/internal/useAutoResolvePrompt";
 import { useShallow } from "zustand/react/shallow";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { toast } from "sonner";
 import type { CardDto, PlayerDto, StackObjectDto } from "@/protocol/game";
 import { GameModals } from "@/components/game/GameModals";
 import { GameOverScreen } from "@/components/game/GameOverScreen";
@@ -50,6 +49,7 @@ import { declareAttackersOutput } from "@/components/prompts/internal/playerActi
 import { DamageOrderModal } from "@/components/prompts/DamageOrderModal";
 import { TargetingCursor } from "@/components/game/TargetingCursor";
 import { OPPONENT_SEATS } from "@/components/game/game.types";
+import type { CombatPairing } from "@/components/game/game.types";
 import { useStackUIStore } from "@/stores/useStackUIStore";
 import { useGameDevStore, DEBUG_KEYWORD_CARD_ID } from "@/stores/useGameDevStore";
 import { stackObjectToCardStub, isPermanentSpellCard } from "@/components/game/game.utils";
@@ -1014,12 +1014,12 @@ export default function Game({ exitTo }: GameProps = {}) {
     [gameView?.battlefield],
   );
 
-  const combatPairings = useMemo(() => {
+  const combatPairings = useMemo<CombatPairing[]>(() => {
     const nameOf = (id: string) =>
       id === myPlayerSlot
         ? "You"
         : (gameView?.players?.find((p) => p.id === id)?.name ?? "A player");
-    const pairs = new Map<string, { attacker: string; defender: string; count: number }>();
+    const pairs = new Map<string, CombatPairing>();
     for (const c of gameView?.battlefield ?? []) {
       if (!c.isAttacking || !c.attackingPlayerId) continue;
       const key = `${c.controllerId}->${c.attackingPlayerId}`;
@@ -1027,28 +1027,14 @@ export default function Game({ exitTo }: GameProps = {}) {
       if (existing) existing.count += 1;
       else
         pairs.set(key, {
+          key,
           attacker: nameOf(c.controllerId),
           defender: nameOf(c.attackingPlayerId),
           count: 1,
         });
     }
-    return pairs;
+    return [...pairs.values()];
   }, [gameView?.battlefield, gameView?.players, myPlayerSlot]);
-  const combatSignature = useMemo(
-    () => [...combatPairings.keys()].sort().join("|"),
-    [combatPairings],
-  );
-  const prevCombatSignature = useRef("");
-  useEffect(() => {
-    if (combatSignature && combatSignature !== prevCombatSignature.current) {
-      for (const { attacker, defender, count } of combatPairings.values()) {
-        toast(`${attacker} ${attacker === "You" ? "attack" : "attacks"} ${defender}`, {
-          description: `${count} ${count === 1 ? "attacker" : "attackers"}`,
-        });
-      }
-    }
-    prevCombatSignature.current = combatSignature;
-  }, [combatSignature, combatPairings]);
 
   const cardZoneTiles = useMemo(() => {
     const map = new Map<string, { playerId: string; key: string }>();
@@ -1634,6 +1620,7 @@ export default function Game({ exitTo }: GameProps = {}) {
                 blockRestrictionHint={blockRestrictionHint}
                 attackerIds={chooseBlockersInput?.attackers.map((a) => a.attackerId) ?? []}
                 blockAssignments={blockAssignments}
+                combatPairings={combatPairings}
                 onDeclareBlockers={(assignments) =>
                   respond({ type: "declareBlockers", assignments })
                 }

--- a/src/views/Game.tsx
+++ b/src/views/Game.tsx
@@ -1015,7 +1015,10 @@ export default function Game({ exitTo }: GameProps = {}) {
   );
 
   const combatPairings = useMemo(() => {
-    const names = new Map((gameView?.players ?? []).map((p) => [p.id, p.name]));
+    const nameOf = (id: string) =>
+      id === myPlayerSlot
+        ? "You"
+        : (gameView?.players?.find((p) => p.id === id)?.name ?? "A player");
     const pairs = new Map<string, { attacker: string; defender: string; count: number }>();
     for (const c of gameView?.battlefield ?? []) {
       if (!c.isAttacking || !c.attackingPlayerId) continue;
@@ -1024,13 +1027,13 @@ export default function Game({ exitTo }: GameProps = {}) {
       if (existing) existing.count += 1;
       else
         pairs.set(key, {
-          attacker: names.get(c.controllerId) ?? "A player",
-          defender: names.get(c.attackingPlayerId) ?? "a player",
+          attacker: nameOf(c.controllerId),
+          defender: nameOf(c.attackingPlayerId),
           count: 1,
         });
     }
     return pairs;
-  }, [gameView?.battlefield, gameView?.players]);
+  }, [gameView?.battlefield, gameView?.players, myPlayerSlot]);
   const combatSignature = useMemo(
     () => [...combatPairings.keys()].sort().join("|"),
     [combatPairings],
@@ -1039,7 +1042,7 @@ export default function Game({ exitTo }: GameProps = {}) {
   useEffect(() => {
     if (combatSignature && combatSignature !== prevCombatSignature.current) {
       for (const { attacker, defender, count } of combatPairings.values()) {
-        toast(`${attacker} attacks ${defender}`, {
+        toast(`${attacker} ${attacker === "You" ? "attack" : "attacks"} ${defender}`, {
           description: `${count} ${count === 1 ? "attacker" : "attackers"}`,
         });
       }


### PR DESCRIPTION
## Summary

- **Always-reserved combat row** — opponent fields permanently reserve the inner-edge combat-row band, so the three battlefield rows are sized once and never reflow when combat starts/ends; the row shows/hides inside the reserved strip.
- **Combat toast** — a "P1 attacks P2" toast (with attacker count) per attacker→defender pairing when combat is declared, deduped so it fires once per declaration.
- **Glide into the attack row** — attackers animate across the unified scene into the combat row instead of popping in (seed the respawn at the card's last on-screen position).
- **Lane attack arrows** — arrows converging on the same player fan out so several attackers don't stack their heads on one avatar.
- **Horizontal-card orientation fix** — recompute a card's frame orientation once the Scryfall layout loads, so split/aftermath cards classified before prefetch no longer disagree between the sprite render, `horizontalFrame`, and the hand: horizontal cards now sit vertical in hand and flip to read (button + `flip-card` key), returning to vertical on hover-out.
- **Commander helm badge** — tinted with each player's seat colour so it's clear whose commander is whose.

## Why

Review feedback on the multiplayer combat work: make combat engagement clearer, stop the opponent grid reflowing when the 4th attack row appears, animate attackers in, and de-overlap arrows. Plus two follow-up fixes surfaced while verifying — the horizontal-card hand flip was broken for split cards (orientation resolved before Scryfall loaded), and the commander badge wasn't player-coloured.

## Test plan

- `yarn lint` clean across all commits (eslint + prettier + tsc).
- Visual verification pending on the branch — the layout/animation/orientation changes are Pixi-rendered and want an eyeball pass: reserved-row height (3 rows stay put), glide easing, arrow lane spacing, the horizontal-card vertical↔landscape flip flow, and the seat-coloured helm.

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main