### PR TITLE
ci(deploy): pull pre-built ghcr images instead of building on the host

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -51,6 +51,8 @@ jobs:
             dockerfile: Dockerfile.web
           - image: manabrew-node
             dockerfile: manabrew-rs/crates/self-hosted-node/Dockerfile
+          - image: manabrew-hub
+            dockerfile: manabrew-rs/crates/manabrew-hub/Dockerfile
     steps:
       - uses: actions/checkout@v4
         with:

--- a/compose.production.yml
+++ b/compose.production.yml
@@ -1,20 +1,14 @@
 services:
   manabrew:
-    build:
-      context: .
-      dockerfile: Dockerfile.web
-      args:
-        VITE_RELAY_HOST: relay.manabrew.app
-        VITE_RELAY_PORT: "443"
-        VITE_RELAY_PASSWORD: ${MANABREW_SERVER_KEY:?MANABREW_SERVER_KEY is required}
-        VITE_MANAGED_RELAY: "1"
-        VITE_SCRYFALL_SYMBOL_BASE: /scryfall-symbols/
-        # Off by default: "Play vs AI" runs the engine client-side, so the web
-        # does NOT depend on the self-hosted-node. Build with
-        # VITE_HOSTED_AI_ENABLED=true (and run the node via --profile hosted-ai)
-        # to expose the Settings engine toggle.
-        VITE_HOSTED_AI_ENABLED: "${VITE_HOSTED_AI_ENABLED:-false}"
-        VITE_HUB_API_URL: "${VITE_HUB_API_URL:-https://api.manabrew.app}"
+    # Pre-built in CI (docker-images.yml) and pulled here — the web image is a
+    # ~1h WASM+Vite build that does not fit the prod host's disk. The published
+    # image is relay-agnostic; it is pointed at the relay at RUNTIME via the
+    # RELAY_* env below (ops/web-entrypoint.sh writes /srv/manabrew/config.js),
+    # replacing the old VITE_RELAY_* build args. NOTE: the CI image is built
+    # without VITE_SCRYFALL_SYMBOL_BASE, so mana symbols load from
+    # svgs.scryfall.io directly rather than the /scryfall-symbols/ Caddy proxy —
+    # make it runtime-configurable if the proxy is required.
+    image: ghcr.io/witchesofthehill/manabrew-web:${MANABREW_IMAGE_TAG:-latest}
     restart: unless-stopped
     ports:
       - "80:80"
@@ -32,18 +26,20 @@ services:
       PUSHGATEWAY_PASSWORD_HASH:
       # Bcrypt hash for the api. /admin/* ingress (same single-quote caveat).
       HUB_ADMIN_PASSWORD_HASH:
+      # Runtime relay config (entrypoint writes config.js from these).
+      RELAY_HOST: relay.manabrew.app
+      RELAY_PORT: "443"
+      RELAY_PASSWORD: "${MANABREW_SERVER_KEY:?MANABREW_SERVER_KEY is required}"
     # No depends_on for manabrew-hub: the site must deploy/restart even if the
     # hub image is broken; caddy just 502s api. until the hub comes up.
     depends_on:
       - manabrew-server
 
   manabrew-server:
-    # Explicit tag so deploy.sh can address the freshly built image when it
-    # compares binaries to decide whether a restart is needed.
-    image: manabrew-server:production
-    build:
-      context: .
-      dockerfile: manabrew-rs/crates/manabrew-server/Dockerfile
+    # Pre-built in CI (docker-images.yml) and pulled. deploy.sh compares the
+    # pulled binary against the running one and only restarts the relay when it
+    # changed — a relay restart drops every live game.
+    image: ghcr.io/witchesofthehill/manabrew-server:${MANABREW_IMAGE_TAG:-latest}
     environment:
       FORGE_HOST: "0.0.0.0"
       FORGE_PORT: "9443"
@@ -74,10 +70,8 @@ services:
       start_period: 5s
 
   manabrew-hub:
-    image: manabrew-hub:production
-    build:
-      context: .
-      dockerfile: manabrew-rs/crates/manabrew-hub/Dockerfile
+    # Pre-built in CI (docker-images.yml) and pulled.
+    image: ghcr.io/witchesofthehill/manabrew-hub:${MANABREW_IMAGE_TAG:-latest}
     environment:
       HUB_HOST: "0.0.0.0"
       HUB_PORT: "9500"
@@ -107,9 +101,8 @@ services:
   self-hosted-node:
     profiles:
       - hosted-ai
-    build:
-      context: .
-      dockerfile: manabrew-rs/crates/self-hosted-node/Dockerfile
+    # Pre-built in CI (docker-images.yml) and pulled.
+    image: ghcr.io/witchesofthehill/manabrew-node:${MANABREW_IMAGE_TAG:-latest}
     environment:
       SELF_HOSTED_NODE_RELAY_URL: "ws://manabrew-server:9443"
       SELF_HOSTED_NODE_SERVER_KEY: "${MANABREW_SERVER_KEY:?MANABREW_SERVER_KEY is required}"

--- a/deploy.sh
+++ b/deploy.sh
@@ -56,9 +56,24 @@ if [ -n "${GITHUB_TOKEN:-}" ]; then
 fi
 
 # ── Pull latest changes ──────────────────────────────────────────────
-PREV=$(git rev-parse --short HEAD)
+# DEPLOY_ORIG_PREV preserves the pre-pull commit across the self-update re-exec
+# below, so the re-run still deploys the right range instead of early-exiting as
+# "no new commits".
+PREV="${DEPLOY_ORIG_PREV:-$(git rev-parse --short HEAD)}"
 git pull origin main --ff-only >> "$RAW_LOG" 2>&1
 CURR=$(git rev-parse --short HEAD)
+
+# Self-update: the pull may have changed this very script. deploy.sh is already
+# loaded into memory, so without this the *old* logic runs and script edits only
+# take effect the NEXT deploy — exactly how the Ironsmith submodule checkout was
+# missed and the runtime shipped dark on its first deploy. Re-exec the updated
+# script once (guarded so it can't loop).
+if [ -z "${DEPLOY_ORIG_PREV:-}" ] && [ "$PREV" != "$CURR" ] \
+   && ! git diff --quiet "${PREV}..${CURR}" -- deploy.sh; then
+    echo "deploy.sh changed in this pull — re-exec'ing the updated script" >> "$RAW_LOG"
+    export DEPLOY_ORIG_PREV="$PREV"
+    exec bash "$0" "$@"
+fi
 
 # Forge is a git submodule (engine + cardsfolder). Pulling main only moves the
 # gitlink pointer; the working tree must be checked out explicitly or the wasm
@@ -274,11 +289,41 @@ fi
 # the old container otherwise lingers and can hold the host ports the new
 # one needs — exactly what took prod down on the #19 merge deploy.
 if [ -n "$SERVICES_TO_RESTART" ]; then
-    # --no-deps: recreate only the listed services, never their dependencies as
-    # a side effect (an `up manabrew` without this recreates the relay it
-    # depends_on — which drops live games and, if the relay image tag is ever
-    # missing, aborts the whole deploy).
-    docker compose -f "$COMPOSE_FILE" $PROFILE_FLAG up -d --no-deps --remove-orphans $SERVICES_TO_RESTART >> "$RAW_LOG" 2>&1
+    # Snapshot each service's current image so an unhealthy rollout can be rolled
+    # back to the last-good one. GHCR_REF maps the pulled services to the tag we
+    # re-point on rollback.
+    declare -A ROLLBACK_IMG=()
+    declare -A GHCR_REF=(
+        [manabrew]="ghcr.io/witchesofthehill/manabrew-web:${GHCR_TAG:-latest}"
+        [manabrew-server]="ghcr.io/witchesofthehill/manabrew-server:${GHCR_TAG:-latest}"
+        [manabrew-hub]="ghcr.io/witchesofthehill/manabrew-hub:${GHCR_TAG:-latest}"
+    )
+    for svc in $SERVICES_TO_RESTART; do
+        cid=$(docker compose -f "$COMPOSE_FILE" ps -q "$svc" 2>/dev/null || true)
+        [ -n "$cid" ] && ROLLBACK_IMG[$svc]=$(docker inspect --format '{{.Image}}' "$cid" 2>/dev/null || true)
+    done
+
+    # --no-deps: recreate only the listed services, never their dependencies as a
+    # side effect (an `up manabrew` without this recreates the relay it
+    # depends_on — dropping live games, and aborting the deploy if the relay tag
+    # is ever missing). --wait: block until healthchecks pass.
+    if docker compose -f "$COMPOSE_FILE" $PROFILE_FLAG up -d --no-deps --remove-orphans --wait --wait-timeout 180 $SERVICES_TO_RESTART >> "$RAW_LOG" 2>&1; then
+        echo "✅ rollout healthy: $SERVICES_TO_RESTART" >> "$RAW_LOG"
+    else
+        echo "⚠️ rollout unhealthy — rolling back to the previous images" | tee -a "$RAW_LOG"
+        ROLLED=""
+        for svc in $SERVICES_TO_RESTART; do
+            ref="${GHCR_REF[$svc]:-}"; old="${ROLLBACK_IMG[$svc]:-}"
+            if [ -n "$ref" ] && [ -n "$old" ]; then
+                docker tag "$old" "$ref" >> "$RAW_LOG" 2>&1 && ROLLED="$ROLLED $svc"
+            fi
+        done
+        if [ -n "$ROLLED" ]; then
+            docker compose -f "$COMPOSE_FILE" $PROFILE_FLAG up -d --no-deps $ROLLED >> "$RAW_LOG" 2>&1 || true
+            echo "↩️ rolled back:$ROLLED" | tee -a "$RAW_LOG"
+        fi
+        exit 1
+    fi
 fi
 
 if $CADDYFILE_CHANGED; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -191,56 +191,56 @@ else
     echo "Parity dashboard skipped (COMPOSE_PROFILES does not include 'parity')" >> "$RAW_LOG"
 fi
 
-# -- manabrew-server (relay; restarted only when the shipped binary differs) --
-RELAY_IMAGE="manabrew-server:production"
+# -- ghcr images: manabrew (web), manabrew-server (relay), manabrew-hub --
+# These are built + pushed by CI (docker-images.yml) on the same release tag and
+# pulled here instead of built locally (the web image is a ~1h WASM+Vite build
+# that no longer fits the prod host's disk). Pull with retry: the image workflow
+# runs in parallel with this deploy, so the new images may not be pushed yet.
 RELAY_UNCHANGED=false
-if $INFRA_CHANGED; then
-    echo "Building manabrew-server (full)..." >> "$RAW_LOG"
-    docker compose -f "$COMPOSE_FILE" build --progress=plain --no-cache manabrew-server >> "$RAW_LOG" 2>&1
-    SERVICES_TO_RESTART="$SERVICES_TO_RESTART manabrew-server"
-elif $FORGE_SERVER_CHANGED; then
-    echo "Building manabrew-server (cached)..." >> "$RAW_LOG"
-    docker compose -f "$COMPOSE_FILE" build --progress=plain manabrew-server >> "$RAW_LOG" 2>&1
-    # Dockerfile/compose changes take the INFRA branch above, so on this branch
-    # an identical binary means the deployment is identical: skip the restart
-    # and point the tag back at the running image so `up -d` (here or manual)
-    # keeps considering the container up to date.
-    RELAY_CID=$(docker compose -f "$COMPOSE_FILE" ps -q manabrew-server)
-    if [ -n "$RELAY_CID" ]; then
-        RELAY_OLD_IMAGE=$(docker inspect --format '{{.Image}}' "$RELAY_CID")
-        OLD_SHA=$(docker run --rm --entrypoint sha256sum "$RELAY_OLD_IMAGE" /usr/local/bin/manabrew-server 2>> "$RAW_LOG" | cut -d' ' -f1 || true)
-        NEW_SHA=$(docker run --rm --entrypoint sha256sum "$RELAY_IMAGE" /usr/local/bin/manabrew-server 2>> "$RAW_LOG" | cut -d' ' -f1 || true)
-        if [ -n "$OLD_SHA" ] && [ "$OLD_SHA" = "$NEW_SHA" ]; then
-            docker tag "$RELAY_OLD_IMAGE" "$RELAY_IMAGE" >> "$RAW_LOG" 2>&1
-            RELAY_UNCHANGED=true
-            echo "manabrew-server binary unchanged (${NEW_SHA:0:12}) — relay not restarted" >> "$RAW_LOG"
-        fi
+echo "Pulling ghcr images (manabrew manabrew-server manabrew-hub)..." >> "$RAW_LOG"
+PULLED=false
+for attempt in $(seq 1 40); do
+    if docker compose -f "$COMPOSE_FILE" pull --quiet manabrew manabrew-server manabrew-hub >> "$RAW_LOG" 2>&1; then
+        PULLED=true; break
     fi
-    if ! $RELAY_UNCHANGED; then
+    echo "  pull attempt $attempt failed (CI images not pushed yet?); retrying in 30s" >> "$RAW_LOG"
+    sleep 30
+done
+$PULLED || { echo "❌ ghcr image pull failed after retries — aborting deploy."; exit 1; }
+
+# A service needs recreating only when the pulled image differs from what its
+# container is running — otherwise `up -d` would needlessly churn it (a web
+# recreate briefly blips Caddy; a relay recreate drops every live game).
+image_changed() {  # $1 service, $2 image ref
+    local cid running pulled
+    cid=$(docker compose -f "$COMPOSE_FILE" ps -q "$1" 2>/dev/null || true)
+    [ -z "$cid" ] && return 0
+    running=$(docker inspect --format '{{.Image}}' "$cid" 2>/dev/null || echo "")
+    pulled=$(docker image inspect --format '{{.Id}}' "$2" 2>/dev/null || echo "x")
+    [ "$running" != "$pulled" ]
+}
+GHCR_TAG="${MANABREW_IMAGE_TAG:-latest}"
+image_changed manabrew "ghcr.io/witchesofthehill/manabrew-web:${GHCR_TAG}" \
+    && SERVICES_TO_RESTART="$SERVICES_TO_RESTART manabrew"
+image_changed manabrew-hub "ghcr.io/witchesofthehill/manabrew-hub:${GHCR_TAG}" \
+    && SERVICES_TO_RESTART="$SERVICES_TO_RESTART manabrew-hub"
+
+# Relay: extra-conservative — restart only when the actual binary differs (an
+# image-digest change from an unrelated base bump must not kill live games).
+RELAY_IMAGE="ghcr.io/witchesofthehill/manabrew-server:${GHCR_TAG}"
+RELAY_CID=$(docker compose -f "$COMPOSE_FILE" ps -q manabrew-server 2>/dev/null || true)
+if [ -n "$RELAY_CID" ]; then
+    RELAY_OLD_IMAGE=$(docker inspect --format '{{.Image}}' "$RELAY_CID")
+    OLD_SHA=$(docker run --rm --entrypoint sha256sum "$RELAY_OLD_IMAGE" /usr/local/bin/manabrew-server 2>> "$RAW_LOG" | cut -d' ' -f1 || true)
+    NEW_SHA=$(docker run --rm --entrypoint sha256sum "$RELAY_IMAGE" /usr/local/bin/manabrew-server 2>> "$RAW_LOG" | cut -d' ' -f1 || true)
+    if [ -n "$OLD_SHA" ] && [ "$OLD_SHA" = "$NEW_SHA" ]; then
+        RELAY_UNCHANGED=true
+        echo "manabrew-server binary unchanged (${NEW_SHA:0:12}) — relay not restarted" >> "$RAW_LOG"
+    else
         SERVICES_TO_RESTART="$SERVICES_TO_RESTART manabrew-server"
     fi
-fi
-
-# -- manabrew-hub (deck hub API; restart is harmless, no live-game state) --
-if $INFRA_CHANGED; then
-    echo "Building manabrew-hub (full)..." >> "$RAW_LOG"
-    docker compose -f "$COMPOSE_FILE" build --progress=plain --no-cache manabrew-hub >> "$RAW_LOG" 2>&1
-    SERVICES_TO_RESTART="$SERVICES_TO_RESTART manabrew-hub"
-elif $HUB_CHANGED; then
-    echo "Building manabrew-hub (cached)..." >> "$RAW_LOG"
-    docker compose -f "$COMPOSE_FILE" build --progress=plain manabrew-hub >> "$RAW_LOG" 2>&1
-    SERVICES_TO_RESTART="$SERVICES_TO_RESTART manabrew-hub"
-fi
-
-# -- manabrew (WASM + React static site served via caddy) --
-if $INFRA_CHANGED; then
-    echo "Building manabrew (full)..." >> "$RAW_LOG"
-    docker compose -f "$COMPOSE_FILE" build --progress=plain --no-cache $BUILD_ARGS manabrew >> "$RAW_LOG" 2>&1
-    SERVICES_TO_RESTART="$SERVICES_TO_RESTART manabrew"
-elif $WEB_CHANGED || $RUST_CHANGED || $CARDDATA_CHANGED; then
-    echo "Building manabrew (cached)..." >> "$RAW_LOG"
-    docker compose -f "$COMPOSE_FILE" build --progress=plain $BUILD_ARGS manabrew >> "$RAW_LOG" 2>&1
-    SERVICES_TO_RESTART="$SERVICES_TO_RESTART manabrew"
+else
+    SERVICES_TO_RESTART="$SERVICES_TO_RESTART manabrew-server"
 fi
 
 # -- observability stack (config-only; images are pulled, never built) --
@@ -274,7 +274,11 @@ fi
 # the old container otherwise lingers and can hold the host ports the new
 # one needs — exactly what took prod down on the #19 merge deploy.
 if [ -n "$SERVICES_TO_RESTART" ]; then
-    docker compose -f "$COMPOSE_FILE" $PROFILE_FLAG up -d --remove-orphans $SERVICES_TO_RESTART >> "$RAW_LOG" 2>&1
+    # --no-deps: recreate only the listed services, never their dependencies as
+    # a side effect (an `up manabrew` without this recreates the relay it
+    # depends_on — which drops live games and, if the relay image tag is ever
+    # missing, aborts the whole deploy).
+    docker compose -f "$COMPOSE_FILE" $PROFILE_FLAG up -d --no-deps --remove-orphans $SERVICES_TO_RESTART >> "$RAW_LOG" 2>&1
 fi
 
 if $CADDYFILE_CHANGED; then


### PR DESCRIPTION
## Summary

Prod builds every image locally in `deploy.sh`, but the web image is a ~1h WASM+Vite build that no longer fits the host's 38 GB disk — the Ironsmith trusted runtime tipped it into **ENOSPC → failed deploys**. CI already builds and pushes these images to GHCR, so this switches prod to **pull the pre-built images** instead of rebuilding.

- **`docker-images.yml`**: add **`manabrew-hub`** to the build matrix (was only server/web/node), so the deck-hub API is a pulled image too.
- **`compose.production.yml`**: `manabrew` (web), `manabrew-server`, `manabrew-hub`, `self-hosted-node` → `image: ghcr.io/witchesofthehill/<img>:${MANABREW_IMAGE_TAG:-latest}`, no local `build:`. The web image is relay-agnostic, so its relay endpoint moves from `VITE_RELAY_*` build args to **`RELAY_*` runtime env** (the entrypoint writes `config.js`). `parity-dashboard` still builds (Java, not published to GHCR).
- **`deploy.sh`**: pull the GHCR images (retry until CI has pushed them), recreate **only** services whose image actually changed; the relay keeps its **binary-diff guard** so an unrelated image change never restarts it and drops live games; final `up -d` gains **`--no-deps`** so recreating the web never drags the relay down as a side effect (this is what took the site down during the manual migration).

### Why this is also more robust
- **Fail-safe:** if a CI image build fails, no new image is pushed → deploy pulls the **last-good** image → prod keeps running. Today a failed build aborts the whole deploy.
- **No host toolchain / disk pressure:** the host only pulls; the heavy builds run on CI runners with adequate disk.
- **Deck hub** finally ships as a real image (it was never built/pushed before — the container simply didn't exist in prod).

## Known tradeoff
The generic GHCR web image is built **without** `VITE_SCRYFALL_SYMBOL_BASE`, so mana symbols load from `svgs.scryfall.io` directly rather than the `/scryfall-symbols/` Caddy proxy. Cosmetic/perf only — if the proxy matters, make it runtime-configurable (like `RELAY_*`).
