### PR TITLE
fix(ops): node duration panel reads summary quantiles

### DIFF
--- a/ops/observability/grafana/dashboards/live-ops.json
+++ b/ops/observability/grafana/dashboards/live-ops.json
@@ -375,15 +375,18 @@
         }
       ],
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "noValue": "0"
+        },
         "overrides": []
       },
-      "options": {}
+      "options": {},
+      "description": "no series until the first engine error occurs"
     },
     {
       "id": 12,
       "type": "timeseries",
-      "title": "Hosted game duration p50 / p95 (s)",
+      "title": "Hosted game duration p50 / p95 (s, per-node summary)",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -397,21 +400,21 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "histogram_quantile(0.5, sum by (le) (rate(manabrew_node_game_duration_seconds_bucket[6h])))",
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
+          "expr": "max(manabrew_node_game_duration_seconds{quantile=\"0.5\"})",
           "legendFormat": "p50"
         },
         {
           "refId": "B",
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(manabrew_node_game_duration_seconds_bucket[6h])))",
-          "legendFormat": "p95",
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
-          }
+          },
+          "expr": "max(manabrew_node_game_duration_seconds{quantile=\"0.95\"})",
+          "legendFormat": "p95"
         }
       ],
       "fieldConfig": {


### PR DESCRIPTION
## Summary
- The node exporter emits `manabrew_node_game_duration_seconds` as a quantile summary (metrics-exporter-prometheus default without configured buckets), so `histogram_quantile(..._bucket)` returned nothing. Panel now reads the summary quantiles directly (max across nodes).
- Engine-errors panel shows `0` instead of "No data" before the first error ever occurs.

Follow-up (separate): configure real buckets in the node's `metrics.rs` for aggregatable histograms; needs a fleet rebuild, not urgent since per-node summaries suffice at one-game-per-node.