### PR TITLE
fix(web): restore hosted-ai + scryfall symbols in the generic ghcr image

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -53,6 +53,12 @@ jobs:
             dockerfile: manabrew-rs/crates/manabrew-server/Dockerfile
           - image: manabrew-web
             dockerfile: Dockerfile.web
+            # Route mana symbols through the web image's own same-origin Caddy
+            # proxy (ops/Caddyfile → /scryfall-symbols/) instead of fetching
+            # svgs.scryfall.io directly, which trips CORS. The proxy ships in
+            # every web image, so this is safe for self-hosters too.
+            build-args: |
+              VITE_SCRYFALL_SYMBOL_BASE=/scryfall-symbols/
           - image: manabrew-node
             dockerfile: manabrew-rs/crates/self-hosted-node/Dockerfile
           - image: manabrew-hub
@@ -107,6 +113,7 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
+          build-args: ${{ matrix.build-args }}
           # amd64 only: the web image compiles Rust→WASM + a Node/Astro build,
           # which is impractical under arm64 QEMU emulation. Add
           # linux/arm64 here (on a native arm runner) if you need it.

--- a/compose.production.yml
+++ b/compose.production.yml
@@ -30,6 +30,9 @@ services:
       RELAY_HOST: relay.manabrew.app
       RELAY_PORT: "443"
       RELAY_PASSWORD: "${MANABREW_SERVER_KEY:?MANABREW_SERVER_KEY is required}"
+      # Enable the Forge "Play vs AI" hosted engine option (the published image
+      # ships it off). Run the node with `--profile hosted-ai` for it to work.
+      HOSTED_AI_ENABLED: "${HOSTED_AI_ENABLED:-true}"
     # No depends_on for manabrew-hub: the site must deploy/restart even if the
     # hub image is broken; caddy just 502s api. until the hub comes up.
     depends_on:

--- a/ops/web-entrypoint.sh
+++ b/ops/web-entrypoint.sh
@@ -1,22 +1,21 @@
 #!/bin/sh
 set -e
 
-# Regenerate the app's runtime relay config from env so one published image can
-# point at any relay without a rebuild. Empty RELAY_HOST leaves the app on its
-# compiled-in default (VITE_RELAY_* / the official relay). Port defaults to 443
-# (the client dials wss://); set RELAY_PORT=9443 for a bare ws:// relay.
-if [ -n "${RELAY_HOST:-}" ]; then
-	cat >/srv/manabrew/config.js <<EOF
-window.__MANABREW_RUNTIME__ = {
-  relay: {
-    host: "${RELAY_HOST}",
-    port: ${RELAY_PORT:-443},
-    password: "${RELAY_PASSWORD:-forge}"
-  }
-};
-EOF
-else
-	echo 'window.__MANABREW_RUNTIME__ = {};' >/srv/manabrew/config.js
-fi
+# Regenerate the app's runtime config from env so one published image serves any
+# deployment without a rebuild.
+#   relay: from RELAY_* (empty RELAY_HOST leaves the app on its compiled-in
+#     VITE_RELAY_* default; port defaults to 443 for wss://, set 9443 for ws://).
+#   hostedAiEnabled: from HOSTED_AI_ENABLED — gates the Forge "Play vs AI"
+#     option, off in the published image.
+{
+	echo 'window.__MANABREW_RUNTIME__ = {'
+	if [ -n "${RELAY_HOST:-}" ]; then
+		echo "  relay: { host: \"${RELAY_HOST}\", port: ${RELAY_PORT:-443}, password: \"${RELAY_PASSWORD:-forge}\" },"
+	fi
+	case "$(printf '%s' "${HOSTED_AI_ENABLED:-}" | tr '[:upper:]' '[:lower:]')" in
+	1 | true | yes | on) echo '  hostedAiEnabled: true,' ;;
+	esac
+	echo '};'
+} >/srv/manabrew/config.js
 
 exec caddy run --config /etc/caddy/Caddyfile --adapter caddyfile

--- a/src/config/webRuntimeConfig.ts
+++ b/src/config/webRuntimeConfig.ts
@@ -16,6 +16,12 @@ export function getHubApiUrl(): string {
 }
 
 export function isHostedEngineAvailable(): boolean {
+  // Runtime config (written from HOSTED_AI_ENABLED by the web image entrypoint)
+  // wins over the build-time default, so the generic published image can ship
+  // this off and a deployment can turn it on without a rebuild.
+  const runtime =
+    typeof window !== "undefined" ? window.__MANABREW_RUNTIME__?.hostedAiEnabled : undefined;
+  if (typeof runtime === "boolean") return runtime;
   return ["1", "true", "yes", "on"].includes(
     (import.meta.env.VITE_HOSTED_AI_ENABLED ?? "").toLowerCase(),
   );

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -19,6 +19,10 @@ interface ImportMeta {
 interface Window {
   __MANABREW_RUNTIME__?: {
     relay?: { host?: string; port?: number; password?: string };
+    // Runtime toggle for the Forge "Play vs AI" hosted engine. The published
+    // web image ships this off; the deployment's entrypoint sets it from
+    // HOSTED_AI_ENABLED. Overrides the build-time VITE_HOSTED_AI_ENABLED.
+    hostedAiEnabled?: boolean;
   };
 }
 


### PR DESCRIPTION
## Summary

Prod hotfix: moving the web image to the pre-built ghcr image (#448) silently dropped two build-time `VITE_*` vars the old local build set.

- **Forge "Play vs AI" greyed out** — `VITE_HOSTED_AI_ENABLED` is unset in the generic image → `isHostedEngineAvailable()` false. Made it a **runtime** toggle (`window.__MANABREW_RUNTIME__.hostedAiEnabled`, written from `HOSTED_AI_ENABLED` by the web entrypoint — same mechanism #448 used for `RELAY_*`) and set it on in `compose.production.yml`. The published image stays **off**, so self-hosters without a node are unaffected.
- **Mana-symbol CORS** — `VITE_SCRYFALL_SYMBOL_BASE` is unset → symbols load from `svgs.scryfall.io` directly instead of the same-origin `/scryfall-symbols/` Caddy proxy. Baked it as a **web-image build-arg** in `docker-images.yml`; the proxy ships in every web image (safe for self-hosters) and it's scoped to the Docker build, so the desktop app keeps its direct URL.

## Why

Both are #448 fallout — the generic image is relay/deployment-agnostic, so anything that was a build-time `VITE_*` in the old local build needs to move to runtime config (hosted-AI) or be baked into the universal image (the symbol proxy).

## Test plan

- [x] `yarn typecheck`, `eslint`, `prettier` green.
- [x] `sh -n` on the entrypoint; verified the generated `config.js` is valid JS with relay + `hostedAiEnabled: true`.
- Runtime toggle takes effect on the next prod deploy of the web image (no rebuild needed to flip it thereafter); the symbol base lands with the next web-image build.