### PR TITLE
fix(harness): prompt for crew creature selection in interactive games

### DIFF
--- a/forge-harness/src/main/java/forge/harness/common/HarnessCostPlumbing.java
+++ b/forge-harness/src/main/java/forge/harness/common/HarnessCostPlumbing.java
@@ -25,11 +25,13 @@ import java.util.Set;
 
 public final class HarnessCostPlumbing {
     private final PlayerController controller;
+    private final HarnessPlayHooks hooks;
     private final Player payer;
     private final List<Set<Card>> reservedSacrificeStack = new ArrayList<>();
 
-    public HarnessCostPlumbing(final PlayerController controller, final Player payer) {
+    public HarnessCostPlumbing(final PlayerController controller, final HarnessPlayHooks hooks, final Player payer) {
         this.controller = controller;
+        this.hooks = hooks;
         this.payer = payer;
     }
 
@@ -836,24 +838,15 @@ public final class HarnessCostPlumbing {
             if (list.isEmpty()) {
                 return null;
             }
-            // Crew / withTotalPowerGE: select creatures greedily (highest power first)
-            // until total power meets the threshold, matching the engine's canPay check.
             if (totalPowerRequired >= 0) {
                 if (CardLists.getTotalPower(list, ability) < totalPowerRequired) {
                     return null;
                 }
-                // Sort by power descending so we tap fewer creatures.
-                list.sort((a, b) -> b.getNetPower() - a.getNetPower());
-                final CardCollection selected = new CardCollection();
-                int accum = 0;
-                for (final Card c : list) {
-                    selected.add(c);
-                    accum = CardLists.getTotalPower(selected, ability);
-                    if (accum >= totalPowerRequired) {
-                        break;
-                    }
+                final CardCollectionView selected = hooks.chooseTapTypeForCost(list, ability, totalPowerRequired);
+                if (selected == null || CardLists.getTotalPower(new CardCollection(selected), ability) < totalPowerRequired) {
+                    return null;
                 }
-                return accum >= totalPowerRequired ? PaymentDecision.card(selected) : null;
+                return PaymentDecision.card(selected);
             }
             final int amount = cost.getAbilityAmount(ability);
             if (sameType) {

--- a/forge-harness/src/main/java/forge/harness/common/HarnessPlayHooks.java
+++ b/forge-harness/src/main/java/forge/harness/common/HarnessPlayHooks.java
@@ -1,6 +1,9 @@
 package forge.harness.common;
 
 import forge.game.card.Card;
+import forge.game.card.CardCollection;
+import forge.game.card.CardCollectionView;
+import forge.game.spellability.SpellAbility;
 
 /**
  * Controller-specific hooks {@link HarnessPlayPlumbing} needs while casting.
@@ -10,4 +13,6 @@ import forge.game.card.Card;
  */
 public interface HarnessPlayHooks {
     void markFailedPaymentCard(Card card);
+
+    CardCollectionView chooseTapTypeForCost(CardCollection valid, SpellAbility ability, int totalPowerRequired);
 }

--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveController.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewInteractiveController.java
@@ -88,7 +88,7 @@ public final class ManaBrewInteractiveController extends PlayerController implem
         super(game, player, lobbyPlayer);
         this.game = game;
         this.session = session;
-        this.costPlumbing = new HarnessCostPlumbing(this, player);
+        this.costPlumbing = new HarnessCostPlumbing(this, this, player);
         this.autoPay = new AutoPay(player, costPlumbing, true);
         this.playPlumbing = new HarnessPlayPlumbing(this, player, costPlumbing);
     }
@@ -102,6 +102,13 @@ public final class ManaBrewInteractiveController extends PlayerController implem
     @Override
     public void markFailedPaymentCard(final Card card) {
         // Interactive play re-prompts naturally; no per-turn skip list.
+    }
+
+    @Override
+    public CardCollectionView chooseTapTypeForCost(final CardCollection valid, final SpellAbility sa, final int totalPowerRequired) {
+        return chooseCardsForEffect(
+                valid, sa, "Select creatures to tap (total power " + totalPowerRequired + " or greater)",
+                0, valid.size(), true, null);
     }
 
     @Override

--- a/forge-harness/src/main/java/forge/harness/parity/DeterministicController.java
+++ b/forge-harness/src/main/java/forge/harness/parity/DeterministicController.java
@@ -104,7 +104,7 @@ public class DeterministicController extends PlayerController implements Harness
         this.deep = deep;
         this.verboseTurns = verboseTurns;
         this.currentTurn = 0;
-        this.costPlumbing = new HarnessCostPlumbing(this, this.player);
+        this.costPlumbing = new HarnessCostPlumbing(this, this, this.player);
         this.autoPay = new AutoPay(this.player, this.costPlumbing);
         this.playPlumbing = new HarnessPlayPlumbing(this, this.player, this.costPlumbing);
     }
@@ -251,6 +251,21 @@ public class DeterministicController extends PlayerController implements Harness
         if (card != null) {
             failedPaymentCardsThisTurn.add(card.getId());
         }
+    }
+
+    // Greedy highest-power-first pick; keep in sync with the Rust parity agent's
+    // DeterministicAgent::choose_tap_type_for_cost.
+    @Override
+    public CardCollectionView chooseTapTypeForCost(final CardCollection valid, final SpellAbility sa, final int totalPowerRequired) {
+        valid.sort((a, b) -> b.getNetPower() - a.getNetPower());
+        final CardCollection selected = new CardCollection();
+        for (final Card c : valid) {
+            selected.add(c);
+            if (CardLists.getTotalPower(selected, sa) >= totalPowerRequired) {
+                break;
+            }
+        }
+        return selected;
     }
 
     @Override


### PR DESCRIPTION
## Summary

Restores the crew creature-selection fix as its own PR. Originally reviewed and merged as #364, but that PR targeted the `fix/concedes-and-leaves` feature branch (PR #343) by mistake. Re-opened here against `main` so each feature ships in its own PR.

Commit:
- `fix(harness): prompt for crew creature selection in interactive games`

## Why

The crew-selection harness fix is independent of the concedes/leaves protocol work and should not be bundled into PR #343. Splitting restores a clean 1-feature-per-PR history.

## Test plan

- Content is identical to the already-reviewed and merged #364 (no code changes on top of that).
- `yarn lint:all`
