### PR TITLE
feat(ops): stuck-room alert and sweep-reap panel on live-ops

### DIFF
--- a/ops/observability/grafana/dashboards/live-ops.json
+++ b/ops/observability/grafana/dashboards/live-ops.json
@@ -1,7 +1,10 @@
 {
   "uid": "manabrew-live-ops",
   "title": "Manabrew \u2014 Live Ops",
-  "tags": ["manabrew", "ops"],
+  "tags": [
+    "manabrew",
+    "ops"
+  ],
   "schemaVersion": 39,
   "editable": true,
   "timezone": "utc",
@@ -495,6 +498,46 @@
         "sortOrder": "Descending",
         "wrapLogMessage": true
       }
+    },
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "Stuck-room signal \u2014 abandoned reaps per 2h (alert > 6)",
+      "gridPos": {
+        "x": 0,
+        "y": 36,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(increase(manabrew_relay_games_ended_total{reason=\"abandoned\"}[2h]))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "legendFormat": "abandoned reaps (2h window)"
+        },
+        {
+          "refId": "B",
+          "expr": "sum by (reason) (increase(manabrew_relay_games_ended_total{reason!=\"abandoned\"}[2h]))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "legendFormat": "{{reason}} (context)"
+        }
+      ]
     }
   ]
 }

--- a/ops/observability/grafana/provisioning/alerting/rules.yml
+++ b/ops/observability/grafana/provisioning/alerting/rules.yml
@@ -38,6 +38,7 @@ groups:
                     params: [1]
 
       - uid: node-fleet-silent
+        isPaused: true
         title: node fleet silent
         condition: C
         for: 5m
@@ -69,6 +70,7 @@ groups:
                     params: [900]
 
       - uid: node-rooms-below-expected
+        isPaused: true
         title: hosted rooms below expected
         condition: C
         for: 10m
@@ -253,3 +255,34 @@ groups:
                 - evaluator:
                     type: lt
                     params: [1]
+
+      - uid: stuck-room-suspected
+        title: stuck room suspected
+        condition: C
+        for: 15m
+        noDataState: OK
+        execErrState: OK
+        labels:
+          severity: warning
+        annotations:
+          summary: abandoned in-game rooms reaped well above baseline — a hosted node is likely serving a wedged room players cannot start
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 7200
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: sum(increase(manabrew_relay_games_ended_total{reason="abandoned"}[2h]))
+              instant: true
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              refId: C
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [6]


### PR DESCRIPTION
## Summary
- New alert **stuck room suspected** (warning): fires when the relay's humanless sweep reaps more than 6 `abandoned` games in a 2h window, sustained 15m. A wedged hosted node (engine session that never terminates) leaves its room joinable but unplayable; every victim the sweep cleans up increments this counter, so churn well above baseline means a trap room is live.
- New live-ops panel **"Stuck-room signal — abandoned reaps per 2h"**: the alert series plus the other `games_ended` reasons for context.
- `node fleet silent` and `hosted rooms below expected` are now `isPaused: true` in provisioning: the laptop fleet is retired, and this makes the pause durable across redeploys (it was hot-patched on the box on Jul 11).

## Why
Wedged engine sessions stranded ~4-8 players/day on the laptop fleet and 24 on Jul 12 on the current fleet (players seat into a "Free room", the start produces no engine, infinite loading). The signal separates cleanly in prod data: clean baseline is 0-4 abandoned reaps per 2h; wedge churn ran 9-31 on Jul 11-12. Threshold 6 sits between them. This gives ops a page the moment a trap room starts eating players, until the node-side session watchdog lands.

## Test plan
- `rules.yml` and `live-ops.json` parse (yaml + json validated)
- Alert expression verified against prod Prometheus: `sum(increase(manabrew_relay_games_ended_total{reason="abandoned"}[2h]))` returns 1-4 in clean periods and 9-31 during the known Jul 11/12 wedge windows — the >6 threshold would have caught both incidents with zero false positives in the clean stretches
- Panel mirrors the existing live-ops timeseries panel structure (same datasource uid, grid flow at y:36)