### PR TITLE
fix(ui): mobile touch interaction fixes across game, editor, and lobby

### DIFF
--- a/src/components/companion/PlayerNotesDialog.tsx
+++ b/src/components/companion/PlayerNotesDialog.tsx
@@ -40,7 +40,7 @@ function PlayerNotesForm({ player, onClose }: { player: CompanionPlayer; onClose
         rows={6}
         autoFocus
         placeholder="e.g. needs 1 mountain · holding a Counterspell · planeswalker at 4"
-        className="w-full resize-y rounded-md border border-input bg-transparent p-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        className="w-full resize-y rounded-md border border-input bg-transparent p-2 text-sm pointer-coarse:text-base focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
       />
       <DialogFooter>
         <Button variant="ghost" onClick={onClose}>

--- a/src/components/editor/CardSearch.tsx
+++ b/src/components/editor/CardSearch.tsx
@@ -4,13 +4,23 @@ import { useKeybindings } from "@/hooks/useKeybindings";
 import { Input } from "@/components/ui/input";
 import { ManaSymbols } from "@/components/game/ManaSymbols";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Loader2, LayoutGrid, List, Info, SlidersHorizontal, PanelRightClose } from "lucide-react";
+import {
+  Loader2,
+  LayoutGrid,
+  List,
+  Info,
+  Plus,
+  SlidersHorizontal,
+  PanelRightClose,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { ScryfallCard } from "@/types/scryfall";
 import type { CardDto } from "@/protocol/game";
 import type { DeckCard } from "@/protocol/deck";
 import { useDraggable } from "@dnd-kit/core";
+import { toast } from "sonner";
+import { useDeckStore } from "@/stores/useDeckStore";
 import { CardDetailModal } from "@/components/editor/CardDetailModal";
 import { CardThumbnail } from "@/components/editor/deckEditor.primitives";
 import { SetSelect } from "@/components/editor/SetSelect";
@@ -380,12 +390,14 @@ function FilterSeparator({ label }: { label: string }) {
 function DraggableCardGrid({
   card,
   onMoreInfo,
+  onAdd,
   standalone,
   onHover,
   onLeave,
 }: {
   card: DeckCard;
   onMoreInfo: () => void;
+  onAdd?: () => void;
   standalone?: boolean;
   onHover?: (card: DeckCard, e: React.MouseEvent) => void;
   onLeave?: () => void;
@@ -412,6 +424,19 @@ function DraggableCardGrid({
     >
       <CardThumbnail card={card} />
       <div className="absolute inset-0 bg-overlay/60 opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity flex flex-col items-center justify-center gap-1.5 rounded-lg pointer-events-none group-hover:pointer-events-auto pointer-coarse:pointer-events-auto">
+        {onAdd && (
+          <Button
+            size="sm"
+            className="w-4/5 gap-1"
+            onClick={(e) => {
+              e.stopPropagation();
+              onAdd();
+            }}
+          >
+            <Plus className="h-3 w-3" />
+            Add
+          </Button>
+        )}
         <Button
           size="sm"
           variant="secondary"
@@ -434,12 +459,14 @@ function DraggableCardGrid({
 function DraggableCardRow({
   card,
   onMoreInfo,
+  onAdd,
   standalone,
   onHover,
   onLeave,
 }: {
   card: DeckCard;
   onMoreInfo: () => void;
+  onAdd?: () => void;
   standalone?: boolean;
   onHover?: (card: DeckCard, e: React.MouseEvent) => void;
   onLeave?: () => void;
@@ -482,6 +509,20 @@ function DraggableCardRow({
 
       {card.manaCost && <ManaSymbols cost={card.manaCost} size="sm" className="shrink-0" />}
 
+      {onAdd && (
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-6 px-2 text-xs gap-1 opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity shrink-0 pointer-events-none group-hover:pointer-events-auto pointer-coarse:pointer-events-auto"
+          onClick={(e) => {
+            e.stopPropagation();
+            onAdd();
+          }}
+        >
+          <Plus className="h-3 w-3" />
+          Add
+        </Button>
+      )}
       <Button
         size="sm"
         variant="ghost"
@@ -512,6 +553,11 @@ interface CardSearchProps {
 
 export function CardSearch({ standalone, onClose, previewSlot, focusSignal }: CardSearchProps) {
   const preview = useCardPreview();
+  const addToMain = useDeckStore((s) => s.addToMain);
+  const addCard = (card: DeckCard) => {
+    addToMain({ ...card, identity: { ...card.identity, id: crypto.randomUUID() } });
+    toast.success(`Added ${card.identity.name}`);
+  };
   const [text, setText] = useState("");
   const [debouncedText, setDebouncedText] = useState("");
   const [activeColors, setActiveColors] = useState<Set<string>>(new Set());
@@ -1058,6 +1104,7 @@ export function CardSearch({ standalone, onClose, previewSlot, focusSignal }: Ca
                   <DraggableCardGrid
                     card={card}
                     onMoreInfo={() => setDetailCard(rawCards[i])}
+                    onAdd={standalone ? undefined : () => addCard(card)}
                     standalone={standalone}
                     onHover={(c, e) =>
                       preview.handleMouseEnter(c as unknown as CardDto, e, { useDelay: true })
@@ -1074,6 +1121,7 @@ export function CardSearch({ standalone, onClose, previewSlot, focusSignal }: Ca
                   key={card.identity.id}
                   card={card}
                   onMoreInfo={() => setDetailCard(rawCards[i])}
+                  onAdd={standalone ? undefined : () => addCard(card)}
                   standalone={standalone}
                   onHover={(c, e) =>
                     preview.handleMouseEnter(c as unknown as CardDto, e, { useDelay: true })

--- a/src/components/editor/DeckBuilder.tsx
+++ b/src/components/editor/DeckBuilder.tsx
@@ -164,7 +164,7 @@ function QuickCardSearch({
         <Plus className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground pointer-events-none" />
         <Input
           ref={inputRef}
-          className="h-7 text-xs pl-6 pr-6"
+          className="h-7 text-xs pl-6 pr-6 pointer-coarse:h-9 pointer-coarse:text-base"
           placeholder="Quick add card…"
           value={query}
           onChange={(e) => handleChange(e.target.value)}
@@ -881,7 +881,7 @@ export function DeckBuilder({
               <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground pointer-events-none" />
               <Input
                 ref={filterInputRef}
-                className="h-6 text-xs pl-6 pr-6"
+                className="h-6 text-xs pl-6 pr-6 pointer-coarse:h-9 pointer-coarse:text-base"
                 placeholder="Filter…"
                 title="Filter cards by name — comma-separate to match several, e.g. bolt, elves"
                 value={deckFilter}

--- a/src/components/editor/DeckListView.tsx
+++ b/src/components/editor/DeckListView.tsx
@@ -1009,7 +1009,7 @@ function CardSection({
       <Button
         size="icon"
         variant="ghost"
-        className="h-5 w-5 text-destructive opacity-0 hover:opacity-100 transition-opacity shrink-0"
+        className="h-5 w-5 text-destructive opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity shrink-0"
         title={`Remove "${tag}" tag`}
         onClick={onRemoveTag}
       >
@@ -1084,7 +1084,7 @@ function CardSection({
                   <Button
                     size="icon"
                     variant="ghost"
-                    className="h-5 w-5 text-muted-foreground/40 opacity-0 group-hover/tag:opacity-100 transition-opacity shrink-0"
+                    className="h-5 w-5 text-muted-foreground/40 opacity-0 group-hover/tag:opacity-100 pointer-coarse:opacity-100 transition-opacity shrink-0"
                     title="Remove from this tag"
                     onClick={() => onUntagCard(name)}
                   >

--- a/src/components/editor/PlaymatEditorModal.tsx
+++ b/src/components/editor/PlaymatEditorModal.tsx
@@ -406,7 +406,7 @@ export function PlaymatEditorModal({
                     onBlur={() => setBgHex(settings.color)}
                     spellCheck={false}
                     autoComplete="off"
-                    className="h-8 min-w-0 flex-1 rounded border border-input bg-background px-2 font-mono text-xs uppercase"
+                    className="h-8 min-w-0 flex-1 rounded border border-input bg-background px-2 font-mono text-xs uppercase pointer-coarse:text-base"
                   />
                   {settings.color && (
                     <Button
@@ -455,7 +455,7 @@ export function PlaymatEditorModal({
                     onBlur={() => setBorderHex(settings.borderColor)}
                     spellCheck={false}
                     autoComplete="off"
-                    className="h-8 min-w-0 flex-1 rounded border border-input bg-background px-2 font-mono text-xs uppercase"
+                    className="h-8 min-w-0 flex-1 rounded border border-input bg-background px-2 font-mono text-xs uppercase pointer-coarse:text-base"
                   />
                 </div>
               </div>

--- a/src/components/game/ManualTabletopControls.tsx
+++ b/src/components/game/ManualTabletopControls.tsx
@@ -413,6 +413,7 @@ export function ManualTabletopControls({ gameView, api }: ManualTabletopControls
                     size="icon"
                     className="h-6 w-6"
                     title={card.tapped ? "Untap" : "Tap"}
+                    aria-label={card.tapped ? "Untap" : "Tap"}
                     onClick={() =>
                       void applyAction({
                         type: "tapCard",
@@ -429,6 +430,7 @@ export function ManualTabletopControls({ gameView, api }: ManualTabletopControls
                     size="icon"
                     className="h-6 w-6"
                     title="Move to hand"
+                    aria-label="Move to hand"
                     onClick={() => void moveCard(card, "hand")}
                   >
                     <Hand className="h-3 w-3" />
@@ -439,6 +441,7 @@ export function ManualTabletopControls({ gameView, api }: ManualTabletopControls
                     size="icon"
                     className="h-6 w-6"
                     title="Move to exile"
+                    aria-label="Move to exile"
                     onClick={() =>
                       void moveCard(
                         card,
@@ -454,6 +457,7 @@ export function ManualTabletopControls({ gameView, api }: ManualTabletopControls
                     size="icon"
                     className="h-6 w-6"
                     title="Move to graveyard"
+                    aria-label="Move to graveyard"
                     onClick={() =>
                       void moveCard(
                         card,

--- a/src/components/game/modals/Modal.tsx
+++ b/src/components/game/modals/Modal.tsx
@@ -70,6 +70,7 @@ export function Modal({
     <div
       className={cn(
         "fixed inset-0 z-[9000] flex items-center justify-center bg-black/60 backdrop-blur-sm",
+        "pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)] pr-[env(safe-area-inset-right)] pt-[env(safe-area-inset-top)]",
         touchGameSurface && "game-touch-surface",
         backdropClassName,
       )}
@@ -84,7 +85,8 @@ export function Modal({
         className={cn(
           "relative bg-card border rounded-xl shadow-2xl flex flex-col w-full mx-4 animate-in fade-in zoom-in-95 duration-200",
           maxWidth,
-          maxHeight || "max-h-[calc(100dvh-1rem)]",
+          maxHeight ||
+            "max-h-[calc(100dvh-1rem-env(safe-area-inset-top)-env(safe-area-inset-bottom))]",
           className,
         )}
         onClick={(e) => e.stopPropagation()}

--- a/src/components/game/panels/MiddleBarDock.tsx
+++ b/src/components/game/panels/MiddleBarDock.tsx
@@ -127,7 +127,14 @@ export function MiddleBarDock({
           title={isMyPriority ? undefined : "Wait until you have priority to concede"}
         >
           <Flag className="mr-2 h-4 w-4" />
-          Concede
+          <span className="flex flex-col">
+            Concede
+            {!isMyPriority && (
+              <span className="text-[10px] text-muted-foreground">
+                Wait until you have priority
+              </span>
+            )}
+          </span>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/components/game/panels/promptContextHints.ts
+++ b/src/components/game/panels/promptContextHints.ts
@@ -47,6 +47,8 @@ export function getPromptContextLines(
       if (cost.delveCount) lines.push(`Delved for {${cost.delveCount}}`);
       return lines;
     }
+    case "chooseTargetSpell":
+      return ["Tap a glowing spell on the stack to counter it"];
     default:
       return [];
   }

--- a/src/components/limited/DraftCardTile.tsx
+++ b/src/components/limited/DraftCardTile.tsx
@@ -3,9 +3,11 @@ import { memo } from "react";
 import { CardThumbnail } from "@/components/editor/deckEditor.primitives";
 import { FoilBadge } from "@/components/limited/FoilBadge";
 import type { useCardPreview } from "@/hooks/useCardPreview";
+import { useLongPressPreview } from "@/hooks/useLongPressPreview";
 import { useDeckCard } from "@/lib/limited.utils";
 import { cn } from "@/lib/utils";
 import type { DraftCard } from "@/types/limited";
+import type { DeckCard } from "@/protocol/deck";
 import type { CardDto } from "@/protocol/game";
 
 interface DraftCardTileProps {
@@ -26,6 +28,15 @@ function DraftCardTileImpl({
   overlay,
 }: DraftCardTileProps) {
   const deckCard = useDeckCard(card, index);
+  const longPress = useLongPressPreview<DeckCard>({
+    resolve: (e) => (deckCard ? { item: deckCard, anchor: e.currentTarget as HTMLElement } : null),
+    show: (item, rect) =>
+      preview?.handleMouseEnter(item as unknown as CardDto, undefined, {
+        useAnchor: true,
+        anchorOverride: rect,
+      }),
+    hide: () => preview?.dismiss(),
+  });
   if (!deckCard) {
     return (
       <div className="relative w-full">
@@ -42,6 +53,7 @@ function DraftCardTileImpl({
         preview?.handleMouseEnter(deckCard as unknown as CardDto, e, { useDelay: true })
       }
       onMouseLeave={() => preview?.handleMouseLeave()}
+      {...longPress}
       className={cn(
         "group relative w-full text-left transition hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-60",
         card.foil && "draft-tile-foil",

--- a/src/components/lobby/ChatComponent.tsx
+++ b/src/components/lobby/ChatComponent.tsx
@@ -81,7 +81,7 @@ export function ChatComponent({ channelId }: ChatComponentProps) {
       </ScrollArea>
       <div className="p-2 border-t flex gap-1.5">
         <Input
-          className="h-8 text-xs"
+          className="h-8 text-xs pointer-coarse:h-10 pointer-coarse:text-base"
           placeholder="Type a message..."
           value={input}
           onChange={(e) => setInput(e.target.value)}

--- a/src/components/lobby/CreateRoomDialog.tsx
+++ b/src/components/lobby/CreateRoomDialog.tsx
@@ -658,7 +658,7 @@ export function CreateRoomDialog({ open, onOpenChange }: CreateRoomDialogProps) 
                     value={cubeInput}
                     onChange={(e) => setCubeInput(e.target.value)}
                     placeholder="cubeid or cubecobra.com/…"
-                    className="h-9 text-sm flex-1"
+                    className="h-9 text-sm flex-1 pointer-coarse:text-base"
                     disabled={importingCube}
                   />
                   <Button

--- a/src/components/lobby/DeckVsSelector.tsx
+++ b/src/components/lobby/DeckVsSelector.tsx
@@ -235,7 +235,7 @@ export function DeckVsSelector({ onStart, onStartTabletop }: DeckVsSelectorProps
             placeholder="Filter decks..."
             value={deckSearch}
             onChange={(e) => setDeckSearch(e.target.value)}
-            className="w-full pl-8 pr-3 py-1.5 rounded-md border bg-background text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+            className="w-full pl-8 pr-3 py-1.5 rounded-md border bg-background text-sm pointer-coarse:text-base focus:outline-none focus:ring-1 focus:ring-primary"
             autoComplete="off"
             autoCorrect="off"
             autoCapitalize="off"

--- a/src/components/lobby/TablesList.tsx
+++ b/src/components/lobby/TablesList.tsx
@@ -521,6 +521,13 @@ export function TablesList({
                       <Swords className="h-3 w-3" /> Start Game
                     </Button>
                   )}
+                  {!canStart && (
+                    <p className="hidden w-full text-right text-[10px] text-muted-foreground pointer-coarse:block">
+                      {!controllerHasDeck && !isOpenFormat
+                        ? "Select a deck before starting"
+                        : "All other players must be ready"}
+                    </p>
+                  )}
                 </div>
               )}
               {!isController && currentRoom.status === "Lobby" && myPlayer && (
@@ -555,7 +562,7 @@ export function TablesList({
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search rooms…"
-              className="h-8 pl-8 text-sm"
+              className="h-8 pl-8 text-sm pointer-coarse:h-10 pointer-coarse:text-base"
             />
           </div>
         </div>

--- a/src/components/prompts/ChooseCardsModal.tsx
+++ b/src/components/prompts/ChooseCardsModal.tsx
@@ -6,6 +6,9 @@ import { Card } from "@/components/game/Card";
 import { stackObjectToCardStub } from "@/components/game/game.utils";
 import { CHOOSE_CARD_TILE_SIZE } from "@/components/game/game.styles";
 import { useGameStore } from "@/stores/useGameStore";
+import { useCardPreview } from "@/hooks/useCardPreview";
+import { useLongPressPreview } from "@/hooks/useLongPressPreview";
+import { HoverCardPreview } from "@/components/game/HoverCardPreview";
 import { useModalKeyboard } from "@/hooks/useModalKeyboard";
 import { cn } from "@/lib/utils";
 import { PromptPresentation } from "./internal/PromptPresentation";
@@ -25,6 +28,7 @@ function SelectableCard({
 }) {
   return (
     <div
+      data-card-id={card.id}
       onClick={disabled ? undefined : onClick}
       className={cn(
         CHOOSE_CARD_TILE_SIZE,
@@ -79,6 +83,18 @@ export function ChooseCardsModal({
   const acknowledge = () => onConfirm([]);
   useModalKeyboard({ onEnter: reveal ? acknowledge : undefined }, [reveal]);
 
+  const preview = useCardPreview();
+  const longPress = useLongPressPreview<CardDto>({
+    resolve: (e) => {
+      const el = (e.target as HTMLElement).closest<HTMLElement>("[data-card-id]");
+      const card = el && cards.find((c) => c.id === el.dataset.cardId);
+      return card ? { item: card, anchor: el } : null;
+    },
+    show: (card, rect) =>
+      preview.handleMouseEnter(card, undefined, { useAnchor: true, anchorOverride: rect }),
+    hide: preview.dismiss,
+  });
+
   return (
     <Modal maxWidth="max-w-3xl" maxHeight="">
       {sourceCard && (
@@ -100,10 +116,11 @@ export function ChooseCardsModal({
             ? "max-h-[60dvh] flex-wrap justify-center overflow-y-auto"
             : "always-scrollbar scrollbar-inset-x flex-nowrap overflow-x-auto",
         )}
+        {...longPress}
       >
         {cards.map((c) =>
           reveal ? (
-            <div key={c.id} className={cn(CHOOSE_CARD_TILE_SIZE, "shrink-0")}>
+            <div key={c.id} data-card-id={c.id} className={cn(CHOOSE_CARD_TILE_SIZE, "shrink-0")}>
               <Card card={c} className="w-full" />
             </div>
           ) : (
@@ -141,6 +158,7 @@ export function ChooseCardsModal({
           </>
         )}
       </Modal.Footer>
+      <HoverCardPreview preview={preview} />
     </Modal>
   );
 }

--- a/src/components/prompts/ScryModal.tsx
+++ b/src/components/prompts/ScryModal.tsx
@@ -3,7 +3,8 @@ import {
   DndContext,
   DragOverlay,
   defaultDropAnimationSideEffects,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   pointerWithin,
   useDraggable,
   useDroppable,
@@ -65,7 +66,7 @@ function DraggableCard({
       {...(disabled ? {} : listeners)}
       className={cn(
         CARD_W,
-        "relative shrink-0 touch-none rounded-lg ring-primary",
+        "relative shrink-0 touch-pan-x rounded-lg ring-primary",
         disabled ? "cursor-default" : "cursor-grab hover:z-10 hover:ring-2",
         isDragging && "opacity-0",
         className,
@@ -130,14 +131,14 @@ function Zone({
 }) {
   const { setNodeRef, isOver } = useDroppable({ id });
   return (
-    <div className="flex min-w-0 flex-1 flex-col">
+    <div className="flex min-w-[140px] flex-1 flex-col">
       <p className="mb-2 text-xs font-bold uppercase tracking-wide text-muted-foreground">
         {DESTINATION_META[destination].label}
       </p>
       <div
         ref={setNodeRef}
         className={cn(
-          "flex h-[320px] items-center overflow-hidden rounded-lg border-2 border-dashed p-3",
+          "flex h-[200px] items-center overflow-hidden rounded-lg border-2 border-dashed p-3 sm:h-[320px]",
           ids.length === 0 ? "justify-center" : "flex-nowrap justify-center",
           isOver ? "border-primary bg-primary/5" : "border-muted-foreground/40",
         )}
@@ -225,7 +226,10 @@ export function ScryModal({ input, respond }: PromptProps<ScryInput, ScryOutput>
     ...Object.fromEntries(zoneIds.map((z) => [z, [] as string[]])),
   }));
   const [activeId, setActiveId] = useState<string | null>(null);
-  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 8 } }),
+  );
 
   // Re-seed when the card set changes (e.g. preview cards arrive after mount).
   const cardKey = useMemo(() => cards.map((c) => c.id).join("|"), [cards]);
@@ -278,7 +282,7 @@ export function ScryModal({ input, respond }: PromptProps<ScryInput, ScryOutput>
         </p>
         <PoolRow id={POOL} ids={items[POOL]} cardsById={cardsById} />
 
-        <div className="flex gap-3 px-5 pb-4">
+        <div className="flex flex-wrap gap-3 px-5 pb-4">
           {zones.map((destination, i) => (
             <Zone
               key={zoneIds[i]}

--- a/src/hooks/useHandDrag.ts
+++ b/src/hooks/useHandDrag.ts
@@ -56,8 +56,17 @@ export function useHandDrag({
       document.removeEventListener("pointermove", handlePointerMove);
       document.removeEventListener("pointerup", handlePointerUp);
       document.removeEventListener("pointercancel", handlePointerCancel);
+      document.removeEventListener("pointerdown", handleSecondPointerDown);
       longPress.cancel();
       teardownRef.current = null;
+    };
+
+    // A second finger means a pinch, not a cast — abort without releasing the
+    // spell over the battlefield.
+    const handleSecondPointerDown = (pe: PointerEvent) => {
+      if (pe.pointerId === start.pointerId) return;
+      teardown();
+      reset();
     };
 
     const handlePointerMove = (pe: PointerEvent) => {
@@ -118,6 +127,7 @@ export function useHandDrag({
     document.addEventListener("pointermove", handlePointerMove);
     document.addEventListener("pointerup", handlePointerUp);
     document.addEventListener("pointercancel", handlePointerCancel);
+    document.addEventListener("pointerdown", handleSecondPointerDown);
     teardownRef.current = () => {
       teardown();
       reset();

--- a/src/pixi/BoardOverlayCanvas.tsx
+++ b/src/pixi/BoardOverlayCanvas.tsx
@@ -137,26 +137,69 @@ export function BoardOverlayCanvas({
   }, []);
 
   useEffect(() => {
-    const onMove = (e: PointerEvent) => {
+    const insideStack = (clientX: number, clientY: number): boolean => {
       const canvas = canvasRef.current;
       const bounds = stackRef.current?.getBounds();
-      if (!canvas) return;
-      if (!bounds) {
-        canvas.style.pointerEvents = "none";
-        return;
-      }
+      if (!canvas || !bounds) return false;
       const rect = canvas.getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      const y = e.clientY - rect.top;
-      const inside =
+      const x = clientX - rect.left;
+      const y = clientY - rect.top;
+      return (
         x >= bounds.x &&
         x <= bounds.x + bounds.width &&
         y >= bounds.y &&
-        y <= bounds.y + bounds.height;
-      canvas.style.pointerEvents = inside ? "auto" : "none";
+        y <= bounds.y + bounds.height
+      );
+    };
+    const onMove = (e: PointerEvent) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      canvas.style.pointerEvents = insideStack(e.clientX, e.clientY) ? "auto" : "none";
+    };
+    // Touch taps arrive with no preceding pointermove, so the hover tracking
+    // above never enables the canvas for them. Intercept the touch at the
+    // window capture phase and replay it onto the canvas so Pixi sees a full
+    // down/up pair (the board underneath must not also react — stop the
+    // original).
+    const clonePointerEvent = (type: string, e: PointerEvent) =>
+      new PointerEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        pointerId: e.pointerId,
+        pointerType: e.pointerType,
+        isPrimary: e.isPrimary,
+        clientX: e.clientX,
+        clientY: e.clientY,
+        button: e.button,
+        buttons: e.buttons,
+      });
+    let replayPointerId: number | null = null;
+    const onDown = (e: PointerEvent) => {
+      if (e.pointerType !== "touch") return;
+      const canvas = canvasRef.current;
+      if (!canvas || !insideStack(e.clientX, e.clientY)) return;
+      e.stopPropagation();
+      canvas.style.pointerEvents = "auto";
+      replayPointerId = e.pointerId;
+      canvas.dispatchEvent(clonePointerEvent("pointerdown", e));
+    };
+    const onUp = (e: PointerEvent) => {
+      if (e.pointerId !== replayPointerId) return;
+      replayPointerId = null;
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      e.stopPropagation();
+      canvas.dispatchEvent(clonePointerEvent("pointerup", e));
+      canvas.style.pointerEvents = "none";
     };
     window.addEventListener("pointermove", onMove);
-    return () => window.removeEventListener("pointermove", onMove);
+    window.addEventListener("pointerdown", onDown, true);
+    window.addEventListener("pointerup", onUp, true);
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerdown", onDown, true);
+      window.removeEventListener("pointerup", onUp, true);
+    };
   }, []);
 
   useEffect(

--- a/src/pixi/board/BoardScene.ts
+++ b/src/pixi/board/BoardScene.ts
@@ -1591,6 +1591,7 @@ export class BoardScene {
     }
     this.dragHandler.cancel();
     this.attackDragCandidate = null;
+    if (this.blockDragBlockerId) this.setBlockDragId(null);
     if (this.unassignDrag) {
       const ud = this.unassignDrag;
       this.unassignDrag = null;

--- a/src/views/DeckEditor.tsx
+++ b/src/views/DeckEditor.tsx
@@ -8,7 +8,8 @@ import { useKeybindings } from "@/hooks/useKeybindings";
 import {
   DndContext,
   DragOverlay,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   useSensor,
   useSensors,
   pointerWithin,
@@ -137,7 +138,10 @@ export default function DeckEditor() {
 
   const blocker = useBlocker(hasUnsavedChanges && view === "editor" && !isReadOnly);
 
-  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 8 } }),
+  );
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary

Systematic touch/smartphone audit fixes, in four commits:

- **Game-blocking fixes** — the spell-stack overlay now receives touch taps (tap a spell to target it, collapse/expand the pile): touch `pointerdown` is intercepted and replayed onto the overlay canvas since the hover-tracking gate never fires for stationary taps. `ScryModal` no longer soft-locks on phones (touch drag via `TouchSensor` hold-to-drag, `touch-pan-x` scrolling in the pool row, wrapping destination zones with phone-sized heights). Game modals get safe-area insets (they portal outside the padded game root, so tall modals' Confirm sat under the iOS home indicator). A long-press during declare-blockers no longer leaves the block-drag armed. A second finger (pinch) during a hand drag aborts the drag instead of casting on release.
- **Deck editor touch enablement** — `TouchSensor` (250ms hold) added to the editor's DnD so cards can actually be dragged between boards on touch; searched cards get an always-visible-on-coarse "Add" button (drag was the only affordance and it was dead); tag-removal buttons are visible on coarse pointers; filter/quick-add inputs sized for touch.
- **Long-press previews** — draft pick tiles and `ChooseCardsModal` card grids adopt the app-wide long-press = preview convention (hold to enlarge, release to hide, tap suppressed), so drafters can finally read cards before an irreversible pick.
- **Copy & input sweep** — seven inputs no longer trigger iOS zoom-on-focus (`pointer-coarse:text-base`); disabled-Start reasons in the lobby and the concede wait-for-priority reason render as visible captions on touch instead of dead `title` tooltips; `chooseTargetSpell` gets a mobile context hint; icon-only tabletop controls get `aria-label`s.

## Why

The mobile audit (deck editor, game, lobby/draft, Pixi board, app-wide sweep) found the deck editor had no touch wiring at all, and several game surfaces relied on hover/`title`/keyboard affordances that don't exist on touch. Details per finding are in the audit; deferred as follow-ups: multiplayer-draft undo (needs protocol work), touch multi-select model, target-commit confirmation.

Based on `various-issues-fix` (#368) — retarget to `main` after that merges.

## Test plan

- `yarn typecheck`, eslint, prettier pass.
- Manual (phone): tap a stack spell while holding a counterspell target prompt → targets; scry 4+ cards → all placeable, Confirm enabled; drag a card from search into the deck with a 250ms hold; long-press a draft pick to preview; chat/search inputs no longer zoom the page on focus; disabled Start button shows its reason.
- Manual (desktop regression): stack hover interactions, editor mouse drag, scry drag, hand drag-to-cast unchanged.