### PR TITLE
fix(web): copy .cargo config into the web image builder

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -57,6 +57,9 @@ RUN corepack enable && yarn install --frozen-lockfile
 
 # Copy the rest of the sources needed for the web build
 COPY Cargo.toml Cargo.lock ./
+# The `xtask` cargo alias (used by `build:web`'s gen:types step) lives in
+# .cargo/config.toml — without it `cargo xtask` fails with "no such command".
+COPY .cargo/ ./.cargo/
 # src-tauri is a workspace member; cargo metadata needs its manifest to resolve
 COPY src-tauri/ ./src-tauri/
 COPY manabrew-rs/ ./manabrew-rs/


### PR DESCRIPTION
## Summary
`build:web`'s `gen:types` step runs `cargo xtask gen-types`, but the `xtask` cargo alias is defined in `.cargo/config.toml`, which the `Dockerfile.web` builder never copied. So the web image build fails with `error: no such command: xtask`, breaking **every web deploy** — and leaving the Ironsmith runtime dark because the web image can't ship at all.

Fix: `COPY .cargo/ ./.cargo/` into the builder stage before `build:web`.

## Why
Regression from the move to `cargo xtask gen-types` for protocol/type generation — the Docker build never had the alias. Confirmed against the failing `docker-images.yml` web build (`no such command: xtask` at the `yarn build:web` step; the ironsmith WASM stage before it built fine).

## Test plan
- Not locally reproducible (no Docker daemon), but the fix is mechanical: the alias in `.cargo/config.toml` is now present in the builder context. Verified `.cargo/` is not excluded by `.dockerignore`.
- Merging unblocks the web build; the next deploy's `deploy.sh` (which now force-checks-out the ironsmith submodule) will additionally light up Ironsmith.