### PR TITLE
fix(ui): reset relay room after forced game end and latch start button

### DIFF
--- a/src/components/lobby/TablesList.tsx
+++ b/src/components/lobby/TablesList.tsx
@@ -118,6 +118,7 @@ interface TablesListProps {
   onStartDraft?: () => void;
   onStartSealed?: () => void;
   startingLimited?: boolean;
+  startingGame?: boolean;
   onAddBot?: () => void;
   onRemoveBot?: (username: string) => void;
   /** Bots this host process spawned — used to show the remove button. The
@@ -141,6 +142,7 @@ export function TablesList({
   onStartDraft,
   onStartSealed,
   startingLimited = false,
+  startingGame = false,
   onAddBot,
   onRemoveBot,
   mySpawnedBots = [],
@@ -172,7 +174,7 @@ export function TablesList({
   const controllerHasDeck =
     isOpenFormat ||
     !!currentRoom?.players.find((p) => p.username === controllerName)?.selected_deck_name;
-  const canStart = allOtherPlayersReady && controllerHasDeck;
+  const canStart = currentRoom?.status === "Lobby" && allOtherPlayersReady && controllerHasDeck;
   const readyDisabled = !isOpenFormat && !myPlayerHasDeck;
 
   const orderedPlayers = currentRoom
@@ -509,7 +511,7 @@ export function TablesList({
                       size="sm"
                       className="gap-1"
                       onClick={() => onStartGame()}
-                      disabled={!canStart}
+                      disabled={!canStart || startingGame}
                       title={
                         !controllerHasDeck
                           ? "Select a deck before starting"
@@ -518,7 +520,7 @@ export function TablesList({
                             : undefined
                       }
                     >
-                      <Swords className="h-3 w-3" /> Start Game
+                      <Swords className="h-3 w-3" /> {startingGame ? "Starting…" : "Start Game"}
                     </Button>
                   )}
                 </div>

--- a/src/hooks/useGameEventListeners.ts
+++ b/src/hooks/useGameEventListeners.ts
@@ -280,6 +280,7 @@ export function useGameEventListeners() {
       unsubscribers.push(
         platform.events.on<{ reason: string; message: string }>("game:forced_end", (payload) => {
           const message = payload?.message ?? "Forced game exit";
+          const { isMultiplayer, isHost } = getState();
           clearActiveGameSession();
           setState({
             isGameActive: false,
@@ -294,6 +295,12 @@ export function useGameEventListeners() {
             snapshots: [],
             debugInfo: `Game ended: ${message}`,
           });
+          // Without EndGame the relay room stays InGame and every rematch
+          // action bounces off "Game has already started".
+          if (isMultiplayer && isHost) {
+            toast.error("Game ended unexpectedly — returning the room to the lobby.");
+            void useServerStore.getState().endGame();
+          }
         }),
       );
     } catch (e) {

--- a/src/views/Lobby.tsx
+++ b/src/views/Lobby.tsx
@@ -145,6 +145,7 @@ export default function Lobby() {
   const [mySpawnedBots, setMySpawnedBots] = useState<string[]>([]);
   const [botDeckTarget, setBotDeckTarget] = useState<string | null>(null);
   const [startingLimited, setStartingLimited] = useState(false);
+  const [startingGame, setStartingGame] = useState(false);
   const [roomPasswords, setRoomPasswords] = useState<Record<string, string>>({});
 
   const draftMode = useMultiplayerDraftStore((s) => s.mode);
@@ -380,6 +381,22 @@ export default function Lobby() {
     setAiDeckDialogOpen(true);
   }
 
+  async function handleStartGame() {
+    const room = currentRoom;
+    if (!room || startingGame) return;
+    setStartingGame(true);
+    const ackPromise = awaitGameStartedAck(room.room_id);
+    ackPromise.catch(() => {});
+    try {
+      await startGame();
+      await ackPromise;
+    } catch (e) {
+      toast.error(`Failed to start game: ${String(e)}`);
+    } finally {
+      setStartingGame(false);
+    }
+  }
+
   async function handleStartDraft() {
     const room = currentRoom;
     if (!room || !username) return;
@@ -588,11 +605,12 @@ export default function Lobby() {
             onSetFormat={setFormat}
             onSetMaxPlayers={handleSetMaxPlayers}
             onOpenDeckDialog={() => setDeckDialogOpen(true)}
-            onStartGame={startGame}
+            onStartGame={handleStartGame}
             onStartTabletop={handleStartTabletop}
             onStartDraft={handleStartDraft}
             onStartSealed={handleStartSealed}
             startingLimited={startingLimited}
+            startingGame={startingGame}
             onAddBot={handleAddAiBot}
             onRemoveBot={handleRemoveBot}
             mySpawnedBots={mySpawnedBots}


### PR DESCRIPTION
## Summary
- When the host's WASM engine dies mid-game (`game:forced_end`, e.g. an engine panic), the host now sends the relay `EndGame` — the relay resets the room to Lobby (existing `reset_room_to_lobby`) and fans out `GameAborted` so guests exit cleanly. A toast tells the host the game ended unexpectedly. Previously nobody informed the relay: the room stayed `InGame` forever and every rematch action bounced off "Game has already started" until all players disconnected and the abort timer reaped it.
- The lobby Start Game button gets a `startingGame` latch mirroring the Draft/Sealed `startingLimited` pattern: it disables and shows "Starting…" from click until the `GameStarted` ack (toast on failure), and `canStart` now also requires `room.status === "Lobby"` — so the button can no longer fire into an in-game room.

## Why
Prod relay logs show two flavors of `start game failed: Game has already started` spam:
- A host whose engine crashed was stranded in a stuck room for a minute+ (deck/ready/start all rejected) until they closed the tab — the room was `InGame` relay-side with no game running anywhere.
- A host whose start *succeeded* kept clicking the still-enabled Start button during the seconds of engine boot, sending a dozen redundant `StartGame`s.

## Test plan
- `yarn typecheck`, eslint, prettier clean; full vitest suite passes
- Engine-crash path: host game force-ends → toast shown, relay logs `ended game in room`, `RoomUpdate` returns the room to Lobby, guests get `GameAborted`; rematch (deck/ready/start) succeeds in the same room
- Start latch: clicking Start disables the button ("Starting…") until `GameStarted` arrives; once the room is `InGame` the button stays disabled; a failed start re-enables it with an error toast
- Draft/Sealed start buttons unaffected (still gated by `startingLimited`, now also by room status, which is `Lobby` whenever they are actionable)