### PR TITLE
feat(ui): deck hub view, publish flow, top decks

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -6,29 +6,29 @@ Read first: `/AGENTS.md`, `docs/STYLE_GUIDELINES.md`, `docs/agents/UI_THEME_RULE
 
 ## Folder map
 
-| Folder                  | What lives there                                                                                                        |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `components/ui/`        | Shadcn primitives (Button, Card, Dialog, …). No domain logic.                                                           |
-| `components/game/`      | Game board UI — has its own AGENTS.md.                                                                                  |
-| `components/editor/`    | Deck builder.                                                                                                           |
-| `components/deck/`      | Deck card displays, label badges. Stateless.                                                                            |
-| `components/lobby/`     | Room list, chat, deck picker.                                                                                           |
-| `components/companion/` | Paper-play life tracker — has its own AGENTS.md.                                                                        |
-| `components/layout/`    | App shell, sidebar, logo. Visible everywhere — change with care.                                                        |
-| `components/dev/`       | Dev-only panels, gated behind a flag. Don't import in production paths.                                                 |
-| `components/icons/`     | Hand-rolled SVG icon components for brands lucide lacks (Discord). Stateless.                                           |
-| `views/`                | Page-level views routed by `router.tsx`. Compose components; no heavy logic.                                            |
-| `stores/`               | Zustand stores. One per concern. Types in `*.types.ts` siblings, constants in `*.constants.ts`.                         |
-| `hooks/`                | App-wide hooks. Component-specific hooks co-locate with the component.                                                  |
-| `themes/`               | The 12 color presets. Schema is `GameThemeColors`. See `docs/agents/UI_THEME_RULES.md`.                                 |
-| `types/`                | Shared TS interfaces. `manabrew.ts` is the engine ↔ UI DTO contract.                                                    |
-| `game/`                 | Frontend game runtime: room host, relay, runtime registry, multiplayer draft host/peer (`draft*.ts`). UI ↔ engine seam. |
-| `pixi/`                 | PIXI.js scene. Reads theme directly via `getTheme().gameTheme.*` — never literal hex.                                   |
-| `platform/`             | Web vs Tauri detection / IPC. New platform calls route through this — never `window.__TAURI__` directly.                |
-| `lib/`                  | Pure utilities (no React). Scryfall helpers, mana parsing, deck import.                                                 |
-| `api/`                  | External I/O: Scryfall HTTP client and Tauri IPC. (`queryClient.ts` is a legacy TanStack remnant — do not build on it.) |
-| `workers/`              | Web worker hosting the WASM engine — used by both browser and desktop (Tauri) builds.                                   |
-| `wasm/`                 | wasm-bindgen output. Don't hand-edit; regenerate via `scripts/build-wasm.mjs`.                                          |
+| Folder                  | What lives there                                                                                                                                                        |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `components/ui/`        | Shadcn primitives (Button, Card, Dialog, …). No domain logic.                                                                                                           |
+| `components/game/`      | Game board UI — has its own AGENTS.md.                                                                                                                                  |
+| `components/editor/`    | Deck builder.                                                                                                                                                           |
+| `components/deck/`      | Deck card displays, label badges. Stateless.                                                                                                                            |
+| `components/lobby/`     | Room list, chat, deck picker.                                                                                                                                           |
+| `components/companion/` | Paper-play life tracker — has its own AGENTS.md.                                                                                                                        |
+| `components/layout/`    | App shell, sidebar, logo. Visible everywhere — change with care.                                                                                                        |
+| `components/dev/`       | Dev-only panels, gated behind a flag. Don't import in production paths.                                                                                                 |
+| `components/icons/`     | Hand-rolled SVG icon components for brands lucide lacks (Discord). Stateless.                                                                                           |
+| `views/`                | Page-level views routed by `router.tsx`. Compose components; no heavy logic.                                                                                            |
+| `stores/`               | Zustand stores. One per concern. Types in `*.types.ts` siblings, constants in `*.constants.ts`.                                                                         |
+| `hooks/`                | App-wide hooks. Component-specific hooks co-locate with the component.                                                                                                  |
+| `themes/`               | The 12 color presets. Schema is `GameThemeColors`. See `docs/agents/UI_THEME_RULES.md`.                                                                                 |
+| `types/`                | Shared TS interfaces. `manabrew.ts` is the engine ↔ UI DTO contract.                                                                                                    |
+| `game/`                 | Frontend game runtime: room host, relay, runtime registry, multiplayer draft host/peer (`draft*.ts`). UI ↔ engine seam.                                                 |
+| `pixi/`                 | PIXI.js scene. Reads theme directly via `getTheme().gameTheme.*` — never literal hex.                                                                                   |
+| `platform/`             | Web vs Tauri detection / IPC. New platform calls route through this — never `window.__TAURI__` directly.                                                                |
+| `lib/`                  | Pure utilities (no React). Scryfall helpers, mana parsing, deck import.                                                                                                 |
+| `api/`                  | External I/O: Scryfall HTTP client, Deck Hub client (`hub.ts` → api.manabrew.app), and Tauri IPC. (`queryClient.ts` is a legacy TanStack remnant — do not build on it.) |
+| `workers/`              | Web worker hosting the WASM engine — used by both browser and desktop (Tauri) builds.                                                                                   |
+| `wasm/`                 | wasm-bindgen output. Don't hand-edit; regenerate via `scripts/build-wasm.mjs`.                                                                                          |
 
 ## Conventions
 

--- a/src/api/hub.ts
+++ b/src/api/hub.ts
@@ -1,0 +1,73 @@
+import { getHubApiUrl } from "@/config/webRuntimeConfig";
+import { platformFetch } from "@/lib/platformFetch";
+import type {
+  HubDeckDetail,
+  HubDeckList,
+  PublishDeckRequest,
+  PublishDeckResponse,
+  TopDeckStat,
+} from "@/protocol/hub";
+
+export type HubSort = "newest" | "name";
+export type TopDecksWindow = "7d" | "30d" | "all";
+
+export interface HubListParams {
+  search?: string;
+  format?: string;
+  sort?: HubSort;
+  page?: number;
+  pageSize?: number;
+}
+
+const MANAGEMENT_TOKEN_HEADER = "X-Management-Token";
+
+async function hubRequest(path: string, init?: RequestInit): Promise<Response> {
+  const response = await platformFetch(`${getHubApiUrl()}${path}`, init);
+  if (!response.ok) {
+    const message = await response.text().catch(() => "");
+    if (response.status === 429) {
+      throw new Error("Too many publishes from your connection — try again later.");
+    }
+    throw new Error(message || `Hub request failed (${response.status})`);
+  }
+  return response;
+}
+
+async function hubJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await hubRequest(path, init);
+  return (await response.json()) as T;
+}
+
+export function fetchHubDecks(params: HubListParams): Promise<HubDeckList> {
+  const query = new URLSearchParams();
+  if (params.search) query.set("search", params.search);
+  if (params.format) query.set("format", params.format);
+  if (params.sort) query.set("sort", params.sort);
+  if (params.page) query.set("page", String(params.page));
+  if (params.pageSize) query.set("pageSize", String(params.pageSize));
+  const suffix = query.size > 0 ? `?${query.toString()}` : "";
+  return hubJson<HubDeckList>(`/api/hub/decks${suffix}`);
+}
+
+export function fetchHubDeck(id: string): Promise<HubDeckDetail> {
+  return hubJson<HubDeckDetail>(`/api/hub/decks/${encodeURIComponent(id)}`);
+}
+
+export function publishDeck(request: PublishDeckRequest): Promise<PublishDeckResponse> {
+  return hubJson<PublishDeckResponse>("/api/hub/decks", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
+}
+
+export async function unpublishDeck(id: string, managementToken: string): Promise<void> {
+  await hubRequest(`/api/hub/decks/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+    headers: { [MANAGEMENT_TOKEN_HEADER]: managementToken },
+  });
+}
+
+export function fetchTopDecks(window: TopDecksWindow, limit = 25): Promise<TopDeckStat[]> {
+  return hubJson<TopDeckStat[]>(`/api/stats/top-decks?window=${window}&limit=${limit}`);
+}

--- a/src/components/deck/DeckGridCard.tsx
+++ b/src/components/deck/DeckGridCard.tsx
@@ -11,7 +11,7 @@ import {
 import { DeckLabelBadge } from "@/components/deck/DeckLabelBadge";
 import { FormatBadge } from "@/components/game/FormatBadge";
 import { ManaSymbols } from "@/components/game/ManaSymbols";
-import { Pencil, Trash2 } from "lucide-react";
+import { Pencil, Share2, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { SavedDeck } from "@/stores/useDeckStore";
 import { DeckCoverImage } from "@/components/deck/deckCover";
@@ -27,6 +27,7 @@ interface DeckGridCardProps {
   onOpen: () => void;
   onDelete?: () => void;
   onRename?: () => void;
+  onPublish?: () => void;
   readOnly?: boolean;
 }
 
@@ -35,6 +36,7 @@ export function DeckGridCard({
   onOpen,
   onDelete,
   onRename,
+  onPublish,
   readOnly = false,
 }: DeckGridCardProps) {
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -60,6 +62,20 @@ export function DeckGridCard({
         {/* Action buttons — visible on hover */}
         {!readOnly && (
           <div className="absolute top-1.5 right-1.5 flex gap-1 opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity z-10">
+            {onPublish && (
+              <Button
+                size="icon"
+                variant="secondary"
+                className="h-6 w-6 bg-background/80 backdrop-blur-sm hover:bg-background"
+                title="Publish to Deck Hub"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onPublish();
+                }}
+              >
+                <Share2 className="h-3 w-3" />
+              </Button>
+            )}
             {onRename && (
               <Button
                 size="icon"

--- a/src/components/deck/HubDeckCard.tsx
+++ b/src/components/deck/HubDeckCard.tsx
@@ -1,0 +1,62 @@
+import { Layers } from "lucide-react";
+import { FormatBadge } from "@/components/game/FormatBadge";
+import { ManaSymbols } from "@/components/game/ManaSymbols";
+import { DECK_NAME_SHADOW_CLASS } from "@/components/deck/deckDisplay.utils";
+import { cn } from "@/lib/utils";
+import type { HubDeckSummary } from "@/protocol/hub";
+
+interface HubDeckCardProps {
+  deck: HubDeckSummary;
+  onOpen: () => void;
+}
+
+export function HubDeckCard({ deck, onOpen }: HubDeckCardProps) {
+  const colorCost = deck.colors
+    .split("")
+    .map((color) => `{${color}}`)
+    .join("");
+
+  return (
+    <div
+      className={cn(
+        "relative group cursor-pointer rounded-lg overflow-hidden border bg-muted",
+        "aspect-[4/3] transition-all hover:ring-2 hover:ring-primary hover:border-primary",
+      )}
+      onClick={onOpen}
+    >
+      {deck.coverImageUrl ? (
+        <img
+          src={deck.coverImageUrl}
+          alt={deck.coverCardName ?? deck.name}
+          loading="lazy"
+          className="absolute inset-0 h-full w-full object-cover"
+        />
+      ) : (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <Layers className="h-10 w-10 text-muted-foreground opacity-30" />
+        </div>
+      )}
+
+      <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-black/10" />
+
+      <div className="absolute bottom-0 left-0 right-0 px-2 pt-6 pb-2 z-10">
+        <p
+          className={cn(
+            "text-white text-sm font-semibold truncate leading-tight",
+            DECK_NAME_SHADOW_CLASS,
+          )}
+        >
+          {deck.name}
+        </p>
+        <p className={cn("text-white/85 text-[11px] truncate", DECK_NAME_SHADOW_CLASS)}>
+          by {deck.author}
+        </p>
+        <div className="flex items-center gap-1 mt-1 flex-wrap">
+          <FormatBadge formatId={deck.format ?? "commander"} />
+          {colorCost && <ManaSymbols cost={colorCost} size="sm" />}
+          <span className="ml-auto text-[10px] text-white/85">{deck.cardCount} cards</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/deck/HubDeckPreviewDialog.tsx
+++ b/src/components/deck/HubDeckPreviewDialog.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { FormatBadge } from "@/components/game/FormatBadge";
+import { fetchHubDeck, unpublishDeck } from "@/api/hub";
+import { useDeckStore } from "@/stores/useDeckStore";
+import { usePublishedDecksStore } from "@/stores/usePublishedDecksStore";
+import type { DeckCard } from "@/protocol/deck";
+import type { HubDeckDetail } from "@/protocol/hub";
+import type { EditorDeck } from "@/types/manabrew";
+
+interface HubDeckPreviewDialogProps {
+  deckId: string | null;
+  onClose: () => void;
+  onUnpublished?: () => void;
+}
+
+interface CardLine {
+  name: string;
+  count: number;
+}
+
+function groupByName(cards: DeckCard[]): CardLine[] {
+  const counts = new Map<string, number>();
+  for (const card of cards) {
+    counts.set(card.identity.name, (counts.get(card.identity.name) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function CardSection({ title, cards }: { title: string; cards: DeckCard[] }) {
+  if (cards.length === 0) return null;
+  return (
+    <div>
+      <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1">
+        {title} ({cards.length})
+      </p>
+      <ul className="text-sm space-y-0.5">
+        {groupByName(cards).map((line) => (
+          <li key={line.name} className="flex gap-2">
+            <span className="text-muted-foreground w-6 text-right shrink-0">{line.count}</span>
+            <span className="truncate">{line.name}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export function HubDeckPreviewDialog({
+  deckId,
+  onClose,
+  onUnpublished,
+}: HubDeckPreviewDialogProps) {
+  const navigate = useNavigate();
+  const addSavedDeck = useDeckStore((s) => s.addSavedDeck);
+  const loadPresetDeck = useDeckStore((s) => s.loadPresetDeck);
+  const published = usePublishedDecksStore((s) => s.published);
+  const removePublished = usePublishedDecksStore((s) => s.removePublished);
+  const [detail, setDetail] = useState<HubDeckDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    setDetail(null);
+    setError(null);
+    if (!deckId) return;
+    let cancelled = false;
+    fetchHubDeck(deckId)
+      .then((d) => {
+        if (!cancelled) setDetail(d);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load deck");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [deckId]);
+
+  const mine = published.find((p) => p.hubId === deckId);
+
+  function handleSave() {
+    if (!detail) return;
+    addSavedDeck(detail.deck as EditorDeck);
+    toast.success(`"${detail.name}" saved to My Decks`);
+    onClose();
+  }
+
+  function handleOpen() {
+    if (!detail) return;
+    loadPresetDeck(detail.deck as EditorDeck);
+    onClose();
+    navigate("/deck-editor");
+  }
+
+  async function handleUnpublish() {
+    if (!mine) return;
+    setBusy(true);
+    try {
+      await unpublishDeck(mine.hubId, mine.managementToken);
+      removePublished(mine.hubId);
+      toast.success(`"${mine.name}" removed from the Deck Hub`);
+      onClose();
+      onUnpublished?.();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Removing failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Dialog open={deckId !== null} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <span className="truncate">{detail?.name ?? "Loading…"}</span>
+            {detail && <FormatBadge formatId={detail.format ?? "commander"} />}
+          </DialogTitle>
+          <DialogDescription>
+            {detail
+              ? `by ${detail.author}${detail.description ? ` — ${detail.description}` : ""}`
+              : (error ?? "Fetching deck from the hub…")}
+          </DialogDescription>
+        </DialogHeader>
+        {detail && (
+          <ScrollArea className="max-h-[50dvh] pr-3">
+            <div className="space-y-3">
+              <CardSection title="Commanders" cards={detail.deck.commanders ?? []} />
+              <CardSection title="Main deck" cards={detail.deck.cards} />
+              <CardSection title="Sideboard" cards={detail.deck.sideboard} />
+            </div>
+          </ScrollArea>
+        )}
+        <DialogFooter className="gap-2">
+          {mine && (
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={busy || !detail}
+              onClick={handleUnpublish}
+              className="mr-auto"
+            >
+              {busy ? "Removing…" : "Remove from hub"}
+            </Button>
+          )}
+          <Button variant="outline" size="sm" disabled={!detail} onClick={handleOpen}>
+            Open read-only
+          </Button>
+          <Button size="sm" disabled={!detail} onClick={handleSave}>
+            Save to My Decks
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/deck/PublishDeckDialog.tsx
+++ b/src/components/deck/PublishDeckDialog.tsx
@@ -1,0 +1,144 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { publishDeck, unpublishDeck } from "@/api/hub";
+import { stripUsernameTag } from "@/lib/username";
+import { usePreferencesStore } from "@/stores/usePreferencesStore";
+import {
+  findPublishedByLocalDeckId,
+  usePublishedDecksStore,
+} from "@/stores/usePublishedDecksStore";
+import type { Deck } from "@/protocol/deck";
+import type { EditorDeck } from "@/types/manabrew";
+
+interface PublishDeckDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  deck: EditorDeck;
+  localDeckId: string | null;
+}
+
+const MAX_AUTHOR_LEN = 50;
+
+function toPublishableDeck(deck: EditorDeck): Deck {
+  const { customTags: _customTags, cardTags: _cardTags, ...wireDeck } = deck;
+  return {
+    ...wireDeck,
+    id: undefined,
+    version: undefined,
+    playmat: undefined,
+    playmatSettings: undefined,
+    stackPositions: undefined,
+  };
+}
+
+export function PublishDeckDialog({
+  open,
+  onOpenChange,
+  deck,
+  localDeckId,
+}: PublishDeckDialogProps) {
+  const serverUsername = usePreferencesStore((s) => s.serverUsername);
+  const published = usePublishedDecksStore((s) => s.published);
+  const addPublished = usePublishedDecksStore((s) => s.addPublished);
+  const removePublished = usePublishedDecksStore((s) => s.removePublished);
+  const [author, setAuthor] = useState(() => stripUsernameTag(serverUsername));
+  const [busy, setBusy] = useState(false);
+
+  const existing = findPublishedByLocalDeckId(published, localDeckId);
+  const cardCount = deck.cards.length + (deck.commanders?.length ?? 0);
+  const trimmedAuthor = author.trim();
+
+  async function handlePublish() {
+    setBusy(true);
+    try {
+      const response = await publishDeck({
+        author: trimmedAuthor,
+        deck: toPublishableDeck(deck),
+      });
+      addPublished({
+        hubId: response.id,
+        localDeckId,
+        name: deck.name,
+        managementToken: response.managementToken,
+        publishedAt: Date.now(),
+      });
+      toast.success(`"${deck.name}" published to the Deck Hub`);
+      onOpenChange(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Publishing failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleUnpublish() {
+    if (!existing) return;
+    setBusy(true);
+    try {
+      await unpublishDeck(existing.hubId, existing.managementToken);
+      removePublished(existing.hubId);
+      toast.success(`"${existing.name}" removed from the Deck Hub`);
+      onOpenChange(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Removing failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{existing ? "Published to Deck Hub" : "Publish to Deck Hub"}</DialogTitle>
+          <DialogDescription>
+            {existing
+              ? `"${existing.name}" is live on the hub. You can remove it at any time.`
+              : `Share "${deck.name}" (${cardCount} cards) so other players can browse and try it. Custom playmats and editor tags are not published.`}
+          </DialogDescription>
+        </DialogHeader>
+        {!existing && (
+          <div className="space-y-2">
+            <Label htmlFor="hub-author">Author name</Label>
+            <Input
+              id="hub-author"
+              value={author}
+              maxLength={MAX_AUTHOR_LEN}
+              onChange={(e) => setAuthor(e.target.value)}
+              placeholder="How you want to be credited"
+            />
+          </div>
+        )}
+        <DialogFooter className="gap-2">
+          <Button variant="outline" size="sm" disabled={busy} onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          {existing ? (
+            <Button variant="destructive" size="sm" disabled={busy} onClick={handleUnpublish}>
+              {busy ? "Removing…" : "Remove from hub"}
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              disabled={busy || trimmedAuthor.length === 0 || deck.cards.length === 0}
+              onClick={handlePublish}
+            >
+              {busy ? "Publishing…" : "Publish"}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Hand,
   Info,
   Layers,
+  LibraryBig,
   Package,
   Settings,
   Swords,
@@ -82,6 +83,17 @@ export function Sidebar({ className, onNavigate }: SidebarProps) {
                 >
                   <Layers className="mr-2 h-4 w-4 shrink-0" />
                   My Decks
+                </Button>
+              )}
+            </NavLink>
+            <NavLink to="/hub" onClick={onNavigate}>
+              {({ isActive }) => (
+                <Button
+                  variant={isActive ? "secondary" : "ghost"}
+                  className="w-full justify-start whitespace-nowrap"
+                >
+                  <LibraryBig className="mr-2 h-4 w-4 shrink-0" />
+                  Deck Hub
                 </Button>
               )}
             </NavLink>

--- a/src/config/webRuntimeConfig.ts
+++ b/src/config/webRuntimeConfig.ts
@@ -11,6 +11,10 @@ export function getStatusBannerUrl(): string {
   return import.meta.env.VITE_STATUS_BANNER_URL || "https://play.manabrew.app/status.json";
 }
 
+export function getHubApiUrl(): string {
+  return import.meta.env.VITE_HUB_API_URL || "https://api.manabrew.app";
+}
+
 export function isHostedEngineAvailable(): boolean {
   return ["1", "true", "yes", "on"].includes(
     (import.meta.env.VITE_HOSTED_AI_ENABLED ?? "").toLowerCase(),

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -29,6 +29,7 @@ export const STORAGE_KEYS = {
   COMPANION: "manabrew-companion",
   KEYBINDINGS: "manabrew-keybindings",
   STATUS_BANNER: "manabrew-status-banner",
+  PUBLISHED_DECKS: "manabrew-published-decks",
 } as const;
 
 // ─── Deck Defaults ───────────────────────────────────────────────────────────

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -21,6 +21,7 @@ import Gauntlet from "@/views/Gauntlet";
 import Settings from "@/views/Settings";
 import About from "@/views/About";
 import Search from "@/views/Search";
+import DeckHub from "@/views/DeckHub";
 
 export const router = createBrowserRouter([
   {
@@ -79,6 +80,14 @@ export const router = createBrowserRouter([
         element: (
           <ErrorBoundary context="Deck Editor">
             <DeckEditor />
+          </ErrorBoundary>
+        ),
+      },
+      {
+        path: "hub",
+        element: (
+          <ErrorBoundary context="Deck Hub">
+            <DeckHub />
           </ErrorBoundary>
         ),
       },

--- a/src/stores/useHubStore.ts
+++ b/src/stores/useHubStore.ts
@@ -1,0 +1,51 @@
+import { create } from "zustand";
+import { fetchHubDecks, fetchTopDecks } from "@/api/hub";
+import type { HubListParams, TopDecksWindow } from "@/api/hub";
+import type { HubDeckList, TopDeckStat } from "@/protocol/hub";
+
+interface HubState {
+  list: HubDeckList | null;
+  listError: string | null;
+  listLoading: boolean;
+  topDecks: TopDeckStat[] | null;
+  topError: string | null;
+  fetchDecks: (params: HubListParams) => Promise<void>;
+  fetchTop: (window: TopDecksWindow) => Promise<void>;
+}
+
+let listRequestId = 0;
+let topRequestId = 0;
+
+export const useHubStore = create<HubState>((set) => ({
+  list: null,
+  listError: null,
+  listLoading: false,
+  topDecks: null,
+  topError: null,
+  fetchDecks: async (params) => {
+    const requestId = ++listRequestId;
+    set({ listLoading: true });
+    try {
+      const list = await fetchHubDecks(params);
+      if (requestId === listRequestId) set({ list, listError: null, listLoading: false });
+    } catch (err) {
+      if (requestId === listRequestId) {
+        set({
+          listError: err instanceof Error ? err.message : "Failed to load the Deck Hub",
+          listLoading: false,
+        });
+      }
+    }
+  },
+  fetchTop: async (window) => {
+    const requestId = ++topRequestId;
+    try {
+      const topDecks = await fetchTopDecks(window);
+      if (requestId === topRequestId) set({ topDecks, topError: null });
+    } catch (err) {
+      if (requestId === topRequestId) {
+        set({ topError: err instanceof Error ? err.message : "Failed to load top decks" });
+      }
+    }
+  },
+}));

--- a/src/stores/usePublishedDecksStore.ts
+++ b/src/stores/usePublishedDecksStore.ts
@@ -1,0 +1,43 @@
+import { create } from "zustand";
+import { createJSONStorage, devtools, persist } from "zustand/middleware";
+import { STORAGE_KEYS } from "@/lib/constants";
+
+export interface PublishedDeckRecord {
+  hubId: string;
+  localDeckId: string | null;
+  name: string;
+  managementToken: string;
+  publishedAt: number;
+}
+
+interface PublishedDecksState {
+  published: PublishedDeckRecord[];
+  addPublished: (record: PublishedDeckRecord) => void;
+  removePublished: (hubId: string) => void;
+}
+
+export const usePublishedDecksStore = create<PublishedDecksState>()(
+  devtools(
+    persist(
+      (set) => ({
+        published: [],
+        addPublished: (record) => set((s) => ({ published: [...s.published, record] })),
+        removePublished: (hubId) =>
+          set((s) => ({ published: s.published.filter((p) => p.hubId !== hubId) })),
+      }),
+      {
+        name: STORAGE_KEYS.PUBLISHED_DECKS,
+        storage: createJSONStorage(() => localStorage),
+      },
+    ),
+    { name: "PublishedDecksStore" },
+  ),
+);
+
+export function findPublishedByLocalDeckId(
+  published: PublishedDeckRecord[],
+  localDeckId: string | null,
+): PublishedDeckRecord | undefined {
+  if (!localDeckId) return undefined;
+  return published.find((p) => p.localDeckId === localDeckId);
+}

--- a/src/views/DeckEditor.tsx
+++ b/src/views/DeckEditor.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/components/ui/dialog";
 import { DeckGridCard } from "@/components/deck/DeckGridCard";
 import { DeckListControls } from "@/components/deck/DeckListControls";
+import { PublishDeckDialog } from "@/components/deck/PublishDeckDialog";
 import { cn } from "@/lib/utils";
 import { Plus } from "lucide-react";
 import { toast } from "sonner";
@@ -85,6 +86,7 @@ export default function DeckEditor() {
   const [searchFocusSignal, setSearchFocusSignal] = useState(0);
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const [choiceDialogOpen, setChoiceDialogOpen] = useState(false);
+  const [publishingDeck, setPublishingDeck] = useState<SavedDeck | null>(null);
 
   useKeybindings({
     "card-search-focus": () => {
@@ -451,6 +453,7 @@ export default function DeckEditor() {
                     onOpen={() => handleSelectDeck(s.id)}
                     onDelete={() => handleDelete(s.id)}
                     onRename={() => startRename(s.id, s.deck.name)}
+                    onPublish={() => setPublishingDeck(s)}
                   />
                 ))}
               </div>
@@ -537,6 +540,17 @@ export default function DeckEditor() {
           onOpenChange={setImportDialogOpen}
           onImport={handleTextImport}
         />
+
+        {publishingDeck && (
+          <PublishDeckDialog
+            open
+            onOpenChange={(open) => {
+              if (!open) setPublishingDeck(null);
+            }}
+            deck={publishingDeck.deck}
+            localDeckId={publishingDeck.id}
+          />
+        )}
 
         <Dialog
           open={renamingId !== null}

--- a/src/views/DeckHub.tsx
+++ b/src/views/DeckHub.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useState } from "react";
+import { ChevronLeft, ChevronRight, Search, Trophy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { HubDeckCard } from "@/components/deck/HubDeckCard";
+import { HubDeckPreviewDialog } from "@/components/deck/HubDeckPreviewDialog";
+import type { HubSort, TopDecksWindow } from "@/api/hub";
+import { useHubStore } from "@/stores/useHubStore";
+import { cn } from "@/lib/utils";
+import { FORMAT_DISPLAY } from "@/lib/constants";
+
+const PAGE_SIZE = 20;
+const SEARCH_DEBOUNCE_MS = 300;
+const HUB_FORMATS = ["commander", "standard", "pioneer", "modern", "pauper", "brawl"] as const;
+const TOP_WINDOWS: { value: TopDecksWindow; label: string }[] = [
+  { value: "7d", label: "7 days" },
+  { value: "30d", label: "30 days" },
+  { value: "all", label: "All time" },
+];
+
+type HubTab = "browse" | "top";
+
+function SegmentedButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <Button variant={active ? "secondary" : "ghost"} size="sm" onClick={onClick}>
+      {children}
+    </Button>
+  );
+}
+
+export default function DeckHub() {
+  const [tab, setTab] = useState<HubTab>("browse");
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [format, setFormat] = useState<string>("");
+  const [sort, setSort] = useState<HubSort>("newest");
+  const [page, setPage] = useState(1);
+  const [previewId, setPreviewId] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [topWindow, setTopWindow] = useState<TopDecksWindow>("30d");
+
+  const list = useHubStore((s) => s.list);
+  const listError = useHubStore((s) => s.listError);
+  const topDecks = useHubStore((s) => s.topDecks);
+  const topError = useHubStore((s) => s.topError);
+  const fetchDecks = useHubStore((s) => s.fetchDecks);
+  const fetchTop = useHubStore((s) => s.fetchTop);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(search);
+      setPage(1);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  useEffect(() => {
+    void fetchDecks({
+      search: debouncedSearch || undefined,
+      format: format || undefined,
+      sort,
+      page,
+      pageSize: PAGE_SIZE,
+    });
+  }, [fetchDecks, debouncedSearch, format, sort, page, refreshKey]);
+
+  useEffect(() => {
+    if (tab !== "top") return;
+    void fetchTop(topWindow);
+  }, [fetchTop, tab, topWindow]);
+
+  const totalPages = list ? Math.max(1, Math.ceil(list.total / PAGE_SIZE)) : 1;
+
+  return (
+    <div className="h-full flex flex-col gap-4">
+      <div className="flex items-center gap-2 flex-wrap">
+        <h1 className="text-xl font-bold mr-2">Deck Hub</h1>
+        <SegmentedButton active={tab === "browse"} onClick={() => setTab("browse")}>
+          <Search className="mr-1 h-4 w-4" />
+          Browse
+        </SegmentedButton>
+        <SegmentedButton active={tab === "top"} onClick={() => setTab("top")}>
+          <Trophy className="mr-1 h-4 w-4" />
+          Top Decks
+        </SegmentedButton>
+      </div>
+
+      {tab === "browse" ? (
+        <>
+          <div className="flex items-center gap-2 flex-wrap">
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search decks, authors, commanders…"
+              className="max-w-xs"
+            />
+            <div className="flex items-center gap-1 flex-wrap">
+              <SegmentedButton active={format === ""} onClick={() => setFormat("")}>
+                All
+              </SegmentedButton>
+              {HUB_FORMATS.map((f) => (
+                <SegmentedButton
+                  key={f}
+                  active={format === f}
+                  onClick={() => {
+                    setFormat(f);
+                    setPage(1);
+                  }}
+                >
+                  {FORMAT_DISPLAY[f] ?? f}
+                </SegmentedButton>
+              ))}
+            </div>
+            <div className="ml-auto flex items-center gap-1">
+              <SegmentedButton active={sort === "newest"} onClick={() => setSort("newest")}>
+                Newest
+              </SegmentedButton>
+              <SegmentedButton active={sort === "name"} onClick={() => setSort("name")}>
+                Name
+              </SegmentedButton>
+            </div>
+          </div>
+
+          <div className="flex-1 min-h-0 overflow-y-auto">
+            {listError ? (
+              <p className="text-sm text-destructive">{listError}</p>
+            ) : list === null ? (
+              <p className="text-sm text-muted-foreground">Loading decks…</p>
+            ) : list.decks.length === 0 ? (
+              <div className="flex flex-col items-center justify-center h-full text-center gap-2">
+                <p className="text-lg font-semibold">No decks here yet</p>
+                <p className="text-sm text-muted-foreground max-w-sm">
+                  Be the first — open My Decks and publish one of your brews to the hub.
+                </p>
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+                {list.decks.map((deck) => (
+                  <HubDeckCard key={deck.id} deck={deck} onOpen={() => setPreviewId(deck.id)} />
+                ))}
+              </div>
+            )}
+          </div>
+
+          {list !== null && list.total > PAGE_SIZE && (
+            <div className="flex items-center justify-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page <= 1}
+                onClick={() => setPage((p) => p - 1)}
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                Page {page} of {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= totalPages}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+        </>
+      ) : (
+        <>
+          <div className="flex items-center gap-1">
+            {TOP_WINDOWS.map((w) => (
+              <SegmentedButton
+                key={w.value}
+                active={topWindow === w.value}
+                onClick={() => setTopWindow(w.value)}
+              >
+                {w.label}
+              </SegmentedButton>
+            ))}
+          </div>
+          <div className="flex-1 min-h-0 overflow-y-auto">
+            {topError ? (
+              <p className="text-sm text-destructive">{topError}</p>
+            ) : topDecks === null ? (
+              <p className="text-sm text-muted-foreground">Loading top decks…</p>
+            ) : topDecks.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No games recorded in this window.</p>
+            ) : (
+              <ol className="space-y-1 max-w-2xl">
+                {topDecks.map((stat, index) => (
+                  <li
+                    key={`${stat.deckName}-${stat.commander ?? ""}`}
+                    className={cn(
+                      "flex items-center gap-3 rounded-md border px-3 py-2",
+                      index === 0 && "border-primary",
+                    )}
+                  >
+                    <span className="text-sm font-bold text-muted-foreground w-6 text-right shrink-0">
+                      {index + 1}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-semibold truncate">{stat.deckName}</p>
+                      {stat.commander && (
+                        <p className="text-xs text-muted-foreground truncate">{stat.commander}</p>
+                      )}
+                    </div>
+                    <span className="text-sm text-muted-foreground shrink-0">
+                      {stat.plays} {stat.plays === 1 ? "game" : "games"}
+                    </span>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Most-played decks across online games. Win rates arrive once winner tracking is fixed
+            for hosted games.
+          </p>
+        </>
+      )}
+
+      <HubDeckPreviewDialog
+        deckId={previewId}
+        onClose={() => setPreviewId(null)}
+        onUnpublished={() => setRefreshKey((k) => k + 1)}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- New **Deck Hub** view at `/hub` (sidebar entry) with two tabs: **Browse** — search/format/sort/paginated grid of published decks (`HubDeckCard`), with a preview dialog (grouped card list, "Save to My Decks", "Open read-only", and "Remove from hub" for your own decks) — and **Top Decks** — most-played decks from relay analytics with a 7d/30d/all window (play counts only; win rates deferred until #360).
- **Publish flow**: a share action on My Decks grid cards opens `PublishDeckDialog` (author prefilled from the username, tag stripped). Playmats/editor tags are stripped client-side before POST (server re-enforces). The per-deck management token from the publish response is kept in a persisted `usePublishedDecksStore`, enabling self-unpublish with no accounts.
- Data layer per repo conventions (no TanStack): `api/hub.ts` on `platformFetch` + `useHubStore` (zustand, stale-response guards). Hub API base from `VITE_HUB_API_URL` (default `https://api.manabrew.app`). Types come from the generated `@/protocol/hub` bindings.

## Why

UI half of the deck hub (#421, ops #422) — launch feedback asked for browsing and trying other players' decks; most of the cohort goldfishes Commander decks vs AI, so hub decks double as fresh opponents/content. Stacked on `chore/deck-hub-ops`.

## Test plan

- `yarn lint` (eslint + prettier + tsc) and `yarn test` (vitest, 9 passed) clean.
- Vite dev smoke with `VITE_HUB_API_URL=http://localhost:9500`: all new modules (`DeckHub`, `HubDeckCard`, `PublishDeckDialog`, `HubDeckPreviewDialog`, `api/hub.ts`, both stores, router/Sidebar/DeckEditor edits) transform without errors and `/hub` serves.
- The HTTP contract these components call was e2e-verified against the real `manabrew-hub` binary in #421 (publish → list → detail → delete, 422/429/403 paths, top-decks against a real events.db).
- Not yet done: a browser click-through of the full flow — no browser automation available in this environment. Worth a manual pass before merge: publish from My Decks, browse/preview/save on `/hub`, unpublish, Top Decks tab.

## Demo

Manual pass pending — screenshots to be added from the local run (`cargo run -p manabrew-hub` + `VITE_HUB_API_URL=http://localhost:9500 yarn dev:web`).