### PR TITLE
fix(web): serve scryfall card images through a same-origin proxy

### DIFF
--- a/ops/Caddyfile
+++ b/ops/Caddyfile
@@ -67,6 +67,23 @@ play.manabrew.app {
         header Cross-Origin-Resource-Policy "same-origin"
     }
 
+    # Card image proxy: cards.scryfall.io intermittently serves cached objects
+    # without CORS headers, which breaks the app's cors-mode fetches (WebGL
+    # textures need cors-clean pixels). Served same-origin here, CORS never
+    # applies. Mirrors the symbols proxy above.
+    @scryimg path_regexp scryimg ^/scryfall-img/(.*)$
+    handle @scryimg {
+        rewrite * /{re.scryimg.1}
+        reverse_proxy https://cards.scryfall.io {
+            header_up Host cards.scryfall.io
+            header_down -Access-Control-Allow-Origin
+            header_down -Cross-Origin-Resource-Policy
+            header_down -Cache-Control
+        }
+        header Cache-Control "public, max-age=604800"
+        header Cross-Origin-Resource-Policy "same-origin"
+    }
+
     @spellbook path_regexp spellbook ^/spellbook-api/(.*)$
     handle @spellbook {
         rewrite * /{re.spellbook.1}

--- a/ops/staging.Caddyfile
+++ b/ops/staging.Caddyfile
@@ -38,6 +38,23 @@
         header Cross-Origin-Resource-Policy "same-origin"
     }
 
+    # Card image proxy: cards.scryfall.io intermittently serves cached objects
+    # without CORS headers, which breaks the app's cors-mode fetches (WebGL
+    # textures need cors-clean pixels). Served same-origin here, CORS never
+    # applies. Mirrors the symbols proxy above.
+    @scryimg path_regexp scryimg ^/scryfall-img/(.*)$
+    handle @scryimg {
+        rewrite * /{re.scryimg.1}
+        reverse_proxy https://cards.scryfall.io {
+            header_up Host cards.scryfall.io
+            header_down -Access-Control-Allow-Origin
+            header_down -Cross-Origin-Resource-Policy
+            header_down -Cache-Control
+        }
+        header Cache-Control "public, max-age=604800"
+        header Cross-Origin-Resource-Policy "same-origin"
+    }
+
     @spellbook path_regexp spellbook ^/spellbook-api/(.*)$
     handle @spellbook {
         rewrite * /{re.spellbook.1}

--- a/ops/standalone.Caddyfile
+++ b/ops/standalone.Caddyfile
@@ -16,6 +16,24 @@
 		file_server
 	}
 
+
+	# Card image proxy: cards.scryfall.io intermittently serves cached objects
+	# without CORS headers, which breaks the app's cors-mode fetches (WebGL
+	# textures need cors-clean pixels). Served same-origin here, CORS never
+	# applies. Mirrors the symbols proxy above.
+	@scryimg path_regexp scryimg ^/scryfall-img/(.*)$
+	handle @scryimg {
+		rewrite * /{re.scryimg.1}
+		reverse_proxy https://cards.scryfall.io {
+			header_up Host cards.scryfall.io
+			header_down -Access-Control-Allow-Origin
+			header_down -Cross-Origin-Resource-Policy
+			header_down -Cache-Control
+		}
+		header Cache-Control "public, max-age=604800"
+		header Cross-Origin-Resource-Policy "same-origin"
+	}
+
 	handle {
 		header {
 			Cross-Origin-Opener-Policy "same-origin"

--- a/src/api/scryfall.ts
+++ b/src/api/scryfall.ts
@@ -213,11 +213,22 @@ export async function fetchCardsBySet(setCode: string): Promise<ScryfallCard[]> 
 
 const SCRYFALL_IMAGE_MAX_RETRIES = 3;
 
-// Avoid scryfall corrupted caches
-function corsCachePartition(url: string): string {
-  const u = new URL(url);
-  u.searchParams.set("mbcors", "1");
-  return u.toString();
+// cards.scryfall.io intermittently serves cached objects with NO CORS headers
+// (verified 2026-07-15: `access-control-allow-origin` absent even with an
+// Origin header, while svgs.scryfall.io still sends it), which makes every
+// cors-mode fetch fail — and WebGL textures need cors-clean pixels, so a
+// plain-<img> fallback can't save the Pixi board. Cache-busting is not an
+// option either: the CDN 403s any unknown query param (the `mbcors=1`
+// partition attempt turned soft failures into hard ones). Instead, card
+// images are fetched same-origin through the `/scryfall-img/` proxy route
+// (ops/Caddyfile + staging/standalone Caddyfiles in prod, the vite dev proxy
+// locally) — same-origin needs no CORS at all. The direct CDN stays as the
+// fallback for deployments without the route.
+const SCRYFALL_IMAGE_CDN_PREFIX = "https://cards.scryfall.io/";
+
+function scryfallImageProxyUrl(url: string): string | null {
+  if (!url.startsWith(SCRYFALL_IMAGE_CDN_PREFIX)) return null;
+  return `/scryfall-img/${url.slice(SCRYFALL_IMAGE_CDN_PREFIX.length)}`;
 }
 
 async function fetchImageBlob(url: string): Promise<string> {
@@ -231,11 +242,16 @@ async function fetchImageBlob(url: string): Promise<string> {
 }
 
 async function fetchImageBlobNoCache(url: string): Promise<string> {
-  try {
-    return await fetchImageBlob(corsCachePartition(url));
-  } catch {
-    return await fetchImageBlob(url);
+  const proxied = scryfallImageProxyUrl(url);
+  if (proxied) {
+    try {
+      return await fetchImageBlob(proxied);
+    } catch {
+      // Proxy route missing or down — the direct CDN works whenever
+      // scryfall's CORS headers are healthy.
+    }
   }
+  return await fetchImageBlob(url);
 }
 
 function loadImageElement(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -88,6 +88,11 @@ export default defineConfig({
         changeOrigin: true,
         rewrite: (p) => p.replace(/^\/scryfall-symbols/, "/card-symbols"),
       },
+      "/scryfall-img": {
+        target: "https://cards.scryfall.io",
+        changeOrigin: true,
+        rewrite: (p) => p.replace(/^\/scryfall-img/, ""),
+      },
     },
   },
   worker: {


### PR DESCRIPTION
Fixes the widespread "images don't load" breakage on prod.

## Root cause

`cards.scryfall.io` is intermittently serving cached objects with **no CORS headers at all** — verified directly:

```
$ curl -sI -H "Origin: https://play.manabrew.app" https://cards.scryfall.io/normal/front/5/6/56ebc372-....jpg | grep -i access-control
(nothing — while svgs.scryfall.io still returns access-control-allow-origin: *)
```

Every `mode: "cors"` fetch of a card image therefore fails, and the Pixi board can't fall back to plain `<img>` (WebGL needs CORS-clean pixels — tainted images throw on `texImage2D`).

#452's `mbcors=1` cache-partition made it strictly worse: **Scryfall's CDN 403s unknown query params** (`age: 0`, fresh rejection), so the primary attempt hard-fails and the fallback hits the same header-less cached object → zero images.

## Fix

Serve card images **same-origin** through a `/scryfall-img/` reverse-proxy — same-origin requests don't need CORS at all, and our Caddy fetches from Scryfall server-side where CORS doesn't apply either. This mirrors the existing `/scryfall-symbols/` proxy exactly:

- `ops/Caddyfile` (play.manabrew.app), `ops/staging.Caddyfile`, `ops/standalone.Caddyfile` (published web image) — all three validated with `caddy validate`
- vite dev proxy for local development
- `fetchImageBlobNoCache` prefers the proxy path and falls back to the direct CDN, so deployments without the route (or an out-of-date Caddy) degrade to yesterday's behavior instead of breaking

The `mbcors` partition is removed.

## Verified

Live bot game on the dev stack: **120 texture fetches through `/scryfall-img/`, 0 failures, 0 `[scryfall-image]` console errors**; battlefield, hand, and zone tiles all render.

> Deploy note: prod needs the updated `ops/Caddyfile` picked up (it's bind-mounted, so a `docker compose exec caddy caddy reload --config /etc/caddy/Caddyfile` after pulling — no image rebuild required for the proxy itself; the web bundle change ships with the normal release).
