### PR TITLE
fix(engine): gate double-faced back-land play on modal (#465 pt.2, fixes #206)

### DIFF
--- a/manabrew-rs/crates/manabrew-engine/src/card/card_assembly.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/card/card_assembly.rs
@@ -317,6 +317,7 @@ pub(crate) fn assemble_card(
 
             card.other_part = Some(CardOtherPart {
                 name: back_face.name.clone(),
+                is_modal: rules.split_type == forge_foundation::CardSplitType::Modal,
                 type_line: back_face.type_line.clone(),
                 mana_cost: back_face.mana_cost.clone(),
                 color: intrinsic_color(back_face),

--- a/manabrew-rs/crates/manabrew-engine/src/card/mod.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/card/mod.rs
@@ -95,6 +95,12 @@ pub fn parse_plotted_turn(kw: &str) -> Option<u32> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CardOtherPart {
     pub name: String,
+    /// True when the card's split type is `Modal` (MDFC). Only a modal back face
+    /// may be played from hand; transform/meld backs may not. Mirrors
+    /// `Card.isModal()` (`getRules().getSplitType() == CardSplitType.Modal`).
+    /// Invariant across `transform()`, so it is not swapped there.
+    #[serde(default)]
+    pub is_modal: bool,
     pub type_line: CardTypeLine,
     pub mana_cost: ManaCost,
     pub color: ColorSet,
@@ -3602,6 +3608,12 @@ impl Card {
     /// Swaps all face-dependent characteristics with `other_part`.
     /// No-op if `other_part` is `None`.
     /// Mirrors Java's `CardUtil.applyState(card, CardStateName.Backside)`.
+    /// Mirror of `Card.isModal()`: true only for MDFC (modal) cards, whose back
+    /// face may be played from hand. Transform / meld backs are not modal.
+    pub fn is_modal(&self) -> bool {
+        self.other_part.as_ref().is_some_and(|other| other.is_modal)
+    }
+
     pub fn transform(&mut self) {
         if let Some(other) = self.other_part.as_mut() {
             std::mem::swap(&mut self.card_name, &mut other.name);

--- a/manabrew-rs/crates/manabrew-engine/src/game_loop/playability.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/game_loop/playability.rs
@@ -131,7 +131,7 @@ impl GameLoop {
                     if card
                         .other_part
                         .as_ref()
-                        .is_some_and(|other| other.type_line.is_land())
+                        .is_some_and(|other| other.is_modal && other.type_line.is_land())
                     {
                         playable.push(crate::agent::PlayOption {
                             card_id,
@@ -142,11 +142,13 @@ impl GameLoop {
                 }
             } else {
                 // MDFC: emit both the back-face LAND and the front-face SPELL
-                // (Java `getPossibleActions`).
+                // (Java `getPossibleActions`). Only *modal* backs are playable;
+                // a transform back land (e.g. Search for Azcanta // Azcanta) is
+                // not — mirror `Card.hasPlayableLandFace` (gated on isModal).
                 if card
                     .other_part
                     .as_ref()
-                    .is_some_and(|other| other.type_line.is_land())
+                    .is_some_and(|other| other.is_modal && other.type_line.is_land())
                 {
                     let cant_play_land =
                         crate::staticability::static_ability_cant_be_cast::cant_play_land_ability(


### PR DESCRIPTION
the runtime card dropped its split type, so the play generator offered a back-face land for any dfc with a land on the back — transform included. that let transform cards get played as a land from hand (search for azcanta, etc), which forge doesn't allow. fixes #206.

fix: keep `is_modal` on the card and only offer the back land when it's modal, matching forge's `hasPlayableLandFace`. mdfc lands still work, transform backs don't.

`cargo check` passes. skipped the parity harness (not reliable until the protocol settles), so this is compile + reading the java. casting modal back-face spells (valki/tibalt) is the other half — staged for when the harness is back, noted in #465.
