### PR TITLE
fix(self-hosted-node): honor preset deck's declared commander

### DIFF
--- a/manabrew-rs/crates/self-hosted-node/src/config.rs
+++ b/manabrew-rs/crates/self-hosted-node/src/config.rs
@@ -41,6 +41,8 @@ pub struct DeckSelection {
 #[derive(Debug, Deserialize)]
 struct PresetDeckFile {
     label: String,
+    #[serde(default)]
+    commander: Option<String>,
     cards: Vec<PresetDeckCard>,
 }
 
@@ -285,7 +287,7 @@ fn load_preset_deck(
             ..Default::default()
         },
         name: label,
-        commander_name,
+        commander_name: commander_name.or(preset.commander),
     })
 }
 


### PR DESCRIPTION
## Summary

`load_preset_deck` (self-hosted-node config) read only `label` and `cards` from a preset deck JSON and derived the commander **solely** from the hardcoded `infer_commander_name` map. That map covers only ~6 deck ids, so a node auto-spawn bot/host configured with any other preset (e.g. `starter_deck_kasla`, `starter_deck_animar`, `starter_deck_ognis`, `starter_deck_urza_chief_artificer`) got `commander_name: None` and played **commanderless** in a Commander pod — even though the preset file itself declares a `commander`.

The fix reads the preset's `commander` field and uses it as the fallback. Explicit env override (`SELF_HOSTED_NODE_BOT_COMMANDER` / `_HOST_COMMANDER`) still wins; the lossy hardcoded map is no longer the only source, and new presets don't need a map entry.

## Scope / what this is NOT

This fixes the **node config auto-spawn path** (`config.bot_deck` / `config.host_deck` loaded from a preset id).

It is **not** the cause of the commanderless bots visible in captured game traces. Those seats came through the **relay spawn path** with client-chosen opponent decks, which is already fixed on `main`:
- `#368` makes the client send `commanderName` derived from the deck's commanders, and
- `bot_deck_from_payload` additionally falls back to `deck.commanders.first()`.

Those traces are pre-#368 captures; post-#368 relay-spawned bots get their commander. This PR closes the remaining gap on the *config-preset* path so node-configured bots/hosts are also robust.

## Test plan

- `cargo check -p self-hosted-node` — clean.
- A preset whose id is absent from `infer_commander_name` but whose JSON declares a `commander` (e.g. `starter_deck_kasla`) now yields a `DeckSelection` with that commander instead of `None`.

## Notes

- Small, isolated; branched off `main`.
