### PR TITLE
ci: warm docker layer caches on main and guard stale preview branches

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -26,6 +26,49 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # GHA caches are ref-scoped: docker layers cached by a PR's preview build
+  # are invisible to other PRs, and a release tag's layers are invisible to
+  # the next tag. Only main-scoped caches are readable everywhere — so warm
+  # the image layer caches (the cargo-chef dependency cooks especially) here.
+  # `push: false`: this only populates the cache. The cook layers sit before
+  # the VITE_* ARGs in Dockerfile.web, so one warm serves the prod, staging
+  # and preview arg variants alike. Ironsmith stays dark (mirrors the
+  # docker-images.yml default; its stage caches on its own sources anyway).
+  docker-layers:
+    name: Warm ${{ matrix.image }} layers
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    if: github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'chore(release):')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: manabrew-server
+            dockerfile: manabrew-rs/crates/manabrew-server/Dockerfile
+          - image: manabrew-web
+            dockerfile: Dockerfile.web
+          - image: manabrew-node
+            dockerfile: manabrew-rs/crates/self-hosted-node/Dockerfile
+          - image: manabrew-hub
+            dockerfile: manabrew-rs/crates/manabrew-hub/Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build (cache only, no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+
   engine:
     name: Warm engine & parity
     runs-on: ubuntu-latest

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -144,9 +144,20 @@ jobs:
           git fetch origin "pull/${PR_NUMBER}/head" --force
           git checkout --detach --force ${PR_SHA}
 
+          # A branch cut before the pulled-image staging stack still has the
+          # old build:-based compose — \`up\` would silently rebuild the web
+          # image ON THE BOX (the exact thing this workflow exists to avoid,
+          # and a disk-filler). Fail fast instead; --no-build below is the
+          # backstop.
+          if ! grep -q 'STAGING_IMAGE_TAG' compose.staging.yml; then
+              echo "❌ compose.staging.yml on this branch predates the pulled-image staging stack."
+              echo "   Merge main into the PR branch and push — the preview will re-run."
+              exit 1
+          fi
+
           export STAGING_IMAGE_TAG="pr-${PR_NUMBER}"
           docker compose -p manabrew-staging -f compose.staging.yml pull --quiet
-          docker compose -p manabrew-staging -f compose.staging.yml up -d --remove-orphans
+          docker compose -p manabrew-staging -f compose.staging.yml up -d --no-build --remove-orphans
           # Record which PR owns the single slot so another PR's teardown
           # doesn't kill this preview.
           echo "${PR_NUMBER}" > "\$STAGING/.preview-pr"


### PR DESCRIPTION
## Summary

Two follow-ups from the first preview deploy after #459 (PR #460's run):

- **Guard stale preview branches** (`preview-deploy.yml`): a PR branched before #459 still carries the old `build:`-based `compose.staging.yml`, so the box-side `up` silently **rebuilt the images on the box** — the exact thing the rework exists to prevent, and a disk-filler (the web image build doesn't fit the host). The deploy step now fails fast with a "merge main into the branch" message when the checked-out compose predates `STAGING_IMAGE_TAG`, and `up -d` gets `--no-build` as a backstop so the box can never compile regardless.
- **Warm docker layer caches from main** (`cache-warm.yml`): GHA caches are ref-scoped — layers cached by one PR's preview build are invisible to every other PR, and a release tag's layers are invisible to the next tag (this predates #459; `docker-images.yml`'s gha cache never actually carried across tags). Only main-scoped caches are readable everywhere. New `docker-layers` matrix job builds all four images on merges to main with `push: false`, populating the shared cache scopes — so preview builds and release image builds restore the cargo-chef dependency cooks instead of cold-compiling. The cook layers sit before the `VITE_*` args in `Dockerfile.web`, so one warm serves the prod/staging/preview variants alike.

## Why

PR #460's preview both cold-compiled in CI (no main-scoped layer cache existed) and then rebuilt on the box anyway (stale branch compose). The first is fixed by warming, the second by the guard; #460 itself was fixed by merging main into it.

## Test plan

- `actionlint` + `shellcheck` clean (remaining findings are the pre-existing intentional client-side heredoc expansions); prettier-stable.
- After this merges: the next merge to main runs the four `Warm <image> layers` jobs (first run is the one cold build); a subsequent PR preview build should show `importing cache manifest` hits and skip the dependency compile.
- Label a pre-#459 branch `deploy-preview`: the deploy job fails fast with the merge-main message instead of building on the box.