### PR TITLE
fix(node): copy forge type lists into docker rust build stage

### DIFF
--- a/manabrew-rs/crates/self-hosted-node/Dockerfile
+++ b/manabrew-rs/crates/self-hosted-node/Dockerfile
@@ -87,6 +87,8 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY manabrew-rs/ manabrew-rs/
 COPY public/preset_decks/ public/preset_decks/
+# host.rs include_str!s TypeLists.txt at compile time.
+COPY forge/forge-gui/res/lists/ forge/forge-gui/res/lists/
 # Stub the non-engine workspace members cargo metadata validates (mirrors
 # manabrew-server's Dockerfile).
 COPY src-tauri/Cargo.toml src-tauri/Cargo.toml
@@ -105,7 +107,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # runtime image needs the JRE on PATH. JRE 21 happily runs the harness's
 # release-17 bytecode (Forge's maven.compiler.release=17), so the build stage
 # can stay on Temurin 17 even though the runtime is 21.
-# The node resolves Forge assets / TypeLists / preset decks relative to its
+# The node resolves Forge assets / preset decks relative to its
 # compile-time workspace root (/build), so the image reproduces that layout.
 FROM eclipse-temurin:21-jre-jammy
 


### PR DESCRIPTION
## Summary

- The `manabrew-node` image build failed at the `rust-builder` stage: `host.rs` embeds `forge/forge-gui/res/lists/TypeLists.txt` at compile time via `include_str!`, but that stage only copied the Rust workspace and preset decks — the forge res tree was only present in the final runtime stage.
- Adds `COPY forge/forge-gui/res/lists/` to the `rust-builder` stage and drops the stale mention of TypeLists from the runtime-stage comment (it has been compile-time embedded since #273, not runtime-resolved).

## Why

The `include_str!` dates back to #273, but nothing compiled `self-hosted-node` inside Docker until the new `docker-images.yml` workflow, whose `manabrew-node` job now fails with `couldn't read .../forge/forge-gui/res/lists/TypeLists.txt`.

## Test plan

- `forge/forge-gui/res/lists/` is inside the build context (not excluded by `.dockerignore`, and the runtime stage already copies the full `res/` tree).
- The failing compile is exactly the missing include path; the CI `docker-images.yml` run on this PR is the end-to-end verification.