### PR TITLE
fix(tauri): adapt embedded local relay to new relay server signatures

### DIFF
--- a/manabrew-rs/crates/manabrew-server/src/analytics/mod.rs
+++ b/manabrew-rs/crates/manabrew-server/src/analytics/mod.rs
@@ -26,6 +26,13 @@ pub struct AnalyticsHandle {
 }
 
 impl AnalyticsHandle {
+    pub fn disabled() -> Self {
+        AnalyticsHandle {
+            events: None,
+            capture: None,
+        }
+    }
+
     pub fn from_config(config: &ServerConfig) -> Self {
         let events = config.events_dir.clone().map(|dir| {
             let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);

--- a/manabrew-rs/crates/manabrew-server/src/main.rs
+++ b/manabrew-rs/crates/manabrew-server/src/main.rs
@@ -1,18 +1,7 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-mod analytics;
-mod cleanup;
-mod config;
-mod connection;
-mod error;
-mod lobby;
-mod metrics;
-mod protocol;
-mod replay;
-mod room;
-mod server;
-mod state;
+use manabrew_server::{analytics, config, metrics, server, state};
 
 #[tokio::main]
 async fn main() {

--- a/manabrew-rs/crates/manabrew-server/src/metrics.rs
+++ b/manabrew-rs/crates/manabrew-server/src/metrics.rs
@@ -46,6 +46,10 @@ pub fn install() -> PrometheusHandle {
         .expect("failed to install metrics recorder")
 }
 
+pub fn detached_handle() -> PrometheusHandle {
+    PrometheusBuilder::new().build_recorder().handle()
+}
+
 pub fn record_game_started(engine: EngineKind) {
     counter!(GAMES_STARTED, LABEL_ENGINE => engine_label(engine)).increment(1);
 }

--- a/src-tauri/src/local_relay.rs
+++ b/src-tauri/src/local_relay.rs
@@ -62,6 +62,7 @@ pub async fn start_local_relay(relay: State<'_, LocalRelayHost>) -> Result<Local
             password.clone(),
             4,
             None,
+            manabrew_server::analytics::AnalyticsHandle::disabled(),
         ));
         let shutdown = Arc::new(tokio::sync::Notify::new());
         let health_addr = std::net::SocketAddr::from(([127, 0, 0, 1], 0));
@@ -69,6 +70,7 @@ pub async fn start_local_relay(relay: State<'_, LocalRelayHost>) -> Result<Local
             state,
             listener,
             health_addr,
+            manabrew_server::metrics::detached_handle(),
             shutdown.clone(),
         ));
 


### PR DESCRIPTION
## Summary

- Fixes the v1.1.1 installer build failure (macOS + Windows): `src-tauri/src/local_relay.rs` embeds `manabrew-server` as a library, and #350 changed the signatures of `ServerState::new` (analytics handle) and `server::serve` (metrics handle) without updating this caller.
- The embedded loopback relay now passes `AnalyticsHandle::disabled()` (no events/captures for local play-vs-AI) and a detached `PrometheusHandle` (no global recorder installed in the desktop app).
- The relay's `main.rs` now consumes the library crate instead of re-declaring modules — the bin/lib double-compile is why the bin's dead-code lint forced `disabled()` to be deleted in #350 in the first place, and why the drift wasn't caught.

## Why

Both v1.1.1 installer jobs failed with E0061 in `local_relay.rs`; release and deploy were skipped (prod was deployed by the preceding v1.1.0 run's deploy job, which pulls latest main — so prod is current; only desktop installers are missing). Branch build checks don't compile `src-tauri`, which is how #350 passed CI.

## Test plan

- `cargo check -p manabrew-server` and `cargo check -p manabrew --features forge-room` (the CI installer configuration) both pass locally.
- `cargo clippy -p manabrew-server` introduces no new warnings.
- Behavior-wise the embedded relay is unchanged: analytics disabled = the same no-op paths as unset env; the detached metrics handle only feeds the (unused) local `/metrics` route.