### PR TITLE
hotfix(harness): reprompt on invalid client answers instead of dying

### DIFF
--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveSession.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveSession.java
@@ -230,6 +230,22 @@ public final class ManaBrewInteractiveSession {
                 Thread.currentThread().interrupt();
                 return new PriorityChoice(PriorityActionKind.PASS, null, null, null);
             }
+            try {
+                return interpretPriorityAction(action, actionsForPrompt, untappableCards);
+            } catch (IllegalArgumentException | UnsupportedOperationException | NullPointerException invalid) {
+                System.err.println("[mana-brew] ignoring invalid priority answer: " + invalid);
+                publishPriorityPrompt(playerId, actionsForPrompt, untappableCards);
+            }
+        }
+        return new PriorityChoice(PriorityActionKind.PASS, null, null, null);
+    }
+
+    private PriorityChoice interpretPriorityAction(
+            final JsonObject action,
+            final List<SpellAbility> actionsForPrompt,
+            final List<Card> untappableCards
+    ) {
+        {
             final String kind = action.has("kind") ? action.get("kind").getAsString() : "";
             if ("pass".equals(kind) || "pass_priority".equals(kind)) {
                 final JsonObject until = action.has("until") && action.get("until").isJsonObject()
@@ -267,7 +283,6 @@ public final class ManaBrewInteractiveSession {
             }
             throw new UnsupportedOperationException("unsupported action kind: " + kind);
         }
-        return new PriorityChoice(PriorityActionKind.PASS, null, null, null);
     }
 
     enum ManaPaymentKind { TAP, UNTAP, PAY, PAY_LIFE, CANCEL, DELVE, UNDELVE }
@@ -354,6 +369,27 @@ public final class ManaBrewInteractiveSession {
                 Thread.currentThread().interrupt();
                 return new ManaPaymentChoice(ManaPaymentKind.CANCEL, null, null, null, null, null, false);
             }
+            try {
+                return interpretManaPaymentChoice(
+                        action, tappableSources, untappableCards, convokeSources, delveSources);
+            } catch (IllegalArgumentException | UnsupportedOperationException | NullPointerException invalid) {
+                System.err.println("[mana-brew] ignoring invalid mana-payment answer: " + invalid);
+                publishManaPaymentPrompt(
+                        playerId, payingFor, remainingCost, tappableSources, untappableCards, convokeSources,
+                        delveSources, delvedCards, canConfirm, canCancel, canPayLife, lifeToPay);
+            }
+        }
+        return new ManaPaymentChoice(ManaPaymentKind.CANCEL, null, null, null, null, null, false);
+    }
+
+    private ManaPaymentChoice interpretManaPaymentChoice(
+            final JsonObject action,
+            final List<SpellAbility> tappableSources,
+            final List<Card> untappableCards,
+            final List<Card> convokeSources,
+            final List<Card> delveSources
+    ) {
+        {
             final String kind = action.has("kind") ? action.get("kind").getAsString() : "";
             switch (kind) {
                 case "tap_land": {
@@ -402,7 +438,6 @@ public final class ManaBrewInteractiveSession {
                     throw new UnsupportedOperationException("unsupported mana-payment action kind: " + kind);
             }
         }
-        return new ManaPaymentChoice(ManaPaymentKind.CANCEL, null, null, null, null, null, false);
     }
 
     private SpellAbility resolveTapSource(final JsonObject action, final List<SpellAbility> tappableSources) {

--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveSession.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveSession.java
@@ -233,7 +233,14 @@ public final class ManaBrewInteractiveSession {
             try {
                 return interpretPriorityAction(action, actionsForPrompt, untappableCards);
             } catch (IllegalArgumentException | UnsupportedOperationException | NullPointerException invalid) {
-                System.err.println("[mana-brew] ignoring invalid priority answer: " + invalid);
+                System.err.println("[mana-brew] ignoring invalid priority answer: " + invalid
+                        + " | playerId=" + playerId
+                        + " options=" + actionsForPrompt.size()
+                        + " untappable=" + untappableCards.size()
+                        + " phase=" + game.getPhaseHandler().getPhase()
+                        + " turn=" + game.getPhaseHandler().getTurn()
+                        + " action=" + action);
+                invalid.printStackTrace(System.err);
                 publishPriorityPrompt(playerId, actionsForPrompt, untappableCards);
             }
         }
@@ -373,7 +380,14 @@ public final class ManaBrewInteractiveSession {
                 return interpretManaPaymentChoice(
                         action, tappableSources, untappableCards, convokeSources, delveSources);
             } catch (IllegalArgumentException | UnsupportedOperationException | NullPointerException invalid) {
-                System.err.println("[mana-brew] ignoring invalid mana-payment answer: " + invalid);
+                System.err.println("[mana-brew] ignoring invalid mana-payment answer: " + invalid
+                        + " | playerId=" + playerId
+                        + " payingFor=" + (payingFor != null ? payingFor.getName() : "null")
+                        + " remainingCost=" + remainingCost
+                        + " tappable=" + tappableSources.size()
+                        + " canConfirm=" + canConfirm + " canCancel=" + canCancel
+                        + " action=" + action);
+                invalid.printStackTrace(System.err);
                 publishManaPaymentPrompt(
                         playerId, payingFor, remainingCost, tappableSources, untappableCards, convokeSources,
                         delveSources, delvedCards, canConfirm, canCancel, canPayLife, lifeToPay);


### PR DESCRIPTION
## Summary

- `awaitPriorityAction` and `awaitManaPaymentChoice` no longer kill the hosted game when a client answer is invalid: interpretation moved into helpers, and the await loops catch `IllegalArgumentException` / `UnsupportedOperationException` / `NullPointerException`, log one line, re-publish the prompt, and keep waiting.

## Why

Any stale or malformed relay answer threw out of the await loop, propagated up `PhaseHandler.mainGameLoop`, and killed the whole game — booting every player with no message. Launch-night data (#314): these two prompts accounted for **10 of 12 hosted-game deaths overnight** (`action index out of range` ×6, `unsupported mana-payment action kind: choose_action` ×4), plus 2 bare `null` errors that are Gson NPEs from answers missing expected fields — which is why `NullPointerException` is included: the try block only interprets the client message, so an NPE there means a malformed answer, not engine state.

Re-prompting (rather than silently ignoring) also resyncs a desynced client — the stale-answer case is a client answering a superseded prompt.

The remaining `await*` prompt handlers (card choice, mode, number, string, …) have the same throw-on-invalid pattern but produced no deaths on launch data; converting them the same way is a follow-up under #314.

## Test plan

- `yarn build:harness` — clean.
- Not exercised against a live desynced client; the failure mode is reproduced from launch traces in #314 and the change is behavior-preserving for valid answers (interpretation logic is moved, not modified).
- Will be hot-deployed to the launch surge fleet after review-by-fire, same as #315.

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main
