### PR TITLE
fix(web): 2-row fill actually renders 2 rows; damp hand growth to half rate

### DIFF
--- a/src/hooks/useHandScale.ts
+++ b/src/hooks/useHandScale.ts
@@ -1,5 +1,6 @@
 import { useSyncExternalStore } from "react";
 import { SHORT_SCREEN_QUERY } from "@/lib/responsive";
+import { usePreferencesStore } from "@/stores/usePreferencesStore";
 
 /** Reference viewport width — sizes are authored at this width. */
 const REF_WIDTH = 1440;
@@ -27,6 +28,22 @@ function getSnapshot() {
   return getScale();
 }
 
+/** The hand follows the card-size slider at HALF rate: full-rate growth made
+ *  the fan so wide/tall that its grid blocker swallowed the whole bottom
+ *  battlefield row, and it dwarfed the (2-row-capped) battlefield cards. */
+const HAND_GROWTH_DAMP = 0.5;
+
+export function handSizeMultiplier(cardSizeMultiplier: number): number {
+  return 1 + (cardSizeMultiplier - 1) * HAND_GROWTH_DAMP;
+}
+
+/** Viewport-derived hand scale times the (damped) card-size multiplier.
+ *  Single source of truth for the fan itself (BoardCanvas → setHandScale),
+ *  the hand reserve (GameBoard), and the drag ghosts (Game.tsx) — the fan and
+ *  the grid reserve must never disagree, or a grown fan eats the bottom
+ *  battlefield row through its cell blocker. */
 export function useHandScale() {
-  return useSyncExternalStore(subscribe, getSnapshot, () => 1);
+  const viewportScale = useSyncExternalStore(subscribe, getSnapshot, () => 1);
+  const cardSizeMultiplier = usePreferencesStore((s) => s.cardSizeMultiplier);
+  return viewportScale * handSizeMultiplier(cardSizeMultiplier);
 }

--- a/src/pixi/BoardCanvas.tsx
+++ b/src/pixi/BoardCanvas.tsx
@@ -344,16 +344,20 @@ export function BoardCanvas({
     // Each region is scaled to fill its OWN height — a single shared scale let
     // the tightest field (self, after the hand-fan reserve) shrink everyone, so
     // the roomier opponent fields wasted space. Every field follows the card
-    // size multiplier (100% = 3-row board), clamped per field to a single-row
+    // size multiplier (100% = 3-row board), clamped per field to a 2-row
     // fill; compact locks to 3 rows regardless.
     const scaleFloor = compact
       ? BATTLEFIELD_CARD_SCALE_FLOOR_COMPACT
       : BATTLEFIELD_CARD_SCALE_FLOOR;
     // The region's playArea insets the usable zone by the playmat pad on every
-    // edge before laying rows; compact subtracts it here too, or the 3-row
-    // scale overshoots and the grid floors to 2 rows.
+    // edge before laying rows, so the pad must come off before picking the
+    // scale on EVERY platform — the exact joint solve fills the height it is
+    // given, and an un-trimmed height makes the real grid floor a row short
+    // (a 2-row fill rendered as a single row). The old desktop path only
+    // survived without the trim because its two-pass band estimate under-sized
+    // cards enough to leave slack.
     const playmatTrim = (usable: number, width: number) =>
-      compact ? Math.max(1, usable - playmatPad(width, usable) * 2) : usable;
+      Math.max(1, usable - playmatPad(width, usable) * 2);
     const selfUsable = playmatTrim(
       Math.max(1, layout.self.height - (selfBottomReserve ?? 0)),
       layout.self.width,
@@ -379,19 +383,15 @@ export function BoardCanvas({
         )
       : battlefieldScaleForMultiplier(oppUsable, cardSizeMultiplier);
     s.configure(players, layout, { self: selfScale, opponent: oppScale });
-    // The hand fan scales with the viewport (`useHandScale`, authored at
-    // 1440px — wiring the React→Pixi hand migration lost, leaving the fan at
-    // reference size on every display) times the card-size multiplier, so the
-    // slider keeps growing the hand past the battlefield's 2-row cap. The
-    // grown fan overlaps the field bottom instead of shrinking it: the hand
-    // reserve stays viewport-only (scaling it with the slider would shrink
-    // the 2-row fill — the board would get SMALLER as the slider rises) and
-    // the fan's blocker rect keeps cards out from underneath. Growth is
-    // capped at a fraction of the field height in HandController.setScale.
-    // Compact keeps the fixed fan its mobile layout was tuned for. Applied
-    // after configure so a rebuilt HandController picks it up and the
-    // zone-height cap re-evaluates.
-    s.setHandScale(compact ? 1 : handViewportScale * cardSizeMultiplier);
+    // The hand fan gets `useHandScale` — viewport factor times the DAMPED
+    // card-size multiplier — the exact number the hand reserve (GameBoard)
+    // and drag ghosts are computed from, so the fan and the grid can never
+    // disagree (a fan bigger than its reserve swallows the bottom battlefield
+    // row through its cell blocker). Growth is additionally capped at a
+    // fraction of the field height in HandController.setScale. Compact keeps
+    // the fixed fan its mobile layout was tuned for. Applied after configure
+    // so a rebuilt HandController picks it up and the cap re-evaluates.
+    s.setHandScale(compact ? 1 : handViewportScale);
     const next: BoardCanvasLayout = {
       self: layout.self,
       dividerY: layout.dividerY,

--- a/src/stores/usePreferencesStore.ts
+++ b/src/stores/usePreferencesStore.ts
@@ -54,8 +54,9 @@ interface PreferencesState {
   // fan. 1 = the classic 3-row board; 1.5 = the 2-row fill that is the
   // geometric max under the 2-rows-minimum rule (a 1-row board is
   // unplayable). Each field clamps against its own height; the hand
-  // (viewport-scaled × multiplier) keeps growing past the battlefield's cap,
-  // up to a fraction of the field height (BoardCanvas.reconfigure).
+  // (viewport-scaled, following the slider at half rate — useHandScale)
+  // grows past the battlefield's cap, up to a fraction of the field height
+  // (BoardCanvas.reconfigure).
   cardSizeMultiplier: number;
   setCardSizeMultiplier: (multiplier: number) => void;
 


### PR DESCRIPTION
Follow-up on #457 — at 150% the self field showed a single row and the hand felt oversized. Two root causes, one commit:

## The "2-row fill" rendered as one row

`BoardRegion.playArea` insets the field by the playmat padding on **every** platform before laying rows, but the scale solve only subtracted that padding in compact mode. The exact joint solve (from #450) fills whatever height it's given, so cards came out ~30px too tall for the real grid and the row count floored from 2 to 1. The old desktop path never noticed because its two-pass band estimate under-sized cards enough to leave slack. The trim is now unconditional.

## Hand growth damped to half rate

At `viewport × 1.5` the fan's grid blocker got wide enough to swallow the **entire** bottom battlefield row (the reserve only tracked the viewport factor), which also made the self field look single-rowed — and the fan dwarfed the 2-row-capped battlefield cards. The hand now follows the slider at half rate (`handSizeMultiplier` in `useHandScale`), and the fan, the hand reserve, and the drag ghosts all read the same value again, so fan and grid can never disagree. Board at 150% still grows ~30% while the hand grows ~25% past it.

![board at 150% — two rows on both fields, proportionate hand](https://raw.githubusercontent.com/witchesofthehill/manabrew/pr-assets/two-row-fill-playmat-pad/board-150.png)

## Test plan

- [x] `yarn tsc --noEmit`, eslint, prettier clean
- [x] `cargo xtask e2e-ui` passes; screenshot above is its output — two rows visible on both fields at 150%, fan clear of the bottom row
- [x] 100% remains the classic 3-row board
