### PR TITLE
feat(ui): drag creatures onto opponents to declare attackers

### DIFF
--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveSession.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveSession.java
@@ -2133,6 +2133,13 @@ public final class ManaBrewInteractiveSession {
         if (defender instanceof Player) {
             return "player-" + SnapshotExtractor.playerIndex(game, (Player) defender);
         }
+        // A planeswalker / battle defender publishes its card id so it matches the
+        // sprite the UI targets (mirrors the Rust host, which keys permanent
+        // defenders by card id). Both the prompt emit and findDefenderByPublishedId
+        // route through here, so the response round-trip stays consistent.
+        if (defender instanceof Card) {
+            return SnapshotExtractor.javaCardId((Card) defender);
+        }
         return "defender-" + defender.getId();
     }
 

--- a/src/components/editor/DeckListView.tsx
+++ b/src/components/editor/DeckListView.tsx
@@ -1,4 +1,12 @@
-import { useState, useCallback, useEffect, useLayoutEffect, useRef, useMemo } from "react";
+import {
+  forwardRef,
+  useState,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useMemo,
+} from "react";
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -762,30 +770,30 @@ function CardVisual({
   );
 }
 
-function DraggableMiniRow({
-  dragId,
-  card,
-  className,
-  children,
-  onMouseEnter,
-  onMouseMove,
-  onMouseLeave,
-}: {
-  dragId: string;
-  card: DeckCard;
-  className?: string;
-  children: React.ReactNode;
-  onMouseEnter?: (e: React.MouseEvent) => void;
-  onMouseMove?: (e: React.MouseEvent) => void;
-  onMouseLeave?: () => void;
-}) {
+const DraggableMiniRow = forwardRef<
+  HTMLDivElement,
+  {
+    dragId: string;
+    card: DeckCard;
+    className?: string;
+    children: React.ReactNode;
+  } & React.HTMLAttributes<HTMLDivElement>
+>(function DraggableMiniRow({ dragId, card, className, children, ...rest }, forwardedRef) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: dragId,
     data: { type: "deck-card", card, name: card.identity.name },
   });
+  // Merge dnd-kit's node ref with any ref injected by a wrapping
+  // ContextMenuTrigger (`asChild`), which also needs it to anchor the menu.
+  const setRefs = (node: HTMLDivElement | null) => {
+    setNodeRef(node);
+    if (typeof forwardedRef === "function") forwardedRef(node);
+    else if (forwardedRef) forwardedRef.current = node;
+  };
   return (
     <div
-      ref={setNodeRef}
+      ref={setRefs}
+      {...rest}
       {...listeners}
       {...attributes}
       className={cn(
@@ -794,14 +802,11 @@ function DraggableMiniRow({
         isDragging && "opacity-30",
       )}
       data-card-name={card.identity.name}
-      onMouseEnter={onMouseEnter}
-      onMouseMove={onMouseMove}
-      onMouseLeave={onMouseLeave}
     >
       {children}
     </div>
   );
-}
+});
 
 // ─── List Row ─────────────────────────────────────────────────────────────────
 

--- a/src/components/editor/DeckListView.tsx
+++ b/src/components/editor/DeckListView.tsx
@@ -399,6 +399,8 @@ function DraggableStackCard({
   topOffset,
   onCardHover,
   onCardLeave,
+  contextLocation,
+  contextActions,
 }: {
   group: CardGroup;
   dragId: string;
@@ -413,6 +415,8 @@ function DraggableStackCard({
   topOffset: number;
   onCardHover: (index: number) => void;
   onCardLeave: () => void;
+  contextLocation?: CardLocation;
+  contextActions?: CardContextActions;
 }) {
   const { name } = group.card.identity;
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
@@ -423,7 +427,7 @@ function DraggableStackCard({
   const isCombo = useIsComboCard(name);
   const isGameChanger = useIsGameChangerCard(name);
 
-  return (
+  const content = (
     <div
       ref={setNodeRef}
       {...listeners}
@@ -458,6 +462,13 @@ function DraggableStackCard({
         rounded="rounded-[4%]"
       />
     </div>
+  );
+
+  if (!contextActions || !contextLocation) return content;
+  return (
+    <CardContextMenu count={group.count} location={contextLocation} {...contextActions}>
+      {content}
+    </CardContextMenu>
   );
 }
 
@@ -512,6 +523,7 @@ interface StackColumnProps {
   onSelectCard?: (cardName: string, addToSelection: boolean) => void;
   onShowInfo?: (cardName: string) => void;
   dragHandleProps?: DragHandleProps;
+  contextMenuFor?: (g: CardGroup) => { location: CardLocation; actions: CardContextActions } | null;
 }
 
 function StackColumn({
@@ -526,6 +538,7 @@ function StackColumn({
   onSelectCard,
   onShowInfo,
   dragHandleProps,
+  contextMenuFor,
 }: StackColumnProps) {
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
   const cardHeight = Math.round(cardWidth * 1.4);
@@ -566,24 +579,29 @@ function StackColumn({
         className="relative transition-[height] duration-200 ease-out"
         style={{ height: totalHeight }}
       >
-        {groups.map((g, i) => (
-          <DraggableStackCard
-            key={g.card.identity.name}
-            group={g}
-            dragId={`deck-${sectionId}-${g.card.identity.name}`}
-            cardWidth={cardWidth}
-            index={i}
-            onAddOne={() => onAddOne(g)}
-            onRemoveOne={() => onRemoveOne(g.card.identity.name)}
-            onUntag={onUntag ? () => onUntag(g.card.identity.name) : undefined}
-            isSelected={selectedCards?.has(g.card.identity.name.toLowerCase())}
-            onSelect={onSelectCard}
-            onShowInfo={onShowInfo ? () => onShowInfo(g.card.identity.name) : undefined}
-            topOffset={getTop(i)}
-            onCardHover={setHoveredIdx}
-            onCardLeave={() => setHoveredIdx(null)}
-          />
-        ))}
+        {groups.map((g, i) => {
+          const cm = contextMenuFor?.(g);
+          return (
+            <DraggableStackCard
+              key={g.card.identity.name}
+              group={g}
+              dragId={`deck-${sectionId}-${g.card.identity.name}`}
+              cardWidth={cardWidth}
+              index={i}
+              onAddOne={() => onAddOne(g)}
+              onRemoveOne={() => onRemoveOne(g.card.identity.name)}
+              onUntag={onUntag ? () => onUntag(g.card.identity.name) : undefined}
+              isSelected={selectedCards?.has(g.card.identity.name.toLowerCase())}
+              onSelect={onSelectCard}
+              onShowInfo={onShowInfo ? () => onShowInfo(g.card.identity.name) : undefined}
+              topOffset={getTop(i)}
+              onCardHover={setHoveredIdx}
+              onCardLeave={() => setHoveredIdx(null)}
+              contextLocation={cm?.location}
+              contextActions={cm?.actions}
+            />
+          );
+        })}
       </div>
     </div>
   );
@@ -1697,7 +1715,32 @@ export function DeckListView({
                 })
               }
               onRemoveOne={onRemoveFromSide}
+              onShowInfo={onShowInfo}
               dragHandleProps={dhProps}
+              contextMenuFor={(g) => ({
+                location: "side",
+                actions: {
+                  onAddOne: () =>
+                    onAddToSide({
+                      ...g.card,
+                      identity: { ...g.card.identity, id: crypto.randomUUID() },
+                    }),
+                  onRemoveOne: () => onRemoveFromSide(g.card.identity.name),
+                  onMoveOneToMain: () => onMoveOneFromSideToMain(g.card.identity.name),
+                  onMoveAllToMain: () => onMoveAllFromSideToMain(g.card.identity.name),
+                  onMoveOneToMaybe: () => onMoveOneFromSideToMaybe(g.card.identity.name),
+                  onMoveAllToMaybe: () => onMoveAllFromSideToMaybe(g.card.identity.name),
+                  onShowInfo: onShowInfo ? () => onShowInfo(g.card.identity.name) : undefined,
+                  onPickPrint: () => onPickPrint(g.card.identity.name),
+                  onToggleFoil: onToggleFoil ? () => onToggleFoil(g.card.identity.name) : undefined,
+                  isFoil: !!g.card.identity.foil,
+                  customTags,
+                  appliedTags: cardTags?.[g.card.identity.name.toLowerCase()],
+                  onApplyTag: (t) => applyCardTag(g.card.identity.name, t),
+                  onRemoveCustomTag: onRemoveTag,
+                  onCreateTag: (t) => createAndApplyTag(g.card.identity.name, t),
+                },
+              })}
             />
           ) : (
             <EmptyStackBoard label="Sideboard" cardWidth={cardWidth} dragHandleProps={dhProps} />
@@ -1733,7 +1776,32 @@ export function DeckListView({
                 })
               }
               onRemoveOne={onRemoveFromMaybe}
+              onShowInfo={onShowInfo}
               dragHandleProps={dhProps}
+              contextMenuFor={(g) => ({
+                location: "maybe",
+                actions: {
+                  onAddOne: () =>
+                    onAddToMaybe({
+                      ...g.card,
+                      identity: { ...g.card.identity, id: crypto.randomUUID() },
+                    }),
+                  onRemoveOne: () => onRemoveFromMaybe(g.card.identity.name),
+                  onMoveOneToMain: () => onMoveOneFromMaybeToMain(g.card.identity.name),
+                  onMoveAllToMain: () => onMoveAllFromMaybeToMain(g.card.identity.name),
+                  onMoveOneToSide: () => onMoveOneFromMaybeToSide(g.card.identity.name),
+                  onMoveAllToSide: () => onMoveAllFromMaybeToSide(g.card.identity.name),
+                  onShowInfo: onShowInfo ? () => onShowInfo(g.card.identity.name) : undefined,
+                  onPickPrint: () => onPickPrint(g.card.identity.name),
+                  onToggleFoil: onToggleFoil ? () => onToggleFoil(g.card.identity.name) : undefined,
+                  isFoil: !!g.card.identity.foil,
+                  customTags,
+                  appliedTags: cardTags?.[g.card.identity.name.toLowerCase()],
+                  onApplyTag: (t) => applyCardTag(g.card.identity.name, t),
+                  onRemoveCustomTag: onRemoveTag,
+                  onCreateTag: (t) => createAndApplyTag(g.card.identity.name, t),
+                },
+              })}
             />
           ) : (
             <EmptyStackBoard label="Maybeboard" cardWidth={cardWidth} dragHandleProps={dhProps} />

--- a/src/components/game/GameBoard.tsx
+++ b/src/components/game/GameBoard.tsx
@@ -103,6 +103,8 @@ interface GameBoardProps {
   onAttackerClick: (card: CardDto) => void;
   onAssignBlock: (blockerId: string, attackerId: string) => void;
   onUnassignBlock: (blockerId: string) => void;
+  onAssignAttacker: (attackerId: string, targetId: string) => void;
+  onUnassignAttacker: (attackerId: string) => void;
   onTargetPlayer: (playerId: string) => void;
   onShowBoardMenu?: () => void;
   onOpenZone: (
@@ -193,6 +195,8 @@ export function GameBoard({
   onAttackerClick,
   onAssignBlock,
   onUnassignBlock,
+  onAssignAttacker,
+  onUnassignAttacker,
   onTargetPlayer,
   onShowBoardMenu,
   onOpenZone,
@@ -235,6 +239,7 @@ export function GameBoard({
   const payManaCostPrompt = promptOf(currentPrompt, "payManaCost");
   const promptAttackerIds = chooseBlockersPrompt?.input.attackers.map((a) => a.attackerId);
   const [dragBlockerId, setDragBlockerId] = useState<string | null>(null);
+  const [dragAttackerId, setDragAttackerId] = useState<string | null>(null);
   const [sheetPlayerId, setSheetPlayerId] = useState<string | null>(null);
 
   // On our turn, one opponent field stays expanded (sticky) instead of an even
@@ -312,6 +317,23 @@ export function GameBoard({
                   .filter((t) => playerIsTargetable(t.id))
                   .map((t) => t.id) ?? [])
               : []),
+            ...(dragAttackerId
+              ? (() => {
+                  const valid =
+                    chooseAttackersPrompt?.input.attackers.find(
+                      (a) => a.attackerId === dragAttackerId,
+                    )?.validTargetIds ?? [];
+                  return (
+                    chooseAttackersPrompt?.input.attackTargets
+                      .filter(
+                        (t) =>
+                          (t.kind === "planeswalker" || t.kind === "battle") &&
+                          valid.includes(t.id),
+                      )
+                      .map((t) => t.id) ?? []
+                  );
+                })()
+              : []),
           ]
         : promptType === "chooseBlockers"
           ? pendingAttacker
@@ -343,6 +365,7 @@ export function GameBoard({
       pendingAttacker,
       pendingBlocker,
       dragBlockerId,
+      dragAttackerId,
       chooseBlockersPrompt,
       damageOrderBlockerIds,
       boardTargets,
@@ -454,6 +477,9 @@ export function GameBoard({
       onAssignBlock,
       onUnassignBlock,
       onBlockDragChange: setDragBlockerId,
+      onAssignAttacker,
+      onUnassignAttacker,
+      onAttackDragChange: setDragAttackerId,
       onHoverOpponent: (playerId) => {
         hoveredOpponentRef.current = playerId;
         if (playerId && isSelfTurn) setStickyOpponentId(playerId);
@@ -480,9 +506,12 @@ export function GameBoard({
       onAttackerClick,
       onAssignBlock,
       onUnassignBlock,
+      onAssignAttacker,
+      onUnassignAttacker,
       onTargetPlayer,
       onShowBoardMenu,
       setDragBlockerId,
+      setDragAttackerId,
       setSheetPlayerId,
       setStickyOpponentId,
       isSelfTurn,
@@ -1208,6 +1237,9 @@ export function GameBoard({
           castingArrow={castingArrow}
           declareBlockers={promptType === "chooseBlockers"}
           combatBlocks={combatAssignmentsAll}
+          declareAttackers={promptType === "chooseAttackers"}
+          attackTargets={chooseAttackersPrompt?.input.attackTargets ?? []}
+          attackerOptions={chooseAttackersPrompt?.input.attackers ?? []}
           phaseStrip={pixiPhaseStrip}
           phaseStripCallbacks={pixiPhaseStripCallbacks}
           focusedOpponentId={focusedOpponentId}

--- a/src/components/game/GameBoard.tsx
+++ b/src/components/game/GameBoard.tsx
@@ -372,6 +372,17 @@ export function GameBoard({
       chooseActionAbilityCardIds,
     ],
   );
+  const hostileAttackTargetIds = useMemo(
+    () =>
+      new Set(
+        promptType === "chooseAttackers"
+          ? (chooseAttackersPrompt?.input.attackTargets
+              .filter((t) => t.kind === "planeswalker" || t.kind === "battle")
+              .map((t) => t.id) ?? [])
+          : [],
+      ),
+    [promptType, chooseAttackersPrompt],
+  );
   const pixiBattlefield = useMemo(
     (): BattlefieldState => ({
       cards: myPermanents,
@@ -399,6 +410,10 @@ export function GameBoard({
       untappableLandIds: promptActions?.filter((a) => a.type === "undoMana").map((a) => a.cardId),
       manaAbilityOptions,
       hostileTargeting,
+      hostileTargetCardIds:
+        promptType === "chooseAttackers"
+          ? selectableBattlefieldCardIds.filter((id) => hostileAttackTargetIds.has(id))
+          : undefined,
     }),
     [
       myPermanents,
@@ -414,6 +429,7 @@ export function GameBoard({
       promptActions,
       manaAbilityOptions,
       hostileTargeting,
+      hostileAttackTargetIds,
     ],
   );
 

--- a/src/components/game/arrowSpecs.ts
+++ b/src/components/game/arrowSpecs.ts
@@ -8,10 +8,10 @@ export interface BuildArrowSpecsOptions {
   attackerIds: string[];
   blockAssignments: { blockerId: string; attackerId: string }[];
   combatAssignments: { blockerId: string; attackerId: string }[];
-  // Pre-commit pending attackers are signalled via card-tap visuals only
-  // (Game.tsx), never an arrow — multiple opponents / planeswalkers / sieges
-  // make any "default" destination misleading.
-  activeAttackers: { attackerId: string; defenderId: string }[];
+  // Attacker→target arrows. `targetKind` picks the endpoint: "player" anchors to
+  // the defender's avatar; "card" anchors to the specific planeswalker/battle
+  // being attacked (drag-declared attacks know their exact target).
+  activeAttackers: { attackerId: string; targetId: string; targetKind: "player" | "card" }[];
   stack?: StackObjectDto[];
   activeStackObjectId?: string | null;
   stageBlockers?: boolean;
@@ -44,10 +44,10 @@ export function buildArrowSpecs(opts: BuildArrowSpecsOptions): ArrowSpec[] {
 
   const specs: ArrowSpec[] = [];
 
-  for (const { attackerId, defenderId } of activeAttackers) {
+  for (const { attackerId, targetId, targetKind } of activeAttackers) {
     specs.push({
       from: { kind: "card", id: attackerId },
-      to: { kind: "player", id: defenderId },
+      to: targetKind === "card" ? { kind: "card", id: targetId } : { kind: "player", id: targetId },
       type: "attack",
     });
   }

--- a/src/components/game/combatRows.ts
+++ b/src/components/game/combatRows.ts
@@ -11,10 +11,14 @@ export interface CombatRowInput {
   battlefield: CardDto[];
   combatAssignments: CombatAssignmentDto[];
   playerIds: string[];
+  /** In-progress (pre-commit) attacker→target assignments from the local
+   *  declaration, staged into the defender's row exactly like committed
+   *  attackers so drag-declared creatures slide into the attack band. */
+  pendingAttacks?: { attackerId: string; targetId: string }[];
 }
 
 export function buildCombatRows(input: CombatRowInput): CombatRow[] {
-  const { battlefield, combatAssignments, playerIds } = input;
+  const { battlefield, combatAssignments, playerIds, pendingAttacks } = input;
   const players = new Set(playerIds);
   const controllerById = new Map<string, string>();
   for (const c of battlefield) controllerById.set(c.id, c.controllerId);
@@ -39,6 +43,14 @@ export function buildCombatRows(input: CombatRowInput): CombatRow[] {
     if (!defenderId) continue;
     attackerDefender.set(c.id, defenderId);
     rowFor(defenderId).attackerIds.push(c.id);
+  }
+
+  for (const { attackerId, targetId } of pendingAttacks ?? []) {
+    if (attackerDefender.has(attackerId)) continue;
+    const defenderId = defenderOf(targetId);
+    if (!defenderId) continue;
+    attackerDefender.set(attackerId, defenderId);
+    rowFor(defenderId).attackerIds.push(attackerId);
   }
 
   for (const a of combatAssignments) {

--- a/src/components/prompts/ChooseAttackers.tsx
+++ b/src/components/prompts/ChooseAttackers.tsx
@@ -32,7 +32,7 @@ export function ChooseAttackers({
         </p>
       )}
       <p className="text-center text-[11px] text-muted-foreground/70">
-        Drag a creature onto a player or planeswalker to attack it.
+        Drag a creature onto a target — or tap the creature, then its target — to attack.
       </p>
       <div className="flex flex-row items-center justify-center gap-1.5">
         <PromptActionButton

--- a/src/components/prompts/ChooseAttackers.tsx
+++ b/src/components/prompts/ChooseAttackers.tsx
@@ -21,10 +21,8 @@ export function ChooseAttackers({
   const attackAllClick = multipleDefenders
     ? () => onBeginAttackTargetPick(availableAttackerIds)
     : () => onDeclareAttackers(availableAttackerIds, selectedDefenderId ?? undefined);
-  const attackCount = multipleDefenders ? attackAssignmentCount : pendingAttackers.length;
-  const attackClick = multipleDefenders
-    ? onSubmitAttack
-    : () => onDeclareAttackers(pendingAttackers, selectedDefenderId ?? undefined);
+  const attackCount = attackAssignmentCount + pendingAttackers.length;
+  const attackClick = onSubmitAttack;
 
   return (
     <div className="flex flex-col items-center gap-1.5">

--- a/src/components/prompts/ChooseAttackers.tsx
+++ b/src/components/prompts/ChooseAttackers.tsx
@@ -31,6 +31,9 @@ export function ChooseAttackers({
           {mustAttackHint}
         </p>
       )}
+      <p className="text-center text-[11px] text-muted-foreground/70">
+        Drag a creature onto a player or planeswalker to attack it.
+      </p>
       <div className="flex flex-row items-center justify-center gap-1.5">
         <PromptActionButton
           label="Attack All"

--- a/src/hooks/useCombatState.ts
+++ b/src/hooks/useCombatState.ts
@@ -130,12 +130,11 @@ export function useCombatState({
       return null;
     }, null);
 
-  // Awaiting-defender state is implicit now: as soon as the user has at
-  // least one pending attacker AND there's more than one legal defender
-  // (multiplayer / planeswalkers / sieges), the next click on a valid
-  // defender commits the whole pending batch against it.
-  const awaitingAttackTarget =
-    promptType === "chooseAttackers" && multipleAttackDefenders && pendingAttackers.length > 0;
+  // Click-to-assign flow (alongside drag): once the user has at least one
+  // pending attacker (tapped a creature), the next click on a valid defender
+  // assigns the whole pending batch to it. Available even with a single legal
+  // defender so tapping a creature then the target always works.
+  const awaitingAttackTarget = promptType === "chooseAttackers" && pendingAttackers.length > 0;
 
   // Default attackDefenderId to first valid defender during ChooseAttackers.
   if (promptType === "chooseAttackers") {
@@ -157,11 +156,8 @@ export function useCombatState({
 
   function assignPendingToTarget(defenderId: string) {
     if (pendingAttackers.length === 0) return;
-    if (possibleDefenders.length <= 1) {
-      respond(declareAttackersOutput(currentPrompt, pendingAttackers, defenderId));
-      setPendingAttackers([]);
-      return;
-    }
+    // Accumulate into attackAssignments (staged in the target's band) and let the
+    // Attack button submit — same path drag uses, so both flows behave alike.
     const pendingSet = new Set(pendingAttackers);
     setAttackAssignments((prev) => [
       ...prev.filter((a) => !pendingSet.has(a.attackerId)),

--- a/src/hooks/useCombatState.ts
+++ b/src/hooks/useCombatState.ts
@@ -175,13 +175,39 @@ export function useCombatState({
       currentPrompt?.input.type === "chooseAttackers"
         ? new Set(currentPrompt.input.attackers.map((a) => a.attackerId))
         : null;
-    const assignments = available
-      ? attackAssignments.filter((a) => available.has(a.attackerId))
-      : attackAssignments;
+    // Fold any still-pending (tapped-but-untargeted) attackers into the default
+    // defender so the tap flow and the drag flow submit together.
+    const pendingPairs = attackDefenderId
+      ? pendingAttackers.map((id) => ({ attackerId: id, targetId: attackDefenderId }))
+      : [];
+    const assignedIds = new Set(attackAssignments.map((a) => a.attackerId));
+    const merged = [
+      ...attackAssignments,
+      ...pendingPairs.filter((p) => !assignedIds.has(p.attackerId)),
+    ];
+    const assignments = available ? merged.filter((a) => available.has(a.attackerId)) : merged;
     if (assignments.length === 0) return;
     respond({ type: "declareAttackers", assignments });
     setAttackAssignments([]);
     setPendingAttackers([]);
+  }
+
+  // Drag-to-attack: drop a creature onto a defender (player / planeswalker /
+  // battle) to assign it directly. Upserts so re-dropping moves the attacker.
+  function assignAttackPair(attackerId: string, targetId: string) {
+    const valid = attackerOptions.find((a) => a.attackerId === attackerId)?.validTargetIds ?? [];
+    if (!valid.includes(targetId)) return;
+    setAttackAssignments((prev) => [
+      ...prev.filter((a) => a.attackerId !== attackerId),
+      { attackerId, targetId },
+    ]);
+    setPendingAttackers((prev) => prev.filter((id) => id !== attackerId));
+  }
+
+  // Drag-to-unattack: drop a staged attacker back on our own field to remove it.
+  function unassignAttack(attackerId: string) {
+    setAttackAssignments((prev) => prev.filter((a) => a.attackerId !== attackerId));
+    setPendingAttackers((prev) => prev.filter((id) => id !== attackerId));
   }
 
   /** "Attack All" — mark every legal attacker as pending. In single-
@@ -323,6 +349,8 @@ export function useCombatState({
     pendingAttackers,
     attackAssignments,
     submitAttack,
+    assignAttackPair,
+    unassignAttack,
     pendingAttacker,
     pendingBlocker,
     attackDefenderId,

--- a/src/pixi/BoardCanvas.tsx
+++ b/src/pixi/BoardCanvas.tsx
@@ -35,6 +35,7 @@ import { RotateCw } from "lucide-react";
 const HAND_ACTIONS_PANEL_W = 220;
 import type { HandActionOption } from "@/stores/useGameUIStore";
 import type { CardDto, PlaymatSettings } from "@/protocol/game";
+import type { AttackTargetDto } from "@/protocol/prompts/common";
 import type {
   ArrowSpec,
   BattlefieldState,
@@ -80,6 +81,12 @@ interface BoardCanvasProps {
   /** Local player is declaring blockers — enables drag-to-block. */
   declareBlockers?: boolean;
   combatBlocks?: { blockerId: string; attackerId: string }[];
+  /** Local player is declaring attackers — enables drag-to-attack. */
+  declareAttackers?: boolean;
+  /** Legal defenders (player / planeswalker / battle) for the active
+   *  `chooseAttackers` prompt, and per-attacker validity. */
+  attackTargets?: AttackTargetDto[];
+  attackerOptions?: { attackerId: string; validTargetIds: string[] }[];
   phaseStrip: PhaseStripState;
   phaseStripCallbacks?: PhaseStripCallbacks;
   /** Fraction of usable height for the local player's bottom region; defaults to
@@ -128,6 +135,9 @@ export function BoardCanvas({
   castingArrow,
   declareBlockers,
   combatBlocks,
+  declareAttackers,
+  attackTargets,
+  attackerOptions,
   phaseStrip,
   phaseStripCallbacks,
   selfHeightFraction,
@@ -231,6 +241,9 @@ export function BoardCanvas({
       onAssignBlock: (...a) => callbacksRef.current.onAssignBlock?.(...a),
       onUnassignBlock: (...a) => callbacksRef.current.onUnassignBlock?.(...a),
       onBlockDragChange: (...a) => callbacksRef.current.onBlockDragChange?.(...a),
+      onAssignAttacker: (...a) => callbacksRef.current.onAssignAttacker?.(...a),
+      onUnassignAttacker: (...a) => callbacksRef.current.onUnassignAttacker?.(...a),
+      onAttackDragChange: (...a) => callbacksRef.current.onAttackDragChange?.(...a),
       onTargetPlayer: (...a) => callbacksRef.current.onTargetPlayer?.(...a),
       onShowPlayerSheet: (...a) => callbacksRef.current.onShowPlayerSheet?.(...a),
       onShowBoardMenu: (...a) => callbacksRef.current.onShowBoardMenu?.(...a),
@@ -428,6 +441,14 @@ export function BoardCanvas({
   useEffect(() => {
     scene?.setDeclareBlockers(declareBlockers ?? false);
   }, [scene, declareBlockers]);
+
+  useEffect(() => {
+    scene?.setDeclareAttackers(
+      declareAttackers ?? false,
+      attackTargets ?? [],
+      attackerOptions ?? [],
+    );
+  }, [scene, declareAttackers, attackTargets, attackerOptions]);
 
   useEffect(() => {
     scene?.applyCombatBlocks(combatBlocks ?? []);

--- a/src/pixi/board/BoardRegion.ts
+++ b/src/pixi/board/BoardRegion.ts
@@ -932,8 +932,14 @@ export class BoardRegion {
     for (let gi = 0; gi < groups.length; gi++) {
       const group = groups[gi]!;
       const col = hexToNum(group.color);
-      const ax = stripLeft + 8 + avatarD / 2;
-      const ay = stripTop + 6 + avatarD / 2 + gi * (avatarD + 4);
+      const ax = stripLeft + 6 + avatarD / 2;
+      // Opponent bands carry a zone tile (exile/…) in the attack-row slot, so the
+      // group label sits just *below* the band (far-left, in the gap above the
+      // divider) to avoid overlapping anything inside the play area; the self band
+      // has no tile there and keeps its top-left anchor inside the strip.
+      const ay = this.mirrored
+        ? stripTop + stripH + 6 + avatarD / 2 + gi * (avatarD + 4)
+        : stripTop + 6 + avatarD / 2 + gi * (avatarD + 4);
       this.combatRowGfx.circle(ax, ay, avatarD / 2);
       this.combatRowGfx.fill({ color: col, alpha: 0.4 });
       this.combatRowGfx.circle(ax, ay, avatarD / 2);
@@ -1438,6 +1444,8 @@ export class BoardRegion {
       sprite.setRing(hexToNum(theme.gameTheme.cardRing));
     } else if (state.untappableLandIds?.includes(card.id)) {
       sprite.setRing(hexToNum(theme.gameTheme.promptAction.cancel));
+    } else if (state.hostileTargetCardIds?.includes(card.id)) {
+      sprite.setRing(hexToNum(theme.gameTheme.pointer.hostile));
     } else if (state.selectableCardIds?.includes(card.id)) {
       sprite.setRing(
         state.hostileTargeting

--- a/src/pixi/board/BoardRegion.ts
+++ b/src/pixi/board/BoardRegion.ts
@@ -479,6 +479,15 @@ export class BoardRegion {
     return entry ? this.localToCanvas(entry.targetX, entry.targetY) : null;
   }
 
+  containsPointInCard(cardId: string, globalX: number, globalY: number): boolean {
+    const entry = this.entries.get(cardId);
+    if (!entry) return false;
+    const b = entry.sprite.getBounds();
+    return (
+      globalX >= b.x && globalX <= b.x + b.width && globalY >= b.y && globalY <= b.y + b.height
+    );
+  }
+
   getZoneTileCenter(key: string): ScreenPos | null {
     const center = this.zoneTiles.getTileCenter(key);
     return center ? this.localToCanvas(center.x, center.y) : null;

--- a/src/pixi/board/BoardRegion.ts
+++ b/src/pixi/board/BoardRegion.ts
@@ -131,6 +131,7 @@ export class BoardRegion {
   private stackCounts = new Map<string, number>();
   private nameGroupChildren = new Set<string>();
   private combatStaging: SceneCombatStaging | null = null;
+  private attackTargetRingId: string | null = null;
   private combatRowAttackerIds = new Set<string>();
   private combatRowBlocks: CombatAssignmentDto[] = [];
   private combatRowBlockerIds = new Set<string>();
@@ -208,7 +209,11 @@ export class BoardRegion {
       onDrop: (key, cx, cy) => this.onZoneTileMoved(key, cx, cy),
       onDragEnd: () => this.hideGridSkeleton(),
     });
-    this.zoneTiles.container.zIndex = 30;
+    // Above the combat-row band (`combatRowGfx`, Z_COMBAT_STAGED - 5) so a zone
+    // tile parked in the inner-edge attack slot (mirrored fields) sits on top of
+    // the red strip instead of being dimmed beneath it — still below staged
+    // attacker cards and the row's avatar/label header.
+    this.zoneTiles.container.zIndex = Z_COMBAT_STAGED - 4;
     this.zoneTiles.setDraggable(!this.mirrored);
     this.container.addChild(this.zoneTiles.container);
 
@@ -479,11 +484,33 @@ export class BoardRegion {
     return entry ? this.localToCanvas(entry.targetX, entry.targetY) : null;
   }
 
-  containsPointInCard(cardId: string, canvasX: number, canvasY: number): boolean {
-    const center = this.getCardPosition(cardId);
-    if (!center) return false;
-    const halfW = (CARD_W * this.cardScale) / 2;
-    const halfH = (CARD_H * this.cardScale) / 2;
+  /** Draw the hostile "under attack" ring on `cardId` (a planeswalker/battle the
+   *  local player is dragging an attacker onto), or clear it. A card not in this
+   *  region is treated as null so the scene can broadcast to every region. */
+  setAttackTargetRing(cardId: string | null): void {
+    const mine = cardId && this.entries.has(cardId) ? cardId : null;
+    if (this.attackTargetRingId === mine) return;
+    const prev = this.attackTargetRingId;
+    this.attackTargetRingId = mine;
+    if (prev && this.lastState) {
+      const e = this.entries.get(prev);
+      if (e) this.applyBattlefieldRing(e.sprite, this.lastState);
+    }
+    if (mine) {
+      const e = this.entries.get(mine);
+      if (e) e.sprite.setRing(hexToNum(this.host.getTheme().gameTheme.pointer.hostile));
+    }
+  }
+
+  containsPointInCard(cardId: string, canvasX: number, canvasY: number, pad = 0): boolean {
+    const entry = this.entries.get(cardId);
+    if (!entry) return false;
+    const center = this.localToCanvas(entry.targetX, entry.targetY);
+    // Battles / planes render sideways — match the landscape footprint so their
+    // targeting zone is identical in size to an upright planeswalker's.
+    const horizontal = entry.sprite.horizontalFrame;
+    const halfW = ((horizontal ? CARD_H : CARD_W) * this.cardScale) / 2 + pad;
+    const halfH = ((horizontal ? CARD_W : CARD_H) * this.cardScale) / 2 + pad;
     return Math.abs(canvasX - center.x) <= halfW && Math.abs(canvasY - center.y) <= halfH;
   }
 
@@ -1389,6 +1416,10 @@ export class BoardRegion {
     const theme = this.host.getTheme();
     const card = sprite.card;
     sprite.setDoomed(card.wouldDieInCombat ?? false);
+    if (this.attackTargetRingId === card.id) {
+      sprite.setRing(hexToNum(theme.gameTheme.pointer.hostile));
+      return;
+    }
     if (this.isDeclaredBlocker(card.id)) {
       sprite.setRing(hexToNum(theme.gameTheme.promptAction.defenseAction));
       return;

--- a/src/pixi/board/BoardRegion.ts
+++ b/src/pixi/board/BoardRegion.ts
@@ -479,13 +479,12 @@ export class BoardRegion {
     return entry ? this.localToCanvas(entry.targetX, entry.targetY) : null;
   }
 
-  containsPointInCard(cardId: string, globalX: number, globalY: number): boolean {
-    const entry = this.entries.get(cardId);
-    if (!entry) return false;
-    const b = entry.sprite.getBounds();
-    return (
-      globalX >= b.x && globalX <= b.x + b.width && globalY >= b.y && globalY <= b.y + b.height
-    );
+  containsPointInCard(cardId: string, canvasX: number, canvasY: number): boolean {
+    const center = this.getCardPosition(cardId);
+    if (!center) return false;
+    const halfW = (CARD_W * this.cardScale) / 2;
+    const halfH = (CARD_H * this.cardScale) / 2;
+    return Math.abs(canvasX - center.x) <= halfW && Math.abs(canvasY - center.y) <= halfH;
   }
 
   getZoneTileCenter(key: string): ScreenPos | null {

--- a/src/pixi/board/BoardScene.ts
+++ b/src/pixi/board/BoardScene.ts
@@ -174,6 +174,9 @@ export class BoardScene {
   private declareAttackers = false;
   private attackTargets: AttackTargetDto[] = [];
   private attackerOptions: { attackerId: string; validTargetIds: string[] }[] = [];
+  // The legal attacker under a pointer-down, armed into an attack drag only once
+  // the pointer actually moves — so a plain tap still reaches the click handler.
+  private attackDragCandidate: string | null = null;
   private attackDragAttackerId: string | null = null;
   private attackDragTargetId: string | null = null;
   // Dragging one of our own already-declared attackers (staged as a guest in an
@@ -1376,12 +1379,10 @@ export class BoardScene {
       ),
     );
     selection.refresh();
-    if (
-      this.declareAttackers &&
-      this.attackerOptions.some((a) => a.attackerId === sprite.card.id)
-    ) {
-      this.setAttackDragId(sprite.card.id);
-    }
+    this.attackDragCandidate =
+      this.declareAttackers && this.attackerOptions.some((a) => a.attackerId === sprite.card.id)
+        ? sprite.card.id
+        : null;
   }
 
   private onGlobalMove(e: FederatedPointerEvent): void {
@@ -1443,6 +1444,9 @@ export class BoardScene {
       local.followAttachmentsDuringDrag(id, p);
     }
 
+    if (this.attackDragCandidate && !this.attackDragAttackerId) {
+      this.setAttackDragId(this.attackDragCandidate);
+    }
     if (this.attackDragAttackerId) {
       this.attackDragTargetId = this.resolveAttackTargetAt(pos.x, pos.y, this.attackDragAttackerId);
       this.updateAttackTargetRing(this.attackDragTargetId);
@@ -1467,6 +1471,7 @@ export class BoardScene {
 
   private onGlobalUp(): void {
     if (this.destroyed) return;
+    this.attackDragCandidate = null;
     if (this.unassignDrag) {
       const ud = this.unassignDrag;
       this.unassignDrag = null;

--- a/src/pixi/board/BoardScene.ts
+++ b/src/pixi/board/BoardScene.ts
@@ -952,9 +952,10 @@ export class BoardScene {
     this.callbacks.onAttackDragChange?.(id);
   }
 
-  /** Resolve a canvas-global point to a legal defender for `attackerId`: a
-   *  planeswalker/battle card directly under the pointer wins; otherwise the
-   *  opponent whose field band the pointer is over (proximity → the player). */
+  /** Resolve a scene-space point (root-local, as `getCardPosition` returns) to a
+   *  legal defender for `attackerId`: a planeswalker/battle card directly under
+   *  the pointer wins; otherwise the opponent whose field band the pointer is
+   *  over (proximity → the player). */
   private resolveAttackTargetAt(gx: number, gy: number, attackerId: string): string | null {
     const valid = this.attackerOptions.find((a) => a.attackerId === attackerId)?.validTargetIds;
     if (!valid || valid.length === 0) return null;
@@ -1398,11 +1399,7 @@ export class BoardScene {
     }
 
     if (this.attackDragAttackerId) {
-      this.attackDragTargetId = this.resolveAttackTargetAt(
-        e.global.x,
-        e.global.y,
-        this.attackDragAttackerId,
-      );
+      this.attackDragTargetId = this.resolveAttackTargetAt(pos.x, pos.y, this.attackDragAttackerId);
       this.hoveredCell = null;
       this.stackTargetId = null;
       local.hideGridSkeleton();

--- a/src/pixi/board/BoardScene.ts
+++ b/src/pixi/board/BoardScene.ts
@@ -9,6 +9,7 @@ import {
 } from "pixi.js";
 import { darken, withAlpha } from "@/themes/gameTheme";
 import type { CardDto, PlaymatSettings } from "@/protocol/game";
+import type { AttackTargetDto } from "@/protocol/prompts/common";
 import {
   CardSprite,
   setCardSpriteTheme,
@@ -167,6 +168,11 @@ export class BoardScene {
 
   private declareBlockers = false;
   private blockDragBlockerId: string | null = null;
+  private declareAttackers = false;
+  private attackTargets: AttackTargetDto[] = [];
+  private attackerOptions: { attackerId: string; validTargetIds: string[] }[] = [];
+  private attackDragAttackerId: string | null = null;
+  private attackDragTargetId: string | null = null;
   private phaseStripAlphaTarget = 1;
 
   private hand: HandController | null = null;
@@ -928,6 +934,49 @@ export class BoardScene {
     this.callbacks.onBlockDragChange?.(id);
   }
 
+  setDeclareAttackers(
+    active: boolean,
+    attackTargets: AttackTargetDto[],
+    attackerOptions: { attackerId: string; validTargetIds: string[] }[],
+  ): void {
+    this.declareAttackers = active;
+    this.attackTargets = attackTargets;
+    this.attackerOptions = attackerOptions;
+    if (!active) this.setAttackDragId(null);
+  }
+
+  private setAttackDragId(id: string | null): void {
+    if (this.attackDragAttackerId === id) return;
+    this.attackDragAttackerId = id;
+    if (id === null) this.attackDragTargetId = null;
+    this.callbacks.onAttackDragChange?.(id);
+  }
+
+  /** Resolve a canvas-global point to a legal defender for `attackerId`: a
+   *  planeswalker/battle card directly under the pointer wins; otherwise the
+   *  opponent whose field band the pointer is over (proximity → the player). */
+  private resolveAttackTargetAt(gx: number, gy: number, attackerId: string): string | null {
+    const valid = this.attackerOptions.find((a) => a.attackerId === attackerId)?.validTargetIds;
+    if (!valid || valid.length === 0) return null;
+    const validSet = new Set(valid);
+    for (const t of this.attackTargets) {
+      if (t.kind === "player" || !validSet.has(t.id)) continue;
+      for (const rec of this.regions.values()) {
+        if (rec.isLocal) continue;
+        if (rec.region.containsPointInCard(t.id, gx, gy)) return t.id;
+      }
+    }
+    const oppId = this.hoveredOpponentId;
+    if (
+      oppId &&
+      validSet.has(oppId) &&
+      this.attackTargets.some((t) => t.id === oppId && t.kind === "player")
+    ) {
+      return oppId;
+    }
+    return null;
+  }
+
   setPhaseStripState(state: PhaseStripState): void {
     this.phaseStrip.update(state);
   }
@@ -1293,6 +1342,12 @@ export class BoardScene {
       ),
     );
     selection.refresh();
+    if (
+      this.declareAttackers &&
+      this.attackerOptions.some((a) => a.attackerId === sprite.card.id)
+    ) {
+      this.setAttackDragId(sprite.card.id);
+    }
   }
 
   private onGlobalMove(e: FederatedPointerEvent): void {
@@ -1342,6 +1397,18 @@ export class BoardScene {
       local.followAttachmentsDuringDrag(id, p);
     }
 
+    if (this.attackDragAttackerId) {
+      this.attackDragTargetId = this.resolveAttackTargetAt(
+        e.global.x,
+        e.global.y,
+        this.attackDragAttackerId,
+      );
+      this.hoveredCell = null;
+      this.stackTargetId = null;
+      local.hideGridSkeleton();
+      return;
+    }
+
     const grid = local.getGridInfo();
     if (primaryPos && grid) {
       this.hoveredCell = cellFromPoint(grid, primaryPos.x, primaryPos.y);
@@ -1369,6 +1436,28 @@ export class BoardScene {
     const local = this.localRegion();
     const selection = this.selection;
     if (!local || !selection) return;
+
+    if (this.attackDragAttackerId) {
+      const draggedIds = [...this.dragHandler.draggingCardIds];
+      const targetId = this.attackDragTargetId;
+      const result = this.dragHandler.end();
+      this.setAttackDragId(null);
+      local.hideGridSkeleton();
+      if (result?.wasDrag) {
+        for (const id of draggedIds) {
+          const opt = this.attackerOptions.find((a) => a.attackerId === id);
+          if (!opt) continue;
+          if (targetId && opt.validTargetIds.includes(targetId)) {
+            this.callbacks.onAssignAttacker?.(id, targetId);
+          } else {
+            this.callbacks.onUnassignAttacker?.(id);
+          }
+        }
+      }
+      const state = local.getLastState();
+      if (state) local.updateBattlefield(state);
+      return;
+    }
 
     if (selection.isMarqueeActive()) {
       selection.endMarquee(local.snapshotCurrentPositions());
@@ -1471,7 +1560,8 @@ export class BoardScene {
       this.arrowSpecs.length === 0 &&
       !this.castingArrow &&
       !castDragging &&
-      !this.blockDragBlockerId
+      !this.blockDragBlockerId &&
+      !this.attackDragAttackerId
     )
       return [];
     const canvasRect = this.app.canvas.getBoundingClientRect();
@@ -1552,6 +1642,37 @@ export class BoardScene {
           toX: this.cursorViewportX - canvasRect.left,
           toY: this.cursorViewportY - canvasRect.top,
           type: "block",
+        });
+      }
+    }
+    if (this.attackDragAttackerId) {
+      const from = this.resolveArrowEndpoint(
+        { kind: "card", id: this.attackDragAttackerId },
+        canvasRect,
+      );
+      if (from) {
+        let toX = this.cursorViewportX - canvasRect.left;
+        let toY = this.cursorViewportY - canvasRect.top;
+        if (this.attackDragTargetId) {
+          const tgt = this.attackTargets.find((t) => t.id === this.attackDragTargetId);
+          const to = this.resolveTargetEndpoint(
+            tgt?.kind === "player"
+              ? { kind: "player", id: this.attackDragTargetId }
+              : { kind: "card", id: this.attackDragTargetId },
+            canvasRect,
+          );
+          if (to) {
+            toX = to.pos.x;
+            toY = to.pos.y;
+          }
+        }
+        resolved.push({
+          fromX: from.x,
+          fromY: from.y,
+          toX,
+          toY,
+          type: "attack",
+          color: hexToNum(this.theme.gameTheme.pointer.hostile),
         });
       }
     }

--- a/src/pixi/board/BoardScene.ts
+++ b/src/pixi/board/BoardScene.ts
@@ -102,6 +102,9 @@ const DELIMITER_EASE = { FACTOR: 0.25, SNAP: 0.0005 } as const;
 
 const GRIP_HIT_WIDTH_PX = 16;
 const ATTACK_ARROW_LANE_PX = 18;
+/** Extra px around a planeswalker/battle card that still counts as targeting it
+ *  while dragging an attacker — makes small opponent permanents easy to hit. */
+const ATTACK_TARGET_HIT_PAD = 44;
 
 /* ─────────────────────────────────────────────────────────────────────────
  * DIVIDER + FOG — tweak these. The vertical divider bar and the fog-of-war
@@ -173,6 +176,9 @@ export class BoardScene {
   private attackerOptions: { attackerId: string; validTargetIds: string[] }[] = [];
   private attackDragAttackerId: string | null = null;
   private attackDragTargetId: string | null = null;
+  // Dragging one of our own already-declared attackers (staged as a guest in an
+  // opponent's band) back toward our field to un-declare it.
+  private unassignDrag: { cardId: string; region: BoardRegion; overOwn: boolean } | null = null;
   private phaseStripAlphaTarget = 1;
 
   private hand: HandController | null = null;
@@ -942,14 +948,24 @@ export class BoardScene {
     this.declareAttackers = active;
     this.attackTargets = attackTargets;
     this.attackerOptions = attackerOptions;
-    if (!active) this.setAttackDragId(null);
+    if (!active) {
+      this.setAttackDragId(null);
+      this.unassignDrag = null;
+    }
   }
 
   private setAttackDragId(id: string | null): void {
     if (this.attackDragAttackerId === id) return;
     this.attackDragAttackerId = id;
-    if (id === null) this.attackDragTargetId = null;
+    if (id === null) {
+      this.attackDragTargetId = null;
+      this.updateAttackTargetRing(null);
+    }
     this.callbacks.onAttackDragChange?.(id);
+  }
+
+  private updateAttackTargetRing(cardId: string | null): void {
+    for (const rec of this.regions.values()) rec.region.setAttackTargetRing(cardId);
   }
 
   /** Resolve a scene-space point (root-local, as `getCardPosition` returns) to a
@@ -960,13 +976,21 @@ export class BoardScene {
     const valid = this.attackerOptions.find((a) => a.attackerId === attackerId)?.validTargetIds;
     if (!valid || valid.length === 0) return null;
     const validSet = new Set(valid);
+    // Generous pad around each planeswalker/battle so dragging *near* one targets
+    // it; when several enlarged hit-zones overlap, the nearest centre wins.
+    let best: { id: string; dist: number } | null = null;
     for (const t of this.attackTargets) {
       if (t.kind === "player" || !validSet.has(t.id)) continue;
       for (const rec of this.regions.values()) {
         if (rec.isLocal) continue;
-        if (rec.region.containsPointInCard(t.id, gx, gy)) return t.id;
+        const center = rec.region.getCardPosition(t.id);
+        if (!center) continue;
+        if (!rec.region.containsPointInCard(t.id, gx, gy, ATTACK_TARGET_HIT_PAD)) continue;
+        const dist = (gx - center.x) ** 2 + (gy - center.y) ** 2;
+        if (!best || dist < best.dist) best = { id: t.id, dist };
       }
     }
+    if (best) return best.id;
     const oppId = this.hoveredOpponentId;
     if (
       oppId &&
@@ -1251,6 +1275,15 @@ export class BoardScene {
         this.overlay?.handleCardTap(sprite.card);
       });
     } else {
+      sprite.on("pointerdown", (e: FederatedPointerEvent) => {
+        // Grab our own declared attacker (staged in this opponent's band) to
+        // drag it back and un-declare it.
+        if (this.declareAttackers && sprite.card.controllerId === this.localPlayerId && region) {
+          e.stopPropagation();
+          this.callbacks.onDismissHoverPreview?.();
+          this.unassignDrag = { cardId: sprite.card.id, region, overOwn: false };
+        }
+      });
       sprite.on("pointertap", () => {
         if (isAttackerTap(region?.getLastState() ?? null, sprite.card.id)) {
           this.callbacks.onAttackerClick?.(sprite.card);
@@ -1355,6 +1388,18 @@ export class BoardScene {
     if (this.destroyed) return;
     const pos = this.root.toLocal(e.global);
     this.updateHoveredOpponent(pos.x, pos.y);
+    if (this.unassignDrag) {
+      const ud = this.unassignDrag;
+      const entry = ud.region.getEntries().get(ud.cardId);
+      if (entry) {
+        entry.targetX = pos.x;
+        entry.targetY = pos.y;
+        entry.sprite.x = pos.x;
+        entry.sprite.y = pos.y;
+      }
+      ud.overOwn = pos.y > this.topHeight;
+      return;
+    }
     if (this.draggingDelim !== null) {
       this.dragDelimiterTo(pos.x);
       return;
@@ -1400,6 +1445,7 @@ export class BoardScene {
 
     if (this.attackDragAttackerId) {
       this.attackDragTargetId = this.resolveAttackTargetAt(pos.x, pos.y, this.attackDragAttackerId);
+      this.updateAttackTargetRing(this.attackDragTargetId);
       this.hoveredCell = null;
       this.stackTargetId = null;
       local.hideGridSkeleton();
@@ -1421,6 +1467,17 @@ export class BoardScene {
 
   private onGlobalUp(): void {
     if (this.destroyed) return;
+    if (this.unassignDrag) {
+      const ud = this.unassignDrag;
+      this.unassignDrag = null;
+      if (ud.overOwn) {
+        this.callbacks.onUnassignAttacker?.(ud.cardId);
+      } else {
+        const state = ud.region.getLastState();
+        if (state) ud.region.updateBattlefield(state);
+      }
+      return;
+    }
     if (this.draggingDelim !== null) {
       this.draggingDelim = null;
       return;

--- a/src/pixi/types.ts
+++ b/src/pixi/types.ts
@@ -127,6 +127,9 @@ export interface BattlefieldState {
   untappableLandIds?: string[];
   manaAbilityOptions?: ManaAbilityActionInfo[];
   hostileTargeting?: boolean;
+  /** Selectable cards that should glow hostile-red rather than the neutral ring
+   *  — planeswalker / battle attack targets during declare-attackers. */
+  hostileTargetCardIds?: string[];
   ownerRingByCard?: Record<string, string>;
   combatRowAttackerIds?: string[];
   combatRowBlocks?: CombatAssignmentDto[];

--- a/src/pixi/types.ts
+++ b/src/pixi/types.ts
@@ -98,6 +98,14 @@ export interface GameCanvasCallbacks {
   /** Fires when a block-drag arms (blockerId) or ends (null), so the UI can
    *  highlight the attackers that blocker may legally block. */
   onBlockDragChange?: (blockerId: string | null) => void;
+  /** Drag-to-attack: a creature sprite was dropped onto a defender (player /
+   *  planeswalker / battle). */
+  onAssignAttacker?: (attackerId: string, targetId: string) => void;
+  /** Drag-to-unattack: a staged attacker was dragged back off its target. */
+  onUnassignAttacker?: (attackerId: string) => void;
+  /** Fires when an attack-drag arms (attackerId) or ends (null), so the UI can
+   *  highlight that attacker's legal defenders. */
+  onAttackDragChange?: (attackerId: string | null) => void;
   onCastSpell?: (cardId: string) => void;
   /**
    * Dismiss the hover preview immediately (no 250ms grace). Used when

--- a/src/views/Game.tsx
+++ b/src/views/Game.tsx
@@ -982,9 +982,10 @@ export default function Game({ exitTo }: GameProps = {}) {
               ),
             ],
             playerIds: gameView.players.map((p) => p.id),
+            pendingAttacks: attackAssignments,
           })
         : [],
-    [gameView, combatAssignments, blockAssignments],
+    [gameView, combatAssignments, blockAssignments, attackAssignments],
   );
   const oppCombatAttackerIds = useMemo(
     () => new Set(combatRows.flatMap((r) => r.attackerIds)),
@@ -1035,12 +1036,34 @@ export default function Game({ exitTo }: GameProps = {}) {
     return map;
   }, [gameView?.players]);
 
+  const attackTargetKindById = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const t of chooseAttackersInput?.attackTargets ?? []) m.set(t.id, t.kind);
+    return m;
+  }, [chooseAttackersInput]);
   const attackArrows = useMemo(
     () => [
-      ...activeAttackers.filter((a) => !oppCombatAttackerIds.has(a.attackerId)),
-      ...attackAssignments.map((a) => ({ attackerId: a.attackerId, defenderId: a.targetId })),
+      ...activeAttackers
+        .filter((a) => !oppCombatAttackerIds.has(a.attackerId))
+        .map((a) => ({
+          attackerId: a.attackerId,
+          targetId: a.defenderId,
+          targetKind: "player" as const,
+        })),
+      // Player attacks read from the attack-row staging; only planeswalker /
+      // battle attacks draw an arrow, pointing at the specific permanent.
+      ...attackAssignments
+        .filter((a) => {
+          const kind = attackTargetKindById.get(a.targetId);
+          return kind === "planeswalker" || kind === "battle";
+        })
+        .map((a) => ({
+          attackerId: a.attackerId,
+          targetId: a.targetId,
+          targetKind: "card" as const,
+        })),
     ],
-    [activeAttackers, attackAssignments, oppCombatAttackerIds],
+    [activeAttackers, attackAssignments, oppCombatAttackerIds, attackTargetKindById],
   );
   const arrowBlocks = useMemo(
     () => combatAssignments.filter((a) => !oppCombatAttackerIds.has(a.attackerId)),

--- a/src/views/Game.tsx
+++ b/src/views/Game.tsx
@@ -473,6 +473,8 @@ export default function Game({ exitTo }: GameProps = {}) {
     blockRequirement,
     assignBlockPair,
     unassignBlock,
+    assignAttackPair,
+    unassignAttack,
     damageOrder,
     toggleDamageOrder,
     undoDamageOrder,
@@ -1506,6 +1508,8 @@ export default function Game({ exitTo }: GameProps = {}) {
           onAttackerClick={handleAttackerClick}
           onAssignBlock={assignBlockPair}
           onUnassignBlock={unassignBlock}
+          onAssignAttacker={assignAttackPair}
+          onUnassignAttacker={unassignAttack}
           onTargetPlayer={handleTargetPlayer}
           onShowBoardMenu={() => setBoardMenuOpen(true)}
           onOpenZone={(title, cards, onClickCard, clickableCardIds, targetHostile) => {


### PR DESCRIPTION
## Summary

Adds **drag-to-declare-attackers** during the `chooseAttackers` step. Pick up a legal attacker and drag it onto an opponent's field to declare it:

- **Drop resolution** — a **planeswalker/battle card** directly under the pointer wins; otherwise the **opponent whose field band** the pointer is over becomes the target (proximity → attack the player). Gated by each attacker's `validTargetIds`.
- **Live feedback** — a hostile arrow follows the drag to the resolved target, and valid defenders (avatars + PW/battle cards) highlight while dragging.
- **Un-declare** — drag a staged attacker back onto your own field to remove it.
- **Group drag** — if multiple creatures are selected, all legal ones assign to the dropped target.
- The drag feeds the **same** `attackAssignments` the tap flow already uses, so tap-to-declare still works and the **Attack (N)** button submits both.

Mirrors the existing block-drag feature's shape (`onBlockDragChange`/`onAssignBlock` → `onAttackDragChange`/`onAssignAttacker`/`onUnassignAttacker`). No engine changes — the `ChooseAttackersInput`/`Output` protocol already models player/planeswalker/battle targets.

## Why

Declaring attackers by tapping (creature, then a defender) is unintuitive, especially with multiple defenders / planeswalkers / battles. Dragging the creature onto its target is the MTGA-style gesture and makes the player-vs-permanent choice unambiguous (specific card = that permanent; anywhere else on the field = the player).

## Test plan

- [ ] Single-defender game: drag a creature up onto the opponent → declared; **Attack (N)** submits.
- [ ] Multiplayer: drag onto different opponents' fields → each attacks the right player.
- [ ] Drag onto a planeswalker / battle card → attacks that permanent; drag onto empty field → attacks the player.
- [ ] Illegal target (not in `validTargetIds`) → no highlight, snaps back.
- [ ] Drag a staged attacker back to own field → un-declared.
- [ ] Tap-to-declare flow still works unchanged; group (multi-select) drag assigns all legal.

_Pixi interaction — verified via typecheck/lint; needs a manual pass in a live game._

## Build artifacts

- [ ] Build macOS .dmg
- [ ] Build Windows .exe