### PR TITLE
feat(ui): self combat row + board-layout polish + dev toggles

### DIFF
--- a/src/components/dev/BattlefieldKeywordDevControls.tsx
+++ b/src/components/dev/BattlefieldKeywordDevControls.tsx
@@ -63,6 +63,8 @@ export function BattlefieldKeywordDevControls() {
   const setDebugCardName = useGameDevStore((s) => s.setDebugCardName);
   const showHoverAreas = useGameDevStore((s) => s.showHoverAreas);
   const setShowHoverAreas = useGameDevStore((s) => s.setShowHoverAreas);
+  const showGridSkeleton = useGameDevStore((s) => s.showGridSkeleton);
+  const setShowGridSkeleton = useGameDevStore((s) => s.setShowGridSkeleton);
 
   const [draftName, setDraftName] = useState(debugCardName);
 
@@ -127,6 +129,27 @@ export function BattlefieldKeywordDevControls() {
             className={cn(
               "block h-4 w-4 rounded-full bg-background shadow-sm transition-transform",
               showHoverAreas ? "translate-x-4" : "translate-x-0.5",
+            )}
+          />
+        </button>
+      </label>
+
+      <label className="flex items-center justify-between gap-2 cursor-pointer">
+        <span className="text-xs">Show grid rows &amp; card skeletons (all players)</span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={showGridSkeleton}
+          className={cn(
+            "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors",
+            showGridSkeleton ? "border-primary bg-primary" : "border-border/70 bg-muted",
+          )}
+          onClick={() => setShowGridSkeleton(!showGridSkeleton)}
+        >
+          <span
+            className={cn(
+              "block h-4 w-4 rounded-full bg-background shadow-sm transition-transform",
+              showGridSkeleton ? "translate-x-4" : "translate-x-0.5",
             )}
           />
         </button>

--- a/src/components/dev/BattlefieldKeywordDevControls.tsx
+++ b/src/components/dev/BattlefieldKeywordDevControls.tsx
@@ -65,6 +65,8 @@ export function BattlefieldKeywordDevControls() {
   const setShowHoverAreas = useGameDevStore((s) => s.setShowHoverAreas);
   const showGridSkeleton = useGameDevStore((s) => s.showGridSkeleton);
   const setShowGridSkeleton = useGameDevStore((s) => s.setShowGridSkeleton);
+  const showAttackRows = useGameDevStore((s) => s.showAttackRows);
+  const setShowAttackRows = useGameDevStore((s) => s.setShowAttackRows);
 
   const [draftName, setDraftName] = useState(debugCardName);
 
@@ -150,6 +152,27 @@ export function BattlefieldKeywordDevControls() {
             className={cn(
               "block h-4 w-4 rounded-full bg-background shadow-sm transition-transform",
               showGridSkeleton ? "translate-x-4" : "translate-x-0.5",
+            )}
+          />
+        </button>
+      </label>
+
+      <label className="flex items-center justify-between gap-2 cursor-pointer">
+        <span className="text-xs">Show attack areas (all players)</span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={showAttackRows}
+          className={cn(
+            "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors",
+            showAttackRows ? "border-primary bg-primary" : "border-border/70 bg-muted",
+          )}
+          onClick={() => setShowAttackRows(!showAttackRows)}
+        >
+          <span
+            className={cn(
+              "block h-4 w-4 rounded-full bg-background shadow-sm transition-transform",
+              showAttackRows ? "translate-x-4" : "translate-x-0.5",
             )}
           />
         </button>

--- a/src/components/editor/usePlaymatPreview.ts
+++ b/src/components/editor/usePlaymatPreview.ts
@@ -6,24 +6,23 @@ import { CardSprite } from "@/pixi/CardSprite";
 import { CARD_W, CARD_H } from "@/components/game/game.constants";
 import { safeDestroy } from "@/pixi/board/pixiHelpers";
 import { useTheme } from "@/hooks/useTheme";
-import { useHandScale } from "@/hooks/useHandScale";
 import { PlaymatLayer, clampPlaymatZoom } from "@/pixi/board/PlaymatLayer";
 import { computeBoardLayout } from "@/pixi/board/boardLayout";
-import { HAND_CARD_BASE } from "@/components/game/game.styles";
-import { BG_ALPHA_IDLE, GAP, TABLE_RADIUS } from "@/pixi/constants";
+import { BG_ALPHA_IDLE, TABLE_RADIUS } from "@/pixi/constants";
 import { hexToNum } from "@/pixi/colorUtils";
 import type { PlaymatSettings } from "@/protocol/game";
 
 const clamp01 = (v: number): number => Math.max(0, Math.min(1, v));
 
 function useBattlefieldMetrics(): { aspect: number; feltWidth: number } {
-  const vScale = useHandScale();
   return useMemo(() => {
     const layout = computeBoardLayout(window.innerWidth, window.innerHeight, 1);
-    const handReserve = Math.round(0.55 * HAND_CARD_BASE.cardH * vScale) + GAP;
-    const feltHeight = Math.max(1, layout.self.height - handReserve);
+    // The in-game playmat fills the FULL field height (BoardRegion.bandZone),
+    // covering under the hand and player panel — so the preview aspect uses the
+    // full self height too, no hand-reserve trim.
+    const feltHeight = Math.max(1, layout.self.height);
     return { aspect: layout.self.width / feltHeight, feltWidth: layout.self.width };
-  }, [vScale]);
+  }, []);
 }
 
 interface PlaymatPreviewArgs {

--- a/src/components/game/GameBoard.tsx
+++ b/src/components/game/GameBoard.tsx
@@ -551,12 +551,15 @@ export function GameBoard({
     if (opponents.length === 0) return;
     function onKey(e: KeyboardEvent) {
       if (e.repeat || e.metaKey || e.ctrlKey || e.altKey) return;
-      if (e.code !== "BracketLeft" && e.code !== "BracketRight") return;
+      let dir: 1 | -1;
+      if (e.code === "Tab") dir = e.shiftKey ? -1 : 1;
+      else if (e.code === "BracketRight") dir = 1;
+      else if (e.code === "BracketLeft") dir = -1;
+      else return;
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
       if (document.querySelector('[role="dialog"]')) return;
       e.preventDefault();
       const ids = opponents.map((o) => o.id);
-      const dir = e.code === "BracketRight" ? 1 : -1;
       setManualFocusId((cur) => {
         const i = cur ? ids.indexOf(cur) : -1;
         if (i < 0) return dir === 1 ? ids[0]! : ids[ids.length - 1]!;
@@ -1007,12 +1010,7 @@ export function GameBoard({
         : playerColors[OPPONENT_SEATS[opponents.findIndex((o) => o.id === pid)] ?? "opponent1"];
     const nameOf = (pid: string): string =>
       pid === me.id ? "You" : (opponents.find((o) => o.id === pid)?.name ?? "Player");
-    const oppState = (cards: CardDto[], combatRow?: CombatRow): BattlefieldState => ({
-      cards,
-      attackingCardIds: promptType === "chooseBlockers" ? promptAttackerIds : undefined,
-      orderedCardIds: damageOrder,
-      selectableCardIds: selectableBattlefieldCardIds,
-      hostileTargeting,
+    const rowFields = (combatRow?: CombatRow): Partial<BattlefieldState> => ({
       combatRowAttackerIds: combatRow?.attackerIds,
       combatRowBlocks: combatRow?.blocks,
       combatRowGroups: combatRow?.groups.map((g) => ({
@@ -1021,6 +1019,14 @@ export function GameBoard({
         avatarUrl: avatarByPlayerId.get(g.controllerId),
         attackerIds: g.attackerIds,
       })),
+    });
+    const oppState = (cards: CardDto[], combatRow?: CombatRow): BattlefieldState => ({
+      cards,
+      attackingCardIds: promptType === "chooseBlockers" ? promptAttackerIds : undefined,
+      orderedCardIds: damageOrder,
+      selectableCardIds: selectableBattlefieldCardIds,
+      hostileTargeting,
+      ...rowFields(combatRow),
     });
 
     const selfCards = [...pixiBattlefield.cards];
@@ -1059,7 +1065,12 @@ export function GameBoard({
       {
         playerId: me.id,
         isLocal: true,
-        state: { ...pixiBattlefield, cards: selfCards, ownerRingByCard },
+        state: {
+          ...pixiBattlefield,
+          cards: selfCards,
+          ...rowFields(combatRowByDefender.get(me.id)),
+          ownerRingByCard,
+        },
         playmat: hiddenPlaymats.has(me.id)
           ? undefined
           : myDeckHasPlaymat

--- a/src/components/game/combatRows.ts
+++ b/src/components/game/combatRows.ts
@@ -10,12 +10,11 @@ export interface CombatRow {
 export interface CombatRowInput {
   battlefield: CardDto[];
   combatAssignments: CombatAssignmentDto[];
-  selfId: string;
   playerIds: string[];
 }
 
 export function buildCombatRows(input: CombatRowInput): CombatRow[] {
-  const { battlefield, combatAssignments, selfId, playerIds } = input;
+  const { battlefield, combatAssignments, playerIds } = input;
   const players = new Set(playerIds);
   const controllerById = new Map<string, string>();
   for (const c of battlefield) controllerById.set(c.id, c.controllerId);
@@ -37,7 +36,7 @@ export function buildCombatRows(input: CombatRowInput): CombatRow[] {
   for (const c of battlefield) {
     if (!c.isAttacking || !c.attackingPlayerId) continue;
     const defenderId = defenderOf(c.attackingPlayerId);
-    if (!defenderId || defenderId === selfId) continue;
+    if (!defenderId) continue;
     attackerDefender.set(c.id, defenderId);
     rowFor(defenderId).attackerIds.push(c.id);
   }

--- a/src/lib/horizontalGameCard.ts
+++ b/src/lib/horizontalGameCard.ts
@@ -2,22 +2,31 @@ import type { CardDto } from "@/protocol/game";
 import { isHorizontalCard } from "@/lib/cardLayout";
 import { peekCard, useScryfallStore } from "@/stores/useScryfallStore";
 
+function peekScryfall(card: CardDto) {
+  const { name, setCode, cardNumber } = card.identity;
+  // Empty set/number (e.g. the dev debug card) must fall through to a name-only
+  // lookup — passing "" would build a set+number key that never matches.
+  return peekCard(useScryfallStore.getState().cards, {
+    name,
+    setCode: setCode || undefined,
+    cardNumber: cardNumber || undefined,
+  });
+}
+
 export function scryfallLayoutOf(card: CardDto): string | undefined {
-  return (
-    peekCard(useScryfallStore.getState().cards, {
-      name: card.identity.name,
-      setCode: card.identity.setCode,
-      cardNumber: card.identity.cardNumber,
-    })?.layout ?? undefined
-  );
+  return peekScryfall(card)?.layout ?? undefined;
 }
 
 /** Horizontal-frame detection that survives a deck whose `layout` field isn't
  *  populated (split / aftermath / room report only their type line): fall back
- *  to the Scryfall-resolved layout, which the hand has already prefetched. */
+ *  to the Scryfall-resolved layout and type line, which the hand has already
+ *  prefetched. The type line catches type-based horizontals (Battle / Plane /
+ *  Phenomenon / Scheme) whose `types` array the source DTO may not carry. */
 export function isHorizontalGameCard(card: CardDto, deckLayout?: string): boolean {
+  const scry = peekScryfall(card);
   return isHorizontalCard({
-    layout: deckLayout ?? scryfallLayoutOf(card),
+    layout: deckLayout ?? scry?.layout ?? undefined,
     types: card.types,
+    typeLine: scry?.type_line,
   });
 }

--- a/src/pixi/BoardCanvas.tsx
+++ b/src/pixi/BoardCanvas.tsx
@@ -484,6 +484,12 @@ export function BoardCanvas({
     scene?.setHoverDebug(showHoverAreas);
   }, [scene, showHoverAreas]);
 
+  const showGridSkeleton = useGameDevStore((s) => s.showGridSkeleton);
+
+  useEffect(() => {
+    scene?.setGridSkeletonDebug(showGridSkeleton);
+  }, [scene, showGridSkeleton]);
+
   const inGameAnimations = usePreferencesStore((s) => s.inGameAnimations);
   useEffect(() => {
     setAnimationsEnabled(inGameAnimations);

--- a/src/pixi/BoardCanvas.tsx
+++ b/src/pixi/BoardCanvas.tsx
@@ -329,7 +329,8 @@ export function BoardCanvas({
     // band (two passes: the band height depends on the scale it reserves).
     const oppTopReserve = showPlayerBars ? PLAYER_BAR_HEIGHT_PX + PLAYER_BAR_TOP_MARGIN_PX * 2 : 0;
     const selfUsable = Math.max(1, layout.self.height - (selfBottomReserve ?? 0));
-    const selfScale = battlefieldScaleForFraction(selfUsable, fraction);
+    const selfBand = combatRowReserve(battlefieldScaleForFraction(selfUsable, fraction));
+    const selfScale = battlefieldScaleForFraction(Math.max(1, selfUsable - selfBand), fraction);
     const oppHeights = layout.opponents.map((o) => Math.max(1, o.rect.height - oppTopReserve));
     const oppUsable = oppHeights.length ? Math.min(...oppHeights) : selfUsable;
     const band = combatRowReserve(maxScaleForRows(oppUsable, BATTLEFIELD_MIN_ROWS));
@@ -496,6 +497,12 @@ export function BoardCanvas({
   useEffect(() => {
     scene?.setGridSkeletonDebug(showGridSkeleton);
   }, [scene, showGridSkeleton]);
+
+  const showAttackRows = useGameDevStore((s) => s.showAttackRows);
+
+  useEffect(() => {
+    scene?.setAttackRowDebug(showAttackRows);
+  }, [scene, showAttackRows]);
 
   const inGameAnimations = usePreferencesStore((s) => s.inGameAnimations);
   useEffect(() => {

--- a/src/pixi/BoardCanvas.tsx
+++ b/src/pixi/BoardCanvas.tsx
@@ -13,12 +13,14 @@ import {
 } from "./hud/PlayerHudLayer";
 import type { PlayerHudSpec as PlayerBarSpec } from "./hud/playerHud.types";
 import type { ZoneTileSpec } from "./board/BoardZoneTiles";
-import { battlefieldScaleForFraction } from "./GridLayout";
+import { battlefieldScaleForFraction, combatRowReserve, maxScaleForRows } from "./GridLayout";
 import { setPixiTextStyleTheme } from "./textStyles";
 import { getTheme } from "@/hooks/useTheme";
 import { usePreferencesStore } from "@/stores/usePreferencesStore";
 import { registerPixiApp } from "./visibility";
 import {
+  BATTLEFIELD_CARD_SCALE_FLOOR,
+  BATTLEFIELD_MIN_ROWS,
   HAND_ACTIONS_CLEAR_DELAY_MS,
   HAND_ACTIONS_GAP_PX,
   PIXI_MAX_FPS,
@@ -320,17 +322,22 @@ export function BoardCanvas({
     const h = app.renderer.height;
     const opponentCount = opponentIds.length;
     const layout = computeBoardLayout(w, h, opponentCount, selfHeightFraction);
-    // Subtract each region's reserved bands before picking the scale so ~3 rows
-    // stay visible in every region: the hand fan for self, the player bar (when
-    // shown) for opponents — otherwise the opponent grid loses a row to the bar.
+    // Each region is scaled to fill its OWN height — a single shared scale let
+    // the tightest field (self, after the hand-fan reserve) shrink everyone, so
+    // the roomier opponent fields wasted space. Self follows the card-scale
+    // preference; opponents lock to 3 rows beneath the always-reserved combat
+    // band (two passes: the band height depends on the scale it reserves).
     const oppTopReserve = showPlayerBars ? PLAYER_BAR_HEIGHT_PX + PLAYER_BAR_TOP_MARGIN_PX * 2 : 0;
     const selfUsable = Math.max(1, layout.self.height - (selfBottomReserve ?? 0));
-    const minHeight = Math.min(
-      selfUsable,
-      ...layout.opponents.map((o) => Math.max(1, o.rect.height - oppTopReserve)),
+    const selfScale = battlefieldScaleForFraction(selfUsable, fraction);
+    const oppHeights = layout.opponents.map((o) => Math.max(1, o.rect.height - oppTopReserve));
+    const oppUsable = oppHeights.length ? Math.min(...oppHeights) : selfUsable;
+    const band = combatRowReserve(maxScaleForRows(oppUsable, BATTLEFIELD_MIN_ROWS));
+    const oppScale = Math.max(
+      BATTLEFIELD_CARD_SCALE_FLOOR,
+      maxScaleForRows(Math.max(1, oppUsable - band), BATTLEFIELD_MIN_ROWS),
     );
-    const cardScale = battlefieldScaleForFraction(minHeight, fraction);
-    s.configure(players, layout, cardScale);
+    s.configure(players, layout, { self: selfScale, opponent: oppScale });
     const next: BoardCanvasLayout = {
       self: layout.self,
       dividerY: layout.dividerY,

--- a/src/pixi/GridLayout.ts
+++ b/src/pixi/GridLayout.ts
@@ -11,8 +11,17 @@ import {
   BATTLEFIELD_MIN_ROWS,
   BATTLEFIELD_MAX_ROWS,
   BATTLEFIELD_CARD_SCALE_FLOOR,
+  COMBAT_ROW_PAD_Y,
+  COMBAT_STAGE_PADDING_PX,
 } from "./constants";
 import type { PlayZoneRect } from "./types";
+
+/** Vertical band an opponent field reserves at its inner edge for the combat
+ *  row, so the grid rows are sized once and never reflow when combat appears.
+ *  Single source of truth — `BoardRegion.playArea` carves the same amount, and
+ *  `BoardCanvas` subtracts it before picking the scale so 3 grid rows survive. */
+export const combatRowReserve = (cardScale: number): number =>
+  CARD_H * cardScale + COMBAT_ROW_PAD_Y * 2 + COMBAT_STAGE_PADDING_PX;
 
 export interface GridBlocker {
   x: number;

--- a/src/pixi/board/BoardRegion.ts
+++ b/src/pixi/board/BoardRegion.ts
@@ -42,8 +42,6 @@ import {
   COMBAT_ROW_PAD_Y,
   COMBAT_ROW_STEP_FRAC,
   COMBAT_STAGE_FAN_FRAC,
-  COMBAT_STAGE_PADDING_PX,
-  COMBAT_STAGE_SELF_EXTRA_PX,
   GRID_SKELETON_FILL_ALPHA,
   GRID_SKELETON_HOVER_ALPHA,
   GRID_SKELETON_STACK_ALPHA,
@@ -66,7 +64,7 @@ import {
   Z_OVERLAY_OFFSET,
 } from "../constants";
 import type { BlockingRect, RegionHost, SceneCombatStaging, SpriteEntry } from "./types";
-import { COLLAPSED_OPPONENT_WIDTH_PX, STRIP_BAND_PX, type RegionOrientation } from "./boardLayout";
+import { COLLAPSED_OPPONENT_WIDTH_PX, type RegionOrientation } from "./boardLayout";
 import { PlaymatLayer, PLAYMAT_PADDING } from "./PlaymatLayer";
 import { loadAvatarTexture } from "../hud/avatarTextureCache";
 import { applyIcon } from "../panelIcons";
@@ -82,7 +80,6 @@ interface BoardRegionOptions {
 const ENTRANCE_LAND_PX = 8;
 const GLIDE_LAND_PX = 24;
 
-const COMBAT_ROW_INSET_X = 12;
 const COMBAT_ROW_AVATAR_D = 24;
 
 /** Keyed by the card object. The engine mints fresh `CardDto` objects per state
@@ -133,6 +130,8 @@ export class BoardRegion {
   private combatRowBlocks: CombatAssignmentDto[] = [];
   private combatRowBlockerIds = new Set<string>();
   private skeletonDebug = false;
+  private attackRowDebug = false;
+  private attackRowDebugGfx = new Graphics();
   private combatRowGroups: NonNullable<BattlefieldState["combatRowGroups"]> = [];
   private combatRowGfx = new Graphics();
   private combatRowLabels: Text[] = [];
@@ -182,6 +181,10 @@ export class BoardRegion {
     this.combatRowGfx.eventMode = "none";
     this.combatRowGfx.zIndex = Z_COMBAT_STAGED - 5;
     this.container.addChild(this.combatRowGfx);
+    this.attackRowDebugGfx.eventMode = "none";
+    this.attackRowDebugGfx.visible = false;
+    this.attackRowDebugGfx.zIndex = Z_COMBAT_STAGED - 6;
+    this.container.addChild(this.attackRowDebugGfx);
 
     this.gridSkeletonGfx = new Graphics();
     this.gridSkeletonGfx.eventMode = "none";
@@ -331,6 +334,7 @@ export class BoardRegion {
     // The playmat fits the visible band, so re-fit it as the band eases.
     this.playmat.layout(this.bandZone(), { dropActive: this.dropActive });
     if (this.combatRowAttackerIds.size > 0) this.applyCombatRow();
+    if (this.attackRowDebug) this.drawAttackRowDebug();
   }
 
   private updateClip(): void {
@@ -727,6 +731,7 @@ export class BoardRegion {
       }
     }
     if (this.skeletonDebug) this.refreshSkeletonDebug();
+    if (this.attackRowDebug) this.drawAttackRowDebug();
   }
 
   private applyAttackLunge(state: BattlefieldState): void {
@@ -788,12 +793,11 @@ export class BoardRegion {
     const ids = [...this.combatRowAttackerIds];
     const y = this.frontEdgeY();
     const cardW = CARD_W * this.cardScale;
-    const bandLeft = this.clipX ?? this.zone.x;
-    const bandWidth = this.clipWidth ?? this.zone.width;
+    const mat = this.playmatRect();
     const fullStep = cardW * COMBAT_ROW_STEP_FRAC;
-    const fitStep = ids.length > 1 ? (bandWidth - cardW) / (ids.length - 1) : fullStep;
+    const fitStep = ids.length > 1 ? (mat.width - cardW) / (ids.length - 1) : fullStep;
     const step = Math.max(0, Math.min(fullStep, fitStep));
-    const centerX = bandLeft + bandWidth / 2;
+    const centerX = mat.x + mat.width / 2;
     const startX = centerX - ((ids.length - 1) * step) / 2;
 
     const attackerX = new Map<string, number>();
@@ -835,8 +839,8 @@ export class BoardRegion {
 
     const red = hexToNum(this.host.getTheme().gameTheme.pt.lethal);
     const halfH = (CARD_H * this.cardScale) / 2;
-    const stripLeft = bandLeft + COMBAT_ROW_INSET_X;
-    const stripW = Math.max(1, bandWidth - COMBAT_ROW_INSET_X * 2);
+    const stripLeft = mat.x;
+    const stripW = mat.width;
     const stripTop = y - halfH - COMBAT_ROW_PAD_Y;
     const stripH = halfH * 2 + COMBAT_ROW_PAD_Y * 2;
     this.combatRowGfx.roundRect(stripLeft, stripTop, stripW, stripH, 10);
@@ -943,13 +947,14 @@ export class BoardRegion {
   }
 
   private frontEdgeY(): number {
-    const gap = STRIP_BAND_PX / 2 + COMBAT_STAGE_PADDING_PX + (CARD_H * this.cardScale) / 2;
+    const halfCard = (CARD_H * this.cardScale) / 2;
+    // Anchor the row's outer edge to the playmat border (bottom inner edge for
+    // opponents, top inner edge for us), not the raw field edge.
+    const mat = this.playmatRect();
     if (this.mirrored) {
-      const dividerY = this.zone.y + this.zone.height + STRIP_BAND_PX / 2;
-      return dividerY - gap;
+      return mat.y + mat.height - COMBAT_ROW_PAD_Y - halfCard;
     }
-    const dividerY = this.zone.y - STRIP_BAND_PX / 2;
-    return dividerY + gap - COMBAT_STAGE_SELF_EXTRA_PX;
+    return mat.y + COMBAT_ROW_PAD_Y + halfCard;
   }
 
   private applyNameGrouping(topLevel: CardDto[]): void {
@@ -1404,17 +1409,32 @@ export class BoardRegion {
     return { x: left, y, width: Math.max(1, right - left), height };
   }
 
+  /** The VISIBLE playmat rect — `PlaymatLayer`'s uniform inset of the band zone.
+   *  The combat row's strip + position align to this so they match the playmat
+   *  border on every side. Keep the inset in sync with `PlaymatLayer.layout`. */
+  private playmatRect(): PlayZoneRect {
+    const b = this.bandZone();
+    const pad = Math.min(b.width, b.height) * PLAYMAT_PADDING;
+    return {
+      x: b.x + pad,
+      y: b.y + pad,
+      width: Math.max(1, b.width - pad * 2),
+      height: Math.max(1, b.height - pad * 2),
+    };
+  }
+
   private playArea(): PlayZoneRect {
     const z = this.usableZone();
     const pad = Math.min(z.width, z.height) * PLAYMAT_PADDING;
-    // Opponent fields permanently reserve the inner-edge combat-row band so the
-    // three grid rows are sized once and never reflow when combat starts/ends;
-    // the row just shows/hides inside the reserved strip.
-    const reserve =
-      this.mirrored || this.combatRowAttackerIds.size > 0 ? combatRowReserve(this.cardScale) : 0;
+    // Every field permanently reserves the inner-edge combat-row band so the
+    // grid rows are sized once and never reflow when combat starts/ends; the row
+    // shows/hides inside the reserved strip. The inner edge (next to the divider)
+    // is the bottom for opponents and the top for the local player.
+    const reserve = combatRowReserve(this.cardScale);
+    const topReserve = this.mirrored ? 0 : reserve;
     return {
       x: z.x + pad,
-      y: z.y + pad,
+      y: z.y + pad + topReserve,
       width: Math.max(1, z.width - pad * 2),
       height: Math.max(1, z.height - pad * 2 - reserve),
     };
@@ -1635,6 +1655,35 @@ export class BoardRegion {
       this.gridSkeletonGfx.visible = false;
       this.gridSkeletonGfx.clear();
     }
+  }
+
+  /** Dev toggle: outline this region's reserved combat-row band (the attack
+   *  area) even when no attack is happening, for every player. */
+  setAttackRowDebug(on: boolean): void {
+    if (this.attackRowDebug === on) return;
+    this.attackRowDebug = on;
+    this.drawAttackRowDebug();
+  }
+
+  private drawAttackRowDebug(): void {
+    const gfx = this.attackRowDebugGfx;
+    gfx.clear();
+    if (!this.attackRowDebug) {
+      gfx.visible = false;
+      return;
+    }
+    const halfH = (CARD_H * this.cardScale) / 2;
+    const mat = this.playmatRect();
+    const stripLeft = mat.x;
+    const stripW = mat.width;
+    const stripTop = this.frontEdgeY() - halfH - COMBAT_ROW_PAD_Y;
+    const stripH = halfH * 2 + COMBAT_ROW_PAD_Y * 2;
+    const red = hexToNum(this.host.getTheme().gameTheme.pt.lethal);
+    gfx.roundRect(stripLeft, stripTop, stripW, stripH, 10);
+    gfx.fill({ color: red, alpha: 0.12 });
+    gfx.roundRect(stripLeft, stripTop, stripW, stripH, 10);
+    gfx.stroke({ color: red, width: 1.5, alpha: 0.7 });
+    gfx.visible = true;
   }
 
   drawGridSkeleton(

--- a/src/pixi/board/BoardRegion.ts
+++ b/src/pixi/board/BoardRegion.ts
@@ -131,6 +131,7 @@ export class BoardRegion {
   private combatRowAttackerIds = new Set<string>();
   private combatRowBlocks: CombatAssignmentDto[] = [];
   private combatRowBlockerIds = new Set<string>();
+  private skeletonDebug = false;
   private combatRowGroups: NonNullable<BattlefieldState["combatRowGroups"]> = [];
   private combatRowGfx = new Graphics();
   private combatRowLabels: Text[] = [];
@@ -724,6 +725,7 @@ export class BoardRegion {
         }
       }
     }
+    if (this.skeletonDebug) this.refreshSkeletonDebug();
   }
 
   private applyAttackLunge(state: BattlefieldState): void {
@@ -1608,8 +1610,28 @@ export class BoardRegion {
   }
 
   hideGridSkeleton(): void {
+    if (this.skeletonDebug) {
+      this.refreshSkeletonDebug();
+      return;
+    }
     this.gridSkeletonGfx.visible = false;
     this.gridSkeletonGfx.clear();
+  }
+
+  /** Dev toggle: keep every grid cell's card skeleton drawn for this region,
+   *  not just during a drag, so the locked rows are visible for all players. */
+  setSkeletonDebug(on: boolean): void {
+    if (this.skeletonDebug === on) return;
+    this.skeletonDebug = on;
+    this.refreshSkeletonDebug();
+  }
+
+  private refreshSkeletonDebug(): void {
+    if (this.skeletonDebug) this.drawGridSkeleton(new Set(), null, null);
+    else {
+      this.gridSkeletonGfx.visible = false;
+      this.gridSkeletonGfx.clear();
+    }
   }
 
   drawGridSkeleton(
@@ -1619,7 +1641,7 @@ export class BoardRegion {
   ): void {
     const gfx = this.gridSkeletonGfx;
     gfx.clear();
-    if (!this.gridInfo || draggingIds.size === 0) {
+    if (!this.gridInfo || (draggingIds.size === 0 && !this.skeletonDebug)) {
       gfx.visible = false;
       return;
     }

--- a/src/pixi/board/BoardRegion.ts
+++ b/src/pixi/board/BoardRegion.ts
@@ -8,6 +8,7 @@ import {
   cellFromPoint,
   cellKey,
   cellsByDistance,
+  combatRowReserve,
   computeGridLayout,
   type GridCell,
   type GridLayoutInfo,
@@ -38,6 +39,7 @@ import {
   EXIT_SHRINK,
   GAP,
   COMBAT_BLOCKER_OVERLAP_FRAC,
+  COMBAT_ROW_PAD_Y,
   COMBAT_ROW_STEP_FRAC,
   COMBAT_STAGE_FAN_FRAC,
   COMBAT_STAGE_PADDING_PX,
@@ -80,7 +82,6 @@ interface BoardRegionOptions {
 const ENTRANCE_LAND_PX = 8;
 const GLIDE_LAND_PX = 24;
 
-const COMBAT_ROW_PAD_Y = 8;
 const COMBAT_ROW_INSET_X = 12;
 const COMBAT_ROW_AVATAR_D = 24;
 
@@ -1388,15 +1389,19 @@ export class BoardRegion {
     return this.usableZone();
   }
 
-  /** The currently-VISIBLE field rect (usable zone ∩ clip band). The playmat
-   *  fits this so it sits inside each field with equal padding on all sides,
-   *  rather than being anchored to the fixed (canvas-right-extending) rect. */
+  /** The playmat's rect: the visible band horizontally (usable width ∩ clip),
+   *  but the FULL field height so it extends under the player panel / bar and
+   *  hand reserve rather than stopping at the reserve-trimmed usable zone. */
   private bandZone(): PlayZoneRect {
     const z = this.usableZone();
-    if (this.clipX === null || this.clipWidth === null) return z;
+    const y = this.zone.y;
+    const height = this.zone.height;
+    if (this.clipX === null || this.clipWidth === null) {
+      return { x: z.x, y, width: z.width, height };
+    }
     const left = Math.max(z.x, this.clipX);
     const right = Math.min(z.x + z.width, this.clipX + this.clipWidth);
-    return { x: left, y: z.y, width: Math.max(1, right - left), height: z.height };
+    return { x: left, y, width: Math.max(1, right - left), height };
   }
 
   private playArea(): PlayZoneRect {
@@ -1406,9 +1411,7 @@ export class BoardRegion {
     // three grid rows are sized once and never reflow when combat starts/ends;
     // the row just shows/hides inside the reserved strip.
     const reserve =
-      this.mirrored || this.combatRowAttackerIds.size > 0
-        ? CARD_H * this.cardScale + COMBAT_ROW_PAD_Y * 2 + COMBAT_STAGE_PADDING_PX
-        : 0;
+      this.mirrored || this.combatRowAttackerIds.size > 0 ? combatRowReserve(this.cardScale) : 0;
     return {
       x: z.x + pad,
       y: z.y + pad,

--- a/src/pixi/board/BoardScene.ts
+++ b/src/pixi/board/BoardScene.ts
@@ -198,6 +198,7 @@ export class BoardScene {
   private playerBlockers = new Map<string, BlockingRect[]>();
   private autoSort = false;
   private gridSkeletonDebug = false;
+  private attackRowDebug = false;
 
   // Delimiters (opponent clip bands). Owned and eased here, not in React.
   // `delimCurrent`/`delimTarget` are `count - 1` ascending fractions of width.
@@ -368,6 +369,7 @@ export class BoardScene {
       region.container.zIndex = zIndex;
       region.setAutoSort(this.autoSort);
       region.setSkeletonDebug(this.gridSkeletonDebug);
+      region.setAttackRowDebug(this.attackRowDebug);
       this.regions.set(spec.playerId, { region, zone, isLocal: spec.isLocal });
       if (spec.isLocal) {
         this.localPlayerId = spec.playerId;
@@ -983,6 +985,12 @@ export class BoardScene {
     for (const rec of this.regions.values()) rec.region.setSkeletonDebug(on);
   }
 
+  setAttackRowDebug(on: boolean): void {
+    if (this.destroyed) return;
+    this.attackRowDebug = on;
+    for (const rec of this.regions.values()) rec.region.setAttackRowDebug(on);
+  }
+
   setTheme(theme: Theme): void {
     if (this.destroyed) return;
     this.theme = theme;
@@ -1178,7 +1186,10 @@ export class BoardScene {
     sprite.eventMode = "static";
     sprite.cursor = "pointer";
     const region = this.regions.get(playerId)?.region;
-    if (isLocal) {
+    // A guest attacker sitting in the local player's combat row (an opponent's
+    // creature, controllerId ≠ us) must keep the attacker wiring — tap/drop to
+    // block — not the local drag wiring, or it can't be blocked.
+    if (isLocal && sprite.card.controllerId === playerId) {
       sprite.on("pointerdown", (e: FederatedPointerEvent) => {
         e.stopPropagation();
         this.onBattlefieldCardDown(sprite, e);

--- a/src/pixi/board/BoardScene.ts
+++ b/src/pixi/board/BoardScene.ts
@@ -197,6 +197,7 @@ export class BoardScene {
   private handInsetRight = 0;
   private playerBlockers = new Map<string, BlockingRect[]>();
   private autoSort = false;
+  private gridSkeletonDebug = false;
 
   // Delimiters (opponent clip bands). Owned and eased here, not in React.
   // `delimCurrent`/`delimTarget` are `count - 1` ascending fractions of width.
@@ -361,6 +362,7 @@ export class BoardScene {
       region.setPlaymat(spec.playmat);
       region.container.zIndex = zIndex;
       region.setAutoSort(this.autoSort);
+      region.setSkeletonDebug(this.gridSkeletonDebug);
       this.regions.set(spec.playerId, { region, zone, isLocal: spec.isLocal });
       if (spec.isLocal) {
         this.localPlayerId = spec.playerId;
@@ -968,6 +970,12 @@ export class BoardScene {
     setCardSpriteHoverDebug(on);
     for (const rec of this.regions.values()) rec.region.redrawHoverDebug();
     this.hand?.setHoverDebug(on);
+  }
+
+  setGridSkeletonDebug(on: boolean): void {
+    if (this.destroyed) return;
+    this.gridSkeletonDebug = on;
+    for (const rec of this.regions.values()) rec.region.setSkeletonDebug(on);
   }
 
   setTheme(theme: Theme): void {

--- a/src/pixi/board/BoardScene.ts
+++ b/src/pixi/board/BoardScene.ts
@@ -328,9 +328,13 @@ export class BoardScene {
     return this.app.canvas as HTMLCanvasElement;
   }
 
-  configure(players: BoardPlayerSpec[], layout: BoardLayout, cardScale: number): void {
+  configure(
+    players: BoardPlayerSpec[],
+    layout: BoardLayout,
+    scales: { self: number; opponent: number },
+  ): void {
     if (this.destroyed) return;
-    this.cardScale = cardScale;
+    this.cardScale = scales.self;
     const seen = new Set<string>();
     let oppIndex = 0;
 
@@ -338,6 +342,7 @@ export class BoardScene {
       const opp = spec.isLocal ? null : layout.opponents[oppIndex++];
       const zone = opp?.rect ?? layout.self;
       const orientation: RegionOrientation = spec.isLocal ? "bottom" : (opp?.orientation ?? "top");
+      const regionScale = spec.isLocal ? scales.self : scales.opponent;
       // The clip bands tile the canvas (no overlap), so z-order is cosmetic.
       const zIndex = spec.isLocal ? 100 : 50;
       seen.add(spec.playerId);
@@ -346,7 +351,7 @@ export class BoardScene {
         existing.zone = zone;
         existing.region.container.zIndex = zIndex;
         existing.region.setZone(zone, orientation);
-        existing.region.setCardScale(cardScale);
+        existing.region.setCardScale(regionScale);
         existing.region.setPlaymatSettings(spec.playmatSettings);
         existing.region.setPlaymat(spec.playmat);
         continue;
@@ -355,7 +360,7 @@ export class BoardScene {
         this.makeRegionHost(spec.playerId, spec.isLocal),
         this.root,
         zone,
-        cardScale,
+        regionScale,
         { orientation },
       );
       region.setPlaymatSettings(spec.playmatSettings);
@@ -393,7 +398,7 @@ export class BoardScene {
 
     this.positionPhaseStrip(layout);
     const selfZone = this.localZone();
-    this.dragHandler.setCardScale(cardScale);
+    this.dragHandler.setCardScale(scales.self);
     this.dragHandler.setContainerSize(this.app.renderer.width, this.app.renderer.height);
     if (selfZone && this.hand) this.dragHandler.setHandExclusion(this.hand.getBlockerRect());
   }

--- a/src/pixi/board/HandController.ts
+++ b/src/pixi/board/HandController.ts
@@ -195,7 +195,7 @@ export class HandController {
       // them landscape to read, and they animate back on hover-out.
       const verticalInHand = sprite.horizontalFrame && this.flippedHorizontalId !== card.id;
       let rot = isSelected || isCastingPermanent ? 0 : (l.rotation * Math.PI) / 180;
-      if (verticalInHand) rot += Math.PI / 2;
+      if (verticalInHand) rot -= Math.PI / 2;
       this.targets.set(card.id, {
         x: centerX + l.x,
         y: bottomY + l.y - l.scaleH / 2 + selectedDrop + castOffset,

--- a/src/pixi/constants.ts
+++ b/src/pixi/constants.ts
@@ -80,6 +80,7 @@ export const CAST_DRAG_HAND_SINK_PX = 200;
 export const EXIT_FADE_LERP = 0.2;
 export const EXIT_SHRINK = 0.95;
 export const COMBAT_STAGE_PADDING_PX = 6;
+export const COMBAT_ROW_PAD_Y = 8;
 // Extra upward tilt for the local player's staged creatures — the self region
 // sits right at the bar, so its creatures can come up a touch further.
 export const COMBAT_STAGE_SELF_EXTRA_PX = 18;

--- a/src/stores/useGameDevStore.ts
+++ b/src/stores/useGameDevStore.ts
@@ -172,6 +172,8 @@ interface GameDevState {
   debugCardName: string;
   showHoverAreas: boolean;
   setShowHoverAreas: (value: boolean) => void;
+  showGridSkeleton: boolean;
+  setShowGridSkeleton: (value: boolean) => void;
   setPromptActionOverride: (value: DevPromptActionOverride | null) => void;
   setDevToolsEnabled: (value: boolean) => void;
   clearPromptActionOverride: () => void;
@@ -207,6 +209,8 @@ export const useGameDevStore = create<GameDevState>()(
       debugCardName: "Raging Goblin",
       showHoverAreas: false,
       setShowHoverAreas: (value) => set({ showHoverAreas: value }),
+      showGridSkeleton: false,
+      setShowGridSkeleton: (value) => set({ showGridSkeleton: value }),
       setPromptActionOverride: (value) => set({ promptActionOverride: value }),
       setDevToolsEnabled: (value) => set({ devToolsEnabled: value }),
       clearPromptActionOverride: () => set({ promptActionOverride: null }),
@@ -246,6 +250,7 @@ export const useGameDevStore = create<GameDevState>()(
           debugCardEnabled: false,
           debugCardName: "Raging Goblin",
           showHoverAreas: false,
+          showGridSkeleton: false,
         }),
     }),
     { name: "gameDev", enabled: import.meta.env.DEV },

--- a/src/stores/useGameDevStore.ts
+++ b/src/stores/useGameDevStore.ts
@@ -174,6 +174,8 @@ interface GameDevState {
   setShowHoverAreas: (value: boolean) => void;
   showGridSkeleton: boolean;
   setShowGridSkeleton: (value: boolean) => void;
+  showAttackRows: boolean;
+  setShowAttackRows: (value: boolean) => void;
   setPromptActionOverride: (value: DevPromptActionOverride | null) => void;
   setDevToolsEnabled: (value: boolean) => void;
   clearPromptActionOverride: () => void;
@@ -211,6 +213,8 @@ export const useGameDevStore = create<GameDevState>()(
       setShowHoverAreas: (value) => set({ showHoverAreas: value }),
       showGridSkeleton: false,
       setShowGridSkeleton: (value) => set({ showGridSkeleton: value }),
+      showAttackRows: false,
+      setShowAttackRows: (value) => set({ showAttackRows: value }),
       setPromptActionOverride: (value) => set({ promptActionOverride: value }),
       setDevToolsEnabled: (value) => set({ devToolsEnabled: value }),
       clearPromptActionOverride: () => set({ promptActionOverride: null }),
@@ -251,6 +255,7 @@ export const useGameDevStore = create<GameDevState>()(
           debugCardName: "Raging Goblin",
           showHoverAreas: false,
           showGridSkeleton: false,
+          showAttackRows: false,
         }),
     }),
     { name: "gameDev", enabled: import.meta.env.DEV },

--- a/src/views/Game.tsx
+++ b/src/views/Game.tsx
@@ -990,12 +990,16 @@ export default function Game({ exitTo }: GameProps = {}) {
       gameView
         ? buildCombatRows({
             battlefield: gameView.battlefield,
-            combatAssignments,
-            selfId: me?.id ?? "",
+            combatAssignments: [
+              ...combatAssignments,
+              ...blockAssignments.filter(
+                (b) => !combatAssignments.some((c) => c.blockerId === b.blockerId),
+              ),
+            ],
             playerIds: gameView.players.map((p) => p.id),
           })
         : [],
-    [gameView, combatAssignments, me?.id],
+    [gameView, combatAssignments, blockAssignments],
   );
   const oppCombatAttackerIds = useMemo(
     () => new Set(combatRows.flatMap((r) => r.attackerIds)),


### PR DESCRIPTION
## Summary

Builds on the multiplayer battlefield accordion with a 4th combat row for the local player, board-layout fixes, and dev tooling.

- **Self combat row** — opponents attacking you now move into a 4th combat row at your field's top inner edge, mirroring opponent rows exactly: attackers glide in, blocks fan in the row, attack arrows suppress. Blocking interaction restored for guest attackers (opponent creatures sitting in the local region got the wrong sprite wiring).
- **Per-region card scale** — each field is sized to fill its own height instead of one global scale shrinking everything to the tightest field. Self follows the card-scale preference; opponents lock to 3 grid rows + the always-reserved combat band.
- **Combat row ↔ playmat alignment** — the combat row and its strip anchor to the playmat's inset rect (`PlaymatLayer` pad) on all four sides, clear of the phase bar.
- **Taller playmat** — fills the full field height (covers under the player panel / hand); reflected in the deck playmat-editor preview aspect.
- **Debug-card horizontal fix** — split/battle/room debug cards render landscape in both the sprite and hover preview (name-only Scryfall peek + `type_line`).
- **Horizontal cards in hand** — now sit upright (were upside-down) vertical-in-hand.
- **Dev toggles** — "show grid rows & card skeletons" and "show attack areas" for every player.
- **Field focus cycling** — Tab / Shift+Tab (and `[` / `]`) cycle opponent field focus.

## Why

The accordion reserves a combat band per opponent so combat never reflows the grid; this extends the same treatment to the local player and fixes the layout fallout discovered while testing (cards shrinking, attack rows overlapping the phase bar / sitting outside the playmat, horizontal cards upside-down in hand). The dev toggles make the reserved-row geometry inspectable, which surfaced several of these bugs.

## Test plan

- `yarn tsc`, `eslint`, and `prettier --check` clean across all changed files.
- Visual verification pending — Pixi-rendered layout/animation changes want an eyeball pass: opponent-attacks-you row + blocking, per-field card sizes, attack-area toggle alignment to the playmat border, horizontal hand-card orientation, and the focus-cycling keys.

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
