### PR TITLE
feat(ironsmith): gate as experimental opt-in + clean up unsupported-deck flow

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -26,6 +26,10 @@ on:
         description: "Extra image tag to push (in addition to the git ref)"
         required: false
         default: ""
+      build_ironsmith:
+        description: "Build the Ironsmith trusted-runtime WASM into the web image (slow — off by default)"
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -62,8 +66,15 @@ jobs:
       # so force-check-out the sources into the build context. Only the web image
       # needs it. If this fetch fails the web image still builds with the runtime
       # dark, so it must not fail the job.
+      #
+      # DEFAULT DARK: the WASM build is the expensive part of this workflow
+      # (Scryfall sync + registry + wasm-pack), and Ironsmith ships opt-in +
+      # experimental, so skip it unless explicitly requested — set the repo
+      # variable BUILD_IRONSMITH_WASM=true (persistent) or run this workflow
+      # manually with build_ironsmith checked. Skipping leaves the submodule
+      # absent → the Dockerfile stage emits an empty pkg → the runtime ships dark.
       - name: Check out ironsmith submodule (web image)
-        if: matrix.image == 'manabrew-web'
+        if: matrix.image == 'manabrew-web' && (vars.BUILD_IRONSMITH_WASM == 'true' || inputs.build_ironsmith == true)
         run: git -c submodule.ironsmith.update=checkout submodule update --init ironsmith || true
 
       - name: Set up Docker Buildx

--- a/src/components/IronsmithUnsupportedDeckModal.tsx
+++ b/src/components/IronsmithUnsupportedDeckModal.tsx
@@ -1,0 +1,67 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { GameIcon } from "@/components/game/GameIcon";
+import { useGameStore } from "@/stores/useGameStore";
+import type { IronsmithDeckIssue } from "@/game";
+
+function groupByPlayer(issues: IronsmithDeckIssue[]): Array<{ player: string; cards: string[] }> {
+  const order: string[] = [];
+  const byPlayer = new Map<string, string[]>();
+  for (const issue of issues) {
+    if (!byPlayer.has(issue.playerName)) {
+      byPlayer.set(issue.playerName, []);
+      order.push(issue.playerName);
+    }
+    const cards = byPlayer.get(issue.playerName)!;
+    if (!cards.includes(issue.cardName)) cards.push(issue.cardName);
+  }
+  return order.map((player) => ({ player, cards: byPlayer.get(player)! }));
+}
+
+export function IronsmithUnsupportedDeckModal() {
+  const issues = useGameStore((s) => s.ironsmithDeckError);
+  const dismiss = useGameStore((s) => s.dismissIronsmithDeckError);
+
+  const groups = issues ? groupByPlayer(issues) : [];
+  const multiPlayer = groups.length > 1;
+
+  return (
+    <Dialog open={issues !== null} onOpenChange={(open) => !open && dismiss()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <GameIcon name="anvil" className="h-4 w-4 text-warning" />
+            Ironsmith can&apos;t run this deck yet
+          </DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-muted-foreground">
+          Ironsmith is an experimental engine with partial card support. These cards aren&apos;t
+          implemented yet, so the match can&apos;t start. Swap them out, or pick a different engine.
+        </p>
+        <div className="max-h-[45dvh] space-y-3 overflow-y-auto pr-1">
+          {groups.map(({ player, cards }) => (
+            <div key={player} className="space-y-1">
+              {multiPlayer && (
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  {player}
+                </h3>
+              )}
+              <ul className="space-y-0.5">
+                {cards.map((card) => (
+                  <li key={card} className="text-sm text-foreground">
+                    {card}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+        <div className="flex justify-end">
+          <Button variant="outline" size="sm" onClick={dismiss}>
+            Got it
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -10,6 +10,7 @@ import { useGameSessionResume } from "@/hooks/useGameSessionResume";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { useKeybindings } from "@/hooks/useKeybindings";
 import { KeyboardShortcutsDialog } from "@/components/KeyboardShortcutsDialog";
+import { IronsmithUnsupportedDeckModal } from "@/components/IronsmithUnsupportedDeckModal";
 import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
 import { ManaBrewLogo } from "./ManaBrewLogo";
 import { DESKTOP_QUERY } from "@/lib/responsive";
@@ -99,6 +100,7 @@ export function AppShell() {
     <div className="h-[100dvh] overflow-hidden flex flex-col">
       <StatusBanner />
       <KeyboardShortcutsDialog open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
+      <IronsmithUnsupportedDeckModal />
       {!isDesktop && (
         <header
           className={cn(

--- a/src/components/lobby/CreateRoomDialog.tsx
+++ b/src/components/lobby/CreateRoomDialog.tsx
@@ -504,9 +504,15 @@ export function CreateRoomDialog({ open, onOpenChange }: CreateRoomDialogProps) 
                       <Badge variant="outline" className="text-[9px]">
                         trusted
                       </Badge>
+                      <Badge
+                        variant="outline"
+                        className="border-warning/40 text-[9px] text-warning"
+                      >
+                        experimental
+                      </Badge>
                     </div>
                     <span className="text-[10px] text-muted-foreground leading-tight">
-                      Ironsmith WASM hosted by the room creator. Experimental card support.
+                      Ironsmith WASM hosted by the room creator. Partial card support.
                     </span>
                   </button>
                 )}
@@ -580,7 +586,7 @@ export function CreateRoomDialog({ open, onOpenChange }: CreateRoomDialogProps) 
                     {kind !== "match"
                       ? "Limited runs on the Manabrew engine only — a work in progress that may have bugs or missing cards. Forge nodes host constructed matches, not drafts."
                       : engine === "Ironsmith"
-                        ? "Ironsmith rooms use Trusted mode: the host browser is authoritative, and hidden information is redacted per player."
+                        ? "Ironsmith is experimental with partial card support — some decks won't run yet. Rooms use Trusted mode: the host browser is authoritative, and hidden information is redacted per player."
                         : "The Manabrew engine is a work in progress and may have bugs or missing cards. For the most stable experience, play on the Forge engine."}
                   </p>
                 </div>

--- a/src/components/lobby/CreateRoomDialog.tsx
+++ b/src/components/lobby/CreateRoomDialog.tsx
@@ -9,6 +9,7 @@ import { DRAFTABLE_SET_TYPES } from "@/components/limited/setFilters";
 import { fetchCubeMetadata, fetchSetPool } from "@/api/limitedEdition";
 import { useScryfallStore } from "@/stores/useScryfallStore";
 import { useServerStore } from "@/stores/useServerStore";
+import { usePreferencesStore } from "@/stores/usePreferencesStore";
 import { getPlatformType } from "@/platform";
 import { isFeatureEnabled } from "@/featureFlags";
 import { IRONSMITH_WASM_AVAILABLE } from "@/game/ironsmithWasmAvailable";
@@ -147,7 +148,9 @@ interface CreateRoomDialogProps {
 export function CreateRoomDialog({ open, onOpenChange }: CreateRoomDialogProps) {
   const { createRoom, username } = useServerStore();
   const isTauri = getPlatformType() === "tauri";
-  const ironsmithEnabled = isFeatureEnabled("ironsmithRuntime") && IRONSMITH_WASM_AVAILABLE;
+  const ironsmithOptedIn = usePreferencesStore((s) => s.ironsmithRuntimeEnabled);
+  const ironsmithEnabled =
+    isFeatureEnabled("ironsmithRuntime") && IRONSMITH_WASM_AVAILABLE && ironsmithOptedIn;
   const [engine, setEngine] = useState<EngineKind>(isTauri ? "Forge" : "Manabrew");
   const [roomPassword, setRoomPassword] = useState("");
   const allSets = useScryfallStore((s) => s.sets);

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -11,7 +11,9 @@ export const featureFlags = {
   // false when the stub is installed because the submodule wasn't built). So a
   // build that skips the submodule ships this dark automatically, never a tile
   // backed by the throwing stub. Build it with `./ironsmith/rebuild-wasm.sh` +
-  // `yarn sync:ironsmith`.
+  // `yarn sync:ironsmith`. Even with the flag on and the wasm bundled, the
+  // engine is OFF until the user opts in via Settings (`ironsmithRuntimeEnabled`
+  // preference) — the experimental engine ships dark in prod by default.
   ironsmithRuntime: true,
 } as const;
 

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -23,7 +23,8 @@ export {
   selectGameRuntime,
 } from "./runtimeRegistry";
 export { ManualTabletopGameApi } from "./manualTabletopApi";
-export { IronsmithTrustedGameApi } from "./ironsmithRuntime";
+export { IronsmithTrustedGameApi, IronsmithUnsupportedDeckError } from "./ironsmithRuntime";
+export type { IronsmithDeckIssue } from "./ironsmithRuntime";
 export {
   applyManualTabletopAction,
   getActiveManualRoomHost,

--- a/src/game/ironsmithRuntime.ts
+++ b/src/game/ironsmithRuntime.ts
@@ -40,6 +40,30 @@ interface IronsmithFatalPrompt {
 
 type IronsmithPromptResult = IronsmithPromptMapping | IronsmithFatalPrompt | null;
 
+export interface IronsmithDeckIssue {
+  playerIndex: number;
+  playerName: string;
+  section: string;
+  cardName: string;
+  error: string;
+}
+
+export class IronsmithUnsupportedDeckError extends Error {
+  readonly issues: IronsmithDeckIssue[];
+  constructor(issues: IronsmithDeckIssue[]) {
+    const cards = [...new Set(issues.map((i) => i.cardName))];
+    const shown = cards.slice(0, 3).join(", ");
+    const rest = cards.length > 3 ? ` and ${cards.length - 3} more` : "";
+    super(
+      cards.length
+        ? `Ironsmith can't run this deck yet — ${cards.length} unsupported ${cards.length === 1 ? "card" : "cards"} (${shown}${rest}).`
+        : "Ironsmith can't run this deck yet.",
+    );
+    this.name = "IronsmithUnsupportedDeckError";
+    this.issues = issues;
+  }
+}
+
 async function ensureIronsmith(): Promise<void> {
   ironsmithInit ??= initIronsmith({ module_or_path: ironsmithWasmModuleUrl }).catch((error) => {
     ironsmithInit = null;
@@ -49,7 +73,10 @@ async function ensureIronsmith(): Promise<void> {
 }
 
 type IronsmithWasmGame = InstanceType<typeof WasmGame> & {
-  validateManabrewMatchConfig: (config: unknown) => { valid?: boolean };
+  validateManabrewMatchConfig: (config: unknown) => {
+    valid?: boolean;
+    issues?: IronsmithDeckIssue[];
+  };
   startManabrewMatch: (config: unknown) => unknown;
   manabrewView: (promptId: string) => {
     state?: { gameView?: GameViewDto };
@@ -251,7 +278,9 @@ export class IronsmithTrustedGameApi implements IGameApi {
       "valid" in validation &&
       validation.valid === false
     ) {
-      throw new Error(`Ironsmith rejected match config: ${JSON.stringify(validation)}`);
+      throw new IronsmithUnsupportedDeckError(
+        Array.isArray(validation.issues) ? validation.issues : [],
+      );
     }
     game.startManabrewMatch(config);
     await this.publish();

--- a/src/game/runtimeRegistry.ts
+++ b/src/game/runtimeRegistry.ts
@@ -1,5 +1,6 @@
 import { getPlatform } from "@/platform";
 import { isFeatureEnabled } from "@/featureFlags";
+import { usePreferencesStore } from "@/stores/usePreferencesStore";
 import { IRONSMITH_WASM_AVAILABLE } from "./ironsmithWasmAvailable";
 import { IronsmithTrustedGameApi } from "./ironsmithRuntime";
 import { ManualTabletopGameApi } from "./manualTabletopApi";
@@ -57,20 +58,37 @@ const ironsmithRuntime: GameRuntime = {
   api: ironsmithApi,
 };
 
+// Ironsmith is experimental and opt-in: it needs the compile flag, a bundled
+// wasm, AND the user's Settings toggle. Resolved dynamically (not baked into the
+// map) so flipping the Settings toggle takes effect without a reload.
+export function isIronsmithRuntimeEnabled(): boolean {
+  return (
+    isFeatureEnabled("ironsmithRuntime") &&
+    IRONSMITH_WASM_AVAILABLE &&
+    usePreferencesStore.getState().ironsmithRuntimeEnabled
+  );
+}
+
 const runtimes: Record<GameRuntimeKind, GameRuntime | null> = {
   manabrew: manabrewRuntime,
-  ironsmith:
-    isFeatureEnabled("ironsmithRuntime") && IRONSMITH_WASM_AVAILABLE ? ironsmithRuntime : null,
+  ironsmith: ironsmithRuntime,
   "manual-tabletop": manualTabletopRuntime,
   forge: null,
 };
 
+function resolveRuntime(kind: GameRuntimeKind): GameRuntime | null {
+  if (kind === "ironsmith" && !isIronsmithRuntimeEnabled()) return null;
+  return runtimes[kind];
+}
+
 export function getAvailableGameRuntimes(): GameRuntime[] {
-  return Object.values(runtimes).filter((runtime): runtime is GameRuntime => runtime !== null);
+  return (Object.keys(runtimes) as GameRuntimeKind[])
+    .map(resolveRuntime)
+    .filter((runtime): runtime is GameRuntime => runtime !== null);
 }
 
 export function getSelectedGameRuntime(): GameRuntime {
-  return runtimes[selectedRuntimeKind] ?? manabrewRuntime;
+  return resolveRuntime(selectedRuntimeKind) ?? manabrewRuntime;
 }
 
 export function getSelectedGameRuntimeKind(): GameRuntimeKind {
@@ -78,7 +96,7 @@ export function getSelectedGameRuntimeKind(): GameRuntimeKind {
 }
 
 export function selectGameRuntime(kind: GameRuntimeKind): GameRuntime {
-  const runtime = runtimes[kind];
+  const runtime = resolveRuntime(kind);
   if (!runtime) {
     throw new Error(`Game runtime is not available: ${kind}`);
   }

--- a/src/stores/gameStore.types.ts
+++ b/src/stores/gameStore.types.ts
@@ -5,6 +5,7 @@ import type { Deck } from "@/protocol/deck";
 import type { GameLogEntry } from "@/types/gameLog";
 import type { GameSnapshotEntry } from "@/types/gameSnapshot";
 import type { EngineKind, GameFormat } from "@/types/server";
+import type { IronsmithDeckIssue } from "@/game";
 
 export type { DisplayEvent };
 
@@ -33,6 +34,11 @@ export interface GameState {
    *  start). The game view shows this instead of hanging on the loading
    *  screen. Cleared when a new game starts. */
   fatalError: string | null;
+  /** Set when an Ironsmith match can't start because the deck contains cards the
+   *  runtime doesn't implement yet. Drives the unsupported-deck modal, shown
+   *  instead of a raw error toast. Cleared on dismiss and on the next start. */
+  ironsmithDeckError: IronsmithDeckIssue[] | null;
+  dismissIronsmithDeckError: () => void;
   /** Card-image prefetch progress shown on the loading screen. Reset to
    *  null between games. Populated while the start-game flow is fetching
    *  Scryfall textures, before the engine is allowed to emit prompts. */

--- a/src/stores/useGameStore.ts
+++ b/src/stores/useGameStore.ts
@@ -8,6 +8,7 @@ import {
   selectGameRuntime,
   startManualRoomSync,
   stopManualRoomSync as stopActiveManualRoomSync,
+  IronsmithUnsupportedDeckError,
 } from "@/game";
 import { isHostedEngineAvailable } from "@/config/webRuntimeConfig";
 import { getFormat } from "@/lib/formats";
@@ -186,6 +187,7 @@ async function initializeGame({
   set({
     isGameActive: true,
     fatalError: null,
+    ironsmithDeckError: null,
     gameView: null,
     currentPrompt: null,
     gameLog: [],
@@ -220,6 +222,7 @@ export const useGameStore = create<GameState>()(
       isGameActive: false,
       debugInfo: "",
       fatalError: null,
+      ironsmithDeckError: null,
       isPrefetchingCards: false,
       deferredQueue: [],
       isFlashing: false,
@@ -245,13 +248,19 @@ export const useGameStore = create<GameState>()(
 
       setGameConfig: (config) => set({ gameConfig: config }),
 
+      dismissIronsmithDeckError: () => set({ ironsmithDeckError: null }),
+
       startGame: async (deck, formatId, commanderName, opponentDeck, engine) => {
         try {
           await initializeGame({ deck, opponentDeck, formatId, commanderName, engine, set, get });
         } catch (e) {
           set({ isGameActive: false, debugInfo: `Start failed: ${e}`, isPrefetchingCards: false });
           console.error("[store] Failed to start game:", e);
-          toast.error(e instanceof Error ? e.message : "Failed to start game");
+          if (e instanceof IronsmithUnsupportedDeckError) {
+            set({ ironsmithDeckError: e.issues });
+          } else {
+            toast.error(e instanceof Error ? e.message : "Failed to start game");
+          }
         }
       },
 
@@ -387,6 +396,7 @@ export const useGameStore = create<GameState>()(
             isMultiplayer: true,
             isHost: localIsHost,
             myPlayerSlot: `player-${enginePlayerIndex}`,
+            ironsmithDeckError: null,
             gameView: null,
             currentPrompt: null,
             gameLog: [],
@@ -423,7 +433,11 @@ export const useGameStore = create<GameState>()(
             gameDecks: {},
           });
           console.error("[store] Failed to start multiplayer game:", e);
-          toast.error(e instanceof Error ? e.message : "Failed to start multiplayer game");
+          if (e instanceof IronsmithUnsupportedDeckError) {
+            set({ ironsmithDeckError: e.issues });
+          } else {
+            toast.error(e instanceof Error ? e.message : "Failed to start multiplayer game");
+          }
         }
       },
 

--- a/src/stores/usePreferencesStore.ts
+++ b/src/stores/usePreferencesStore.ts
@@ -57,6 +57,13 @@ interface PreferencesState {
   inGameAnimations: boolean;
   setInGameAnimations: (value: boolean) => void;
 
+  // Opt-in for the experimental Ironsmith trusted engine. Off by default so the
+  // engine ships dark in prod; the runtime registry and lobby tile also gate on
+  // the compile flag + `IRONSMITH_WASM_AVAILABLE`, so this only surfaces it
+  // where the real wasm is bundled.
+  ironsmithRuntimeEnabled: boolean;
+  setIronsmithRuntimeEnabled: (value: boolean) => void;
+
   cardPreviewMode: CardPreviewMode;
   setCardPreviewMode: (mode: CardPreviewMode) => void;
 
@@ -88,6 +95,7 @@ const PERSISTED_PREFERENCE_KEYS = [
   "battlefieldCardScale",
   "battlefieldCardStyle",
   "inGameAnimations",
+  "ironsmithRuntimeEnabled",
   "cardPreviewMode",
   "cardHoverDelayMs",
   "appThemeColorOverrides",
@@ -170,6 +178,9 @@ export const usePreferencesStore = create<PreferencesState>()(
 
           inGameAnimations: true,
           setInGameAnimations: (inGameAnimations) => set({ inGameAnimations }),
+
+          ironsmithRuntimeEnabled: false,
+          setIronsmithRuntimeEnabled: (ironsmithRuntimeEnabled) => set({ ironsmithRuntimeEnabled }),
 
           cardPreviewMode: "hover",
           setCardPreviewMode: (cardPreviewMode) => set({ cardPreviewMode }),

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -1,6 +1,8 @@
 import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { usePreferencesStore, type ZonePanelItem } from "@/stores/usePreferencesStore";
+import { isFeatureEnabled } from "@/featureFlags";
+import { IRONSMITH_WASM_AVAILABLE } from "@/game/ironsmithWasmAvailable";
 import { stripUsernameTag } from "@/lib/username";
 import { normalizeToWebp, ImageTooLargeError, AVATAR_IMAGE_BUDGET } from "@/lib/imageEncode";
 import { BattlefieldStylePreview } from "@/components/game/BattlefieldStylePreview";
@@ -1007,6 +1009,33 @@ export default function Settings() {
                 works (cards move, state indicators and damage numbers stay).
               </p>
             </div>
+
+            {isFeatureEnabled("ironsmithRuntime") && IRONSMITH_WASM_AVAILABLE && (
+              <div className="rounded-lg border bg-card/40 p-4 space-y-2">
+                <Label>Ironsmith engine (experimental)</Label>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant={prefs.ironsmithRuntimeEnabled ? "default" : "outline"}
+                    size="sm"
+                    onClick={() => prefs.setIronsmithRuntimeEnabled(true)}
+                  >
+                    On
+                  </Button>
+                  <Button
+                    variant={!prefs.ironsmithRuntimeEnabled ? "default" : "outline"}
+                    size="sm"
+                    onClick={() => prefs.setIronsmithRuntimeEnabled(false)}
+                  >
+                    Off
+                  </Button>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Adds the experimental Ironsmith trusted engine as a Create Room option. Card
+                  support is partial and games may be rough — off by default. Leave this off unless
+                  you're testing Ironsmith.
+                </p>
+              </div>
+            )}
 
             <div className="rounded-lg border bg-card/40 p-4 space-y-2">
               <Label>Card Preview Trigger</Label>

--- a/tests/e2e-ironsmith/README.md
+++ b/tests/e2e-ironsmith/README.md
@@ -17,8 +17,10 @@ create room, pick deck) are engine-generic and reusable for any multiplayer flow
    ./ironsmith/rebuild-wasm.sh          # first run needs the Scryfall sync
    yarn sync:ironsmith
    ```
-2. **Feature flag ON.** `ironsmithRuntime` ships `false` (dark). Flip it to `true`
-   in `src/featureFlags.ts` for the duration of testing.
+2. **Enable the engine.** The `ironsmithRuntime` compile flag is on, but the
+   engine is opt-in: turn it **On** under Settings → _Ironsmith engine
+   (experimental)_ (persists the `ironsmithRuntimeEnabled` preference). The tests
+   drive the real UI, so enable it there before running.
 3. **A relay** on `:9443` with server key `forge`:
    ```bash
    yarn dev:relay              # or: MANABREW_SERVER_KEY=forge cargo run --release -p manabrew-server


### PR DESCRIPTION
Makes the Ironsmith trusted runtime a properly-gated experimental feature instead of something exposed (and rough) by default, and stops paying its expensive WASM build on every release.

## Gating — opt-in + dark by default

- **Settings opt-in.** New `ironsmithRuntimeEnabled` preference (default **off**) with a toggle under Settings → *Ironsmith engine (experimental)*. The runtime registry and the Create Room tile resolve Ironsmith availability **dynamically** from it (plus the compile flag + `IRONSMITH_WASM_AVAILABLE`), so flipping it takes effect without a reload. Prod ships the engine dark; opt in to try it.
- **Dark in CI by default.** `docker-images.yml` only checks out the `ironsmith` submodule — which is what triggers the ~1h Scryfall + registry + `wasm-pack` build in `Dockerfile.web` — when `vars.BUILD_IRONSMITH_WASM == 'true'` or the manual `build_ironsmith` dispatch input is set. Otherwise the Dockerfile stage emits an empty pkg and the runtime ships dark, so normal releases don't pay the build cost.

## UX

- **Experimental disclaimer.** The Ironsmith engine tile gets an `experimental` badge (next to `trusted`), the subtext reads "Partial card support", and the Create Room warning leads with "Ironsmith is experimental with partial card support — some decks won't run yet".
- **Unsupported-deck flow.** An Ironsmith deck with unimplemented cards used to fail with a raw JSON validation payload in an error toast. The runtime now throws a typed `IronsmithUnsupportedDeckError` carrying the structured issues; both start paths route it to a dedicated modal listing the unsupported cards grouped by player. Every other start failure still toasts as before.

## Why

Ironsmith's card coverage is partial by design and current gameplay is rough (reported unusable), so it shouldn't be the default anyone hits — and rebuilding its 45 MB WASM on every CI release is wasteful while it's not shipping. Both gates default it off; testers enable the Settings toggle (and, for a prod image, the CI var) when validating.

## Test plan

- [x] `yarn typecheck` (tsc), `eslint`, `prettier --check` — all green.
- [ ] Real gameplay is **not** validated here — deferred until protocol-v1 (#445) and the master bridge (#454) land, then re-run the `tests/e2e-ironsmith` suite (README updated: enable via Settings). Which decks run / deck to try: `Mono Red Prison` (Vintage) — see `tests/e2e-ironsmith/README.md` § Notes.

## Coordination

- Overlaps **#454** (track master + protocol-v1 bridge) and **#445** on `ironsmithRuntime.ts` — whichever merges second reconciles; the typed `IronsmithUnsupportedDeckError` throw here belongs on the new `startHost` validation path.
