### PR TITLE
fix(web): viewport + slider-scaled hand fan, honest 75-150% size range

### DIFF
--- a/src/components/game/modals/GameSettingsModal.tsx
+++ b/src/components/game/modals/GameSettingsModal.tsx
@@ -58,7 +58,7 @@ export function GameSettingsModal({ onClose }: { onClose: () => void }) {
       <Modal.Body className="space-y-5">
         <SettingRow
           label={`Card size (${Math.round(prefs.cardSizeMultiplier * 100)}%)`}
-          hint="Scales cards on every battlefield. 100% is the classic 3-row board; large sizes are clamped so at least 2 rows always fit each field."
+          hint="Scales cards on every battlefield and your hand fan. 100% is the classic 3-row board; battlefield cards cap at a 2-row fill, the hand keeps growing past them."
         >
           <input
             type="range"

--- a/src/pixi/BoardCanvas.tsx
+++ b/src/pixi/BoardCanvas.tsx
@@ -13,6 +13,7 @@ import { battlefieldScaleForMultiplier, combatRowReserve, maxScaleForRows } from
 import { playmatPad } from "./board/PlaymatLayer";
 import { setPixiTextStyleTheme } from "./textStyles";
 import { getTheme } from "@/hooks/useTheme";
+import { useHandScale } from "@/hooks/useHandScale";
 import { usePreferencesStore } from "@/stores/usePreferencesStore";
 import { isCoarsePointer } from "@/lib/responsive";
 import { registerPixiApp } from "./visibility";
@@ -25,8 +26,6 @@ import {
   PIXI_MAX_FPS,
   Z_HAND_ACTIONS_MENU,
 } from "./constants";
-import { CARD_H } from "@/components/game/game.constants";
-import { HAND_CARD_BASE } from "@/components/game/game.styles";
 import { HandCardActions } from "@/components/game/zones/HandCardActions";
 import { useCardFaces } from "@/hooks/useCardFaces";
 import { isHorizontalGameCard } from "@/lib/horizontalGameCard";
@@ -179,6 +178,7 @@ export function BoardCanvas({
   const cardSizeMultiplier = usePreferencesStore((s) => s.cardSizeMultiplier);
   const cardStyle = usePreferencesStore((s) => s.battlefieldCardStyle);
   const lockZoneTiles = usePreferencesStore((s) => s.lockZoneTiles);
+  const handViewportScale = useHandScale();
 
   const [handHover, setHandHover] = useState<HandHoverState | null>(null);
   const clearTimerRef = useRef<number | null>(null);
@@ -379,11 +379,19 @@ export function BoardCanvas({
         )
       : battlefieldScaleForMultiplier(oppUsable, cardSizeMultiplier);
     s.configure(players, layout, { self: selfScale, opponent: oppScale });
-    // The hand fan holds its classic (authored) size and the battlefield grows
-    // up to meet it — the fan only enlarges past that on displays tall enough
-    // for battlefield cards to outgrow it. Applied after configure so a
-    // rebuilt HandController picks it up and the zone-height cap re-evaluates.
-    s.setHandScale(Math.max(1, (selfScale * CARD_H) / HAND_CARD_BASE.cardH));
+    // The hand fan scales with the viewport (`useHandScale`, authored at
+    // 1440px — wiring the React→Pixi hand migration lost, leaving the fan at
+    // reference size on every display) times the card-size multiplier, so the
+    // slider keeps growing the hand past the battlefield's 2-row cap. The
+    // grown fan overlaps the field bottom instead of shrinking it: the hand
+    // reserve stays viewport-only (scaling it with the slider would shrink
+    // the 2-row fill — the board would get SMALLER as the slider rises) and
+    // the fan's blocker rect keeps cards out from underneath. Growth is
+    // capped at a fraction of the field height in HandController.setScale.
+    // Compact keeps the fixed fan its mobile layout was tuned for. Applied
+    // after configure so a rebuilt HandController picks it up and the
+    // zone-height cap re-evaluates.
+    s.setHandScale(compact ? 1 : handViewportScale * cardSizeMultiplier);
     const next: BoardCanvasLayout = {
       self: layout.self,
       dividerY: layout.dividerY,
@@ -400,6 +408,7 @@ export function BoardCanvas({
   }, [
     playersKey,
     cardSizeMultiplier,
+    handViewportScale,
     selfHeightFraction,
     compact,
     selfBottomReserve,

--- a/src/stores/usePreferencesStore.ts
+++ b/src/stores/usePreferencesStore.ts
@@ -11,7 +11,10 @@ export type CardPreviewMode = "hover" | "shift" | "alt" | "ctrl";
 export type BattlefieldCardStyle = "realistic" | "art" | "frame";
 
 export const CARD_SIZE_MULTIPLIER_MIN = 0.75;
-export const CARD_SIZE_MULTIPLIER_MAX = 3;
+// Under the 2-rows-minimum battlefield rule, a 2-row fill is only ~1.35-1.5x
+// the classic 3-row size on ANY display — a knob past 150% would be a lie
+// (the old 300% top was one: everything saturated around 150%).
+export const CARD_SIZE_MULTIPLIER_MAX = 1.5;
 
 interface PreferencesState {
   appThemePreset: string;
@@ -47,12 +50,12 @@ interface PreferencesState {
   battlefieldAutoSort: boolean;
   setBattlefieldAutoSort: (value: boolean) => void;
 
-  // One knob for battlefield card size on ALL fields. 1 = the classic 3-row
-  // board; 3 = 300%. Each field clamps to a 2-row fill of its own height (a
-  // 1-row board is unplayable), so on small windows large multipliers
-  // saturate early. The hand keeps its classic size and only grows past it on
-  // displays tall enough for battlefield cards to outgrow it
-  // (BoardCanvas.reconfigure).
+  // One knob for card size: battlefield cards on ALL fields plus the hand
+  // fan. 1 = the classic 3-row board; 1.5 = the 2-row fill that is the
+  // geometric max under the 2-rows-minimum rule (a 1-row board is
+  // unplayable). Each field clamps against its own height; the hand
+  // (viewport-scaled × multiplier) keeps growing past the battlefield's cap,
+  // up to a fraction of the field height (BoardCanvas.reconfigure).
   cardSizeMultiplier: number;
   setCardSizeMultiplier: (multiplier: number) => void;
 
@@ -128,6 +131,13 @@ function pickPersistedPreferences(persistedState: unknown): Partial<PreferencesS
   // wins on rehydrate. Without this, users who once had the empty default
   // saved would never get a generated name.
   if (next.serverUsername === "") delete next.serverUsername;
+  // Values saved while the slider still went to 300% clamp to the new max.
+  if (typeof next.cardSizeMultiplier === "number") {
+    next.cardSizeMultiplier = Math.max(
+      CARD_SIZE_MULTIPLIER_MIN,
+      Math.min(CARD_SIZE_MULTIPLIER_MAX, next.cardSizeMultiplier),
+    );
+  }
   return next as Partial<PreferencesState>;
 }
 

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -893,6 +893,13 @@ export default function Settings() {
                     <Button
                       variant="outline"
                       size="sm"
+                      onClick={() => prefs.setCardSizeMultiplier(CARD_SIZE_MULTIPLIER_MIN)}
+                    >
+                      75%
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
                       onClick={() => prefs.setCardSizeMultiplier(1)}
                     >
                       100%
@@ -900,27 +907,26 @@ export default function Settings() {
                     <Button
                       variant="outline"
                       size="sm"
-                      onClick={() => prefs.setCardSizeMultiplier(2)}
+                      onClick={() => prefs.setCardSizeMultiplier(CARD_SIZE_MULTIPLIER_MAX)}
                     >
-                      200%
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => prefs.setCardSizeMultiplier(3)}
-                    >
-                      300%
+                      150%
                     </Button>
                   </div>
                   <p className="text-xs text-muted-foreground">
-                    Scales cards on every battlefield. 100% is the classic 3-row board; large sizes
-                    are clamped so at least 2 rows always fit each field.
+                    Scales cards on every battlefield and your hand fan. 100% is the classic 3-row
+                    board; battlefield cards cap at a 2-row fill so the board stays playable, while
+                    the hand keeps growing past them.
                   </p>
                 </div>
                 <div className="w-[120px] shrink-0 flex justify-center">
                   <BattlefieldStylePreview
                     style={prefs.battlefieldCardStyle}
-                    width={Math.round(40 + ((prefs.cardSizeMultiplier - 0.75) / 2.25) * 80)}
+                    width={Math.round(
+                      48 +
+                        ((prefs.cardSizeMultiplier - CARD_SIZE_MULTIPLIER_MIN) /
+                          (CARD_SIZE_MULTIPLIER_MAX - CARD_SIZE_MULTIPLIER_MIN)) *
+                          72,
+                    )}
                   />
                 </div>
               </div>

--- a/tests/e2e-ui/board-settings.mjs
+++ b/tests/e2e-ui/board-settings.mjs
@@ -103,10 +103,11 @@ const readPref = (key) =>
     }
   }, key);
 
-await page.locator("[data-modal-panel] input[type=range]").first().fill("300");
+await page.locator("[data-modal-panel] input[type=range]").first().fill("150");
 await page.waitForTimeout(300);
-if ((await readPref("cardSizeMultiplier")) !== 3) await fail("cardSizeMultiplier did not persist");
-console.log("ok: card size slider persists (300%)");
+if ((await readPref("cardSizeMultiplier")) !== 1.5)
+  await fail("cardSizeMultiplier did not persist");
+console.log("ok: card size slider persists (150%)");
 
 await page.getByRole("button", { name: /^Locked$/ }).click();
 await page.waitForTimeout(200);
@@ -117,7 +118,7 @@ console.log("ok: zone pile lock persists");
 await page.getByRole("button", { name: /^Done$/ }).click();
 // Long settle: the rescale re-fetches card textures at the new resolution.
 await page.waitForTimeout(4000);
-if (SHOT) await page.screenshot({ path: `${SHOT}/board-300.png` });
+if (SHOT) await page.screenshot({ path: `${SHOT}/board-150.png` });
 
 // ── 4. ScryModal big hover preview ──────────────────────────────────────────
 // Inject a surveil-style scry prompt with real cards from the live gameView.


### PR DESCRIPTION
Follow-ups on #450 from playing with the merged build:

## Hand was too small (and never scaled)

The Pixi hand fan was authored to scale with the viewport (`useHandScale`, 1440px reference, up to 1.3× on wide screens) — but the React→Pixi hand migration lost that wiring, so the fan rendered at reference size on every display while the hand reserve and drag ghosts already assumed the scaled size. Restored: `BoardCanvas.reconfigure` now drives `setHandScale` with the viewport scale **times the card-size multiplier**, so the slider keeps growing the hand *past* the battlefield's 2-row cap.

Two guards make that safe:
- the hand **reserve** stays viewport-only — scaling it with the slider would shrink the 2-row fill, i.e. the board would get *smaller* as the slider rises;
- the grown fan overlaps the field bottom instead, and the fan's grid blocker (`BoardScene.localBlockers`) keeps cards out from underneath, with `HandController`'s field-height growth cap on top. Compact/mobile keeps its fixed fan.

## The 300% slider was a lie

Under the 2-rows-minimum rule (#450 review), a 2-row fill is only ~1.35–1.5× the classic 3-row size **on any display** — the knob saturated around 150% no matter what, exactly as it felt on prod. The range is now an honest **75–150%** (Settings presets 75/100/150), and values persisted from the 300% era clamp on rehydrate.

![board at 150% — 2-row battlefield, hand grown past it](https://raw.githubusercontent.com/witchesofthehill/manabrew/pr-assets/hand-scale-and-size-range/board-150.png)

## Test plan

- [x] `yarn tsc --noEmit`, eslint, prettier clean
- [x] `cargo xtask e2e-ui` passes end-to-end (slider assertion updated to the new range; screenshot above is its output)
- [x] Verified live: 100% matches the classic board; 150% gives the 2-row fill with the hand visibly larger than board cards, hovered cards lifting fully into view
