### PR TITLE
hotfix(harness): resolve prompt seat ids via registered players

### DIFF
--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveSession.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveSession.java
@@ -641,7 +641,7 @@ public final class ManaBrewInteractiveSession {
     boolean awaitMulliganDecision(final int playerId, final int cardsToReturn) {
         requireAttached();
         final List<Card> cards = new ArrayList<Card>(
-                game.getPlayers().get(playerId).getCardsIn(forge.game.zone.ZoneType.Hand));
+                game.getRegisteredPlayers().get(playerId).getCardsIn(forge.game.zone.ZoneType.Hand));
         publishCardChoicePrompt("mulligan", playerId, cards, 0, 0, cardsToReturn);
         while (!closed && !game.isGameOver()) {
             final JsonObject action;
@@ -1908,7 +1908,7 @@ public final class ManaBrewInteractiveSession {
             final Map<Card, List<Card>> validBlockersByAttacker,
             final String error
     ) {
-        final Player defendingPlayer = game.getPlayers().get(playerId);
+        final Player defendingPlayer = game.getRegisteredPlayers().get(playerId);
         final List<BlockableAttackerDto> attackerOptions = new java.util.ArrayList<>();
         for (final Card attacker : attackers) {
             final List<String> validBlockerIds = new java.util.ArrayList<>();


### PR DESCRIPTION
## Summary

- Resolve prompt seat ids through `game.getRegisteredPlayers()` instead of `game.getPlayers()` in `ManaBrewInteractiveSession` (`publishBlockersPrompt`, `awaitMulliganDecision`).

## Why

Seat ids are encoded with `SnapshotExtractor.playerIndex`, which indexes `getRegisteredPlayers()` (all players, stable order). `getPlayers()` is the list of players *still fighting* — it shrinks when someone is eliminated, so in a 4-player pod every blockers prompt for a later seat after the first elimination threw `IndexOutOfBoundsException: Index 3 out of bounds for length 3` and killed the hosted game. Observed live on launch day; crash signature and full trace in #314 (signature 1). The `awaitMulliganDecision` site is the same bug latent (mulligans normally precede eliminations).

These are the only two `getPlayers().get(seatId)` sites in the harness; the rest of the session already goes through `playerIndex`-produced ids symmetrically.

## Test plan

- `yarn build:harness` — clean.
- `./forge-harness/build-native.sh` — clean; the fixed library is already hot-deployed on the launch-day surge nodes (rolling restart, no games interrupted).
- Not yet reproduced in a scripted 4-player elimination game — the failing index arithmetic is directly visible from the trace (`playerIndex` encodes against the registered list; the crash shows seat 3 vs a 3-long in-game list).

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main

(The bundled desktop Forge engine has the same bug — worth ticking these if a desktop release is planned; see also the deck-DTO wire break for desktop clients, reported separately.)
