### PR TITLE
fix(carddb): point cardset rebuild hints at the real archive builder

### DIFF
--- a/manabrew-rs/crates/parity/src/runner.rs
+++ b/manabrew-rs/crates/parity/src/runner.rs
@@ -929,7 +929,7 @@ pub fn load_data(cards_dir: Option<&str>, verbose: bool) -> Result<LoadedData, S
     let archive_path = cardset_archive_path();
     if !archive_path.exists() {
         return Err(format!(
-            "Cardset archive not found at {}. Run `cargo build -p forge-web` (or `yarn build:wasm`) to build it.",
+            "Cardset archive not found at {}. Run `cargo run -p forge-cardset-archive --features build --release --bin build-cardset-archive` to build it.",
             archive_path.display()
         ));
     }

--- a/manabrew-rs/crates/self-hosted-node/src/engine_backend/rust_backend.rs
+++ b/manabrew-rs/crates/self-hosted-node/src/engine_backend/rust_backend.rs
@@ -165,7 +165,7 @@ fn ensure_dbs_loaded() {
         info!(path = %archive_path.display(), "loading card + token databases from archive");
         let file = std::fs::File::open(&archive_path).unwrap_or_else(|e| {
             panic!(
-                "Cardset archive not found at {}: {e}. Run `cargo build -p forge-web` (or `yarn build:wasm`) to build it.",
+                "Cardset archive not found at {}: {e}. Run `cargo run -p forge-cardset-archive --features build --release --bin build-cardset-archive` to build it.",
                 archive_path.display()
             )
         });

--- a/src-tauri/src/card_db.rs
+++ b/src-tauri/src/card_db.rs
@@ -59,7 +59,8 @@ fn ensure_dbs_loaded() {
         let Some(bytes) = cardset_archive_bytes() else {
             panic!(
                 "[carddb] cardset archive unavailable.\n\
-                 Run `cargo build -p forge-web` (or `yarn build:wasm`) to rebuild it."
+                 Run `cargo run -p forge-cardset-archive --features build --release --bin build-cardset-archive` \
+                 (or `cargo build -p manabrew`, whose build script rebuilds it)."
             );
         };
         if let Err(err) = load_dbs_from_bytes(bytes, "cardset.rkyv") {


### PR DESCRIPTION
## Summary

- Three "cardset archive not found" panics (`src-tauri/src/card_db.rs`, `self-hosted-node`'s `rust_backend.rs`, `parity`'s `runner.rs`) told the user to run `cargo build -p forge-web` — a crate that doesn't exist — and `yarn build:wasm`, which writes the content-addressed web copy under `public/wasm/`, not the `src-tauri/resources/cardset.rkyv` these code paths actually read.
- All three hints now name the real builder: `cargo run -p forge-cardset-archive --features build --release --bin build-cardset-archive` (the app-crate panic also mentions `cargo build -p manabrew`, whose build script produces the same file).

## Why

A wrong panic hint sends whoever hits it down a dead end (`error: package(s) forge-web not found`). This is the canonical command documented in `manabrew-rs/AGENTS.md` and used by the CI workflows.

Merging this also cuts the first release since #434, so the publish pipeline runs end-to-end with the Xcode 16 pin — `ios-ipa` → `deploy-sidestore` → `play.manabrew.app/sidestore/apps.json` goes live.

## Test plan

- `cargo fmt` clean; `cargo check -p self-hosted-node -p parity` passes (string-only changes; the app crate compiles in CI where the native harness lib exists).
- The PR's own build checks now include the iOS and Android builds.
- After merge: watch the `v*` publish run — all jobs green, then `curl https://play.manabrew.app/sidestore/apps.json` returns JSON.