### PR TITLE
fix(ops): source top-decks panel from game_players

### DIFF
--- a/ops/observability/grafana/dashboards/product.json
+++ b/ops/observability/grafana/dashboards/product.json
@@ -520,7 +520,7 @@
       "id": 13,
       "type": "table",
       "title": "Top commanders",
-      "description": "deck selections, humans",
+      "description": "true commander picks from deck selections (sparse before 2026-07-06)",
       "datasource": {
         "type": "frser-sqlite-datasource",
         "uid": "events-sqlite"
@@ -553,8 +553,8 @@
     {
       "id": 14,
       "type": "table",
-      "title": "Top decks",
-      "description": "deck selections, humans",
+      "title": "Top decks by games",
+      "description": "games each deck appeared in (humans; incl. launch archive)",
       "datasource": {
         "type": "frser-sqlite-datasource",
         "uid": "events-sqlite"
@@ -572,8 +572,8 @@
             "type": "frser-sqlite-datasource",
             "uid": "events-sqlite"
           },
-          "queryText": "SELECT deck_name, count(*) AS picks FROM decks WHERE deck_name IS NOT NULL AND is_bot = 0 GROUP BY 1 ORDER BY 2 DESC LIMIT 20",
-          "rawQueryText": "SELECT deck_name, count(*) AS picks FROM decks WHERE deck_name IS NOT NULL AND is_bot = 0 GROUP BY 1 ORDER BY 2 DESC LIMIT 20",
+          "queryText": "SELECT deck_name, count(*) AS games FROM game_players WHERE deck_name IS NOT NULL AND is_bot = 0 GROUP BY 1 ORDER BY 2 DESC LIMIT 20",
+          "rawQueryText": "SELECT deck_name, count(*) AS games FROM game_players WHERE deck_name IS NOT NULL AND is_bot = 0 GROUP BY 1 ORDER BY 2 DESC LIMIT 20",
           "queryType": "table",
           "timeColumns": []
         }


### PR DESCRIPTION
## Summary
- `Top decks` now reads `game_players` (1,087 human rows incl. the launch archive) instead of `decks` (7 usable rows — the archive's deck selections were mostly bot-made).
- `Top commanders` stays on `decks` (true commander picks) with a description noting it's sparse before 2026-07-06 — the recovered launch data only recorded deck names, which aren't reliably commanders.

## Test plan
- Queries verified against prod events.db.