### PR TITLE
fix(ci): pin ios ipa job to macos-15 for xcode 16

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -238,6 +238,123 @@ jobs:
           done
           exit $EXIT
 
+  # ── Mobile builds (unsigned) ───────────────────────────────────────
+  # Compile-and-bundle checks mirroring publish.yml's ios-ipa / android-apk
+  # jobs (same cardset-archive step, same runner pins) so a PR can't break
+  # the release pipeline's mobile builds. Keep the step lists in sync with
+  # publish.yml.
+  ios-build:
+    name: iOS build
+    runs-on: macos-15
+    needs: changes
+    if: needs.changes.outputs.run_checks == 'true'
+    timeout-minutes: 60
+    defaults:
+      run:
+        working-directory: ios-build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: ios-build
+          submodules: recursive
+          clean: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Yarn
+        run: npm install --global yarn
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios,wasm32-unknown-unknown
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ios-build
+          shared-key: tauri-ios
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.13.1
+
+      - run: yarn
+
+      - name: Build WASM + bundle cards
+        run: yarn build:wasm
+
+      - name: Build cardset archive
+        run: |
+          cargo run -p forge-cardset-archive --features build --release \
+            --bin build-cardset-archive
+
+      - name: Tauri build (iOS, unsigned)
+        run: yarn tauri ios build --no-sign
+
+  android-build:
+    name: Android build
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.run_checks == 'true'
+    timeout-minutes: 60
+    defaults:
+      run:
+        working-directory: android-build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: android-build
+          submodules: recursive
+          clean: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Yarn
+        run: npm install --global yarn
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,wasm32-unknown-unknown
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: android-build
+          shared-key: tauri-android
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.13.1
+
+      - run: yarn
+
+      - name: Build WASM + bundle cards
+        run: yarn build:wasm
+
+      - name: Build cardset archive
+        run: |
+          cargo run -p forge-cardset-archive --features build --release \
+            --bin build-cardset-archive
+
+      - name: Tauri build (Android APK, arm64)
+        run: node scripts/mobile-dev.mjs android build --apk --target aarch64
+
   forge-room-graalvm-windows:
     name: GraalVM build (Windows)
     runs-on: windows-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -445,7 +445,12 @@ jobs:
   # (tauri.ios.conf.json overrides beforeBuildCommand to `yarn vite:build`).
   ios-ipa:
     name: Build iOS .ipa
-    runs-on: macos-latest
+    # Pinned to macos-15 (Xcode 16.4): Xcode 26 (macos-latest/macos-26) dropped
+    # the swiftCompatibility* libs that swift-rs-built objects still reference,
+    # so the archive link fails — tauri-apps/tauri#15066. Re-evaluate on a
+    # tauri/rustc fix; sideloaded unsigned IPAs are exempt from the App Store
+    # iOS-26-SDK deadline.
+    runs-on: macos-15
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,11 +20,6 @@ name: Publish
 on:
   push:
     tags: ["v*"]
-  # TEMPORARY (drop before merge): lets the `test-ios-ipa` PR label trigger a
-  # standalone ios-ipa run. Every other job is gated to tag pushes, and the
-  # release/deploy chain is additionally starved of its `needs`.
-  pull_request:
-    types: [labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -37,7 +32,6 @@ jobs:
   # `--target` to `tauri build`.
   macos-dmg:
     name: Build macOS .dmg
-    if: github.event_name == 'push'
     runs-on: macos-latest
     timeout-minutes: 60
     steps:
@@ -239,7 +233,6 @@ jobs:
   # runner image. MSVC env is loaded per-step via ilammy/msvc-dev-cmd.
   windows-exe:
     name: Build Windows .exe
-    if: github.event_name == 'push'
     runs-on: windows-latest
     timeout-minutes: 90
     steps:
@@ -452,7 +445,6 @@ jobs:
   # (tauri.ios.conf.json overrides beforeBuildCommand to `yarn vite:build`).
   ios-ipa:
     name: Build iOS .ipa
-    if: github.event_name == 'push' || github.event.label.name == 'test-ios-ipa'
     # Pinned to macos-15 (Xcode 16.4): Xcode 26 (macos-latest/macos-26) dropped
     # the swiftCompatibility* libs that swift-rs-built objects still reference,
     # so the archive link fails — tauri-apps/tauri#15066. Re-evaluate on a
@@ -522,7 +514,6 @@ jobs:
   # secret would be needed to produce an installable signed build.
   android-apk:
     name: Build Android .apk
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,11 @@ name: Publish
 on:
   push:
     tags: ["v*"]
+  # TEMPORARY (drop before merge): lets the `test-ios-ipa` PR label trigger a
+  # standalone ios-ipa run. Every other job is gated to tag pushes, and the
+  # release/deploy chain is additionally starved of its `needs`.
+  pull_request:
+    types: [labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -32,6 +37,7 @@ jobs:
   # `--target` to `tauri build`.
   macos-dmg:
     name: Build macOS .dmg
+    if: github.event_name == 'push'
     runs-on: macos-latest
     timeout-minutes: 60
     steps:
@@ -233,6 +239,7 @@ jobs:
   # runner image. MSVC env is loaded per-step via ilammy/msvc-dev-cmd.
   windows-exe:
     name: Build Windows .exe
+    if: github.event_name == 'push'
     runs-on: windows-latest
     timeout-minutes: 90
     steps:
@@ -445,6 +452,7 @@ jobs:
   # (tauri.ios.conf.json overrides beforeBuildCommand to `yarn vite:build`).
   ios-ipa:
     name: Build iOS .ipa
+    if: github.event_name == 'push' || github.event.label.name == 'test-ios-ipa'
     # Pinned to macos-15 (Xcode 16.4): Xcode 26 (macos-latest/macos-26) dropped
     # the swiftCompatibility* libs that swift-rs-built objects still reference,
     # so the archive link fails — tauri-apps/tauri#15066. Re-evaluate on a
@@ -514,6 +522,7 @@ jobs:
   # secret would be needed to produce an installable signed build.
   android-apk:
     name: Build Android .apk
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
## Summary

- The `ios-ipa` job now fails at the Xcode archive link step on `macos-latest` (now the `macos-26` image, Xcode 26.5): `symbol(s) not found for architecture arm64` for `__swift_FORCE_LOAD_$_swiftCompatibility56` / `swiftCompatibilityConcurrency`, referenced by the swift-rs-built objects in `libapp.a` (SwiftRs, Tauri, tauri-plugin-opener).
- Pins the job to `macos-15` (default Xcode 16.4), which still ships the Swift back-compat libraries.

## Why

Xcode 26 removed the `swiftCompatibility*` static libs, but the Swift bridge objects compiled during the Rust build still reference them — a known open issue with no tauri/rustc fix yet: tauri-apps/tauri#15066. Building with Xcode 16.x is the documented workaround. The App Store's iOS-26-SDK requirement doesn't apply — this IPA is unsigned and sideloaded via SideStore. The previous run's cardset + gradle fixes (#431) worked: Android now builds, and iOS got past resource bundling to this link error.

## Test plan

- Only the `ios-ipa` job's runner changes; `macos-dmg` stays on `macos-latest` (desktop link is unaffected).
- Verification is the next `v*` publish run: `ios-ipa` green → `deploy-sidestore` runs → `play.manabrew.app/sidestore/apps.json` serves JSON (route is already live, currently a 404 awaiting the file).