### PR TITLE
fix(server): include commanders in deck_selected analytics

### DIFF
--- a/manabrew-rs/crates/manabrew-server/src/analytics/mod.rs
+++ b/manabrew-rs/crates/manabrew-server/src/analytics/mod.rs
@@ -185,7 +185,8 @@ pub fn emit_game_ended(
 
 pub fn aggregate_deck_cards(deck: &Deck) -> Vec<CardEntry> {
     let mut counts: HashMap<(String, String), u32> = HashMap::new();
-    for card in &deck.cards {
+    let commanders = deck.commanders.iter().flatten();
+    for card in deck.cards.iter().chain(commanders) {
         *counts
             .entry((card.identity.name.clone(), card.identity.set_code.clone()))
             .or_insert(0) += 1;


### PR DESCRIPTION
## Summary

`aggregate_deck_cards` (the analytics helper behind the `deck_selected` event) counted only `deck.cards` and never `deck.commanders`, so the commander was dropped from the logged card list.

## Why

Human seats still had their commander recorded via the separate `commander` field on the event, so the loss was invisible for them. But **bot seats send `commander: null`**, so their commander was lost entirely — the logged deck came out one card short (99 instead of 100) with no commander at all.

This surfaced while building the trace-replay parity harness (#426): replays of bot seats diverged at turn 1 on a `libraryCount` off-by-one, because the reconstructed deck was missing that one card before any draw. The trace confirmed the real deck was 100; the analytics decklist was the lossy source.

The one-line fix chains `deck.commanders` into the aggregation so the logged card list is the full registered deck for every seat (humans unchanged in total; bots now complete). Companion is intentionally excluded — it starts outside the deck, so counting it would over-count the library.

## Test plan

- `cargo check -p manabrew-server` / `cargo build -p manabrew-server` — clean.
- Behavioral: a Commander deck now aggregates to 100 entries (99 + commander) instead of 99; a bot deck with a commander in `deck.commanders` and `commander: null` now records the commander card.

## Notes

- Forward-only: affects newly emitted `deck_selected` events, not historical analytics.
- Small, isolated server-side change; branched off `main` (extracted from the parity work in #426, which contains no analytics-emission changes).
