### PR TITLE
chore: release the next version as 1.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,21 +6,61 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
   "changelog-sections": [
-    { "type": "feat", "section": "Features" },
-    { "type": "fix", "section": "Fixes" },
-    { "type": "perf", "section": "Performance" },
-    { "type": "refactor", "section": "Refactors" },
-    { "type": "revert", "section": "Reverts" },
-    { "type": "docs", "section": "Docs", "hidden": true },
-    { "type": "style", "section": "Style", "hidden": true },
-    { "type": "chore", "section": "Chores", "hidden": true },
-    { "type": "test", "section": "Tests", "hidden": true },
-    { "type": "build", "section": "Build", "hidden": true },
-    { "type": "ci", "section": "CI", "hidden": true }
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance"
+    },
+    {
+      "type": "refactor",
+      "section": "Refactors"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "docs",
+      "section": "Docs",
+      "hidden": true
+    },
+    {
+      "type": "style",
+      "section": "Style",
+      "hidden": true
+    },
+    {
+      "type": "chore",
+      "section": "Chores",
+      "hidden": true
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": true
+    },
+    {
+      "type": "build",
+      "section": "Build",
+      "hidden": true
+    },
+    {
+      "type": "ci",
+      "section": "CI",
+      "hidden": true
+    }
   ],
   "packages": {
     ".": {
       "package-name": "manabrew",
+      "release-as": "1.0.0",
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
## Summary

- Adds `"release-as": "1.0.0"` to the release-please config so the next release PR cuts **v1.0.0**.

## Why

The 0.6.0 protocol changes (nested deck identity, game-view/prompt reshapes) broke every released pre-0.6 client, and with #322 the relay now actively rejects them with an update nudge. That's a breaking contract with installed desktop apps; `bump-minor-pre-major` would hide the next break as another minor. Crossing to 1.0.0 makes the compatibility break visible in the version and starts honest semver for installers.

Housekeeping: `release-as` is sticky — it must be **removed after v1.0.0 ships** or every subsequent release re-pins to 1.0.0. (Formatting churn in the file is prettier normalizing the JSON via the pre-commit hook; the semantic change is the one line.)

## Test plan

- Config-only change; release-please validates the schema on its next run. Verify the release PR it opens is titled `chore(main): release 1.0.0`.

## Build artifacts

- [ ] Build macOS .dmg on merge to main
- [ ] Build Windows .exe / .msi on merge to main