### PR TITLE
chore(ui): ship deck hub dark behind feature flag

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { NavLink } from "react-router-dom";
 import { cn } from "@/lib/utils";
 import { FEATURES } from "@/lib/features";
+import { isFeatureEnabled } from "@/featureFlags";
 import { DESIGN_SYSTEM_ENABLED } from "@/config/designSystem";
 import { DISCORD_INVITE_URL, GITHUB_REPO_URL } from "@/lib/constants";
 import { useGameStore } from "@/stores/useGameStore";
@@ -88,17 +89,19 @@ export function Sidebar({ className, onNavigate }: SidebarProps) {
                 </Button>
               )}
             </NavLink>
-            <NavLink to="/hub" onClick={onNavigate}>
-              {({ isActive }) => (
-                <Button
-                  variant={isActive ? "secondary" : "ghost"}
-                  className="w-full justify-start whitespace-nowrap"
-                >
-                  <LibraryBig className="mr-2 h-4 w-4 shrink-0" />
-                  Deck Hub
-                </Button>
-              )}
-            </NavLink>
+            {isFeatureEnabled("deckHub") && (
+              <NavLink to="/hub" onClick={onNavigate}>
+                {({ isActive }) => (
+                  <Button
+                    variant={isActive ? "secondary" : "ghost"}
+                    className="w-full justify-start whitespace-nowrap"
+                  >
+                    <LibraryBig className="mr-2 h-4 w-4 shrink-0" />
+                    Deck Hub
+                  </Button>
+                )}
+              </NavLink>
+            )}
             <NavLink to="/companion" onClick={onNavigate}>
               {({ isActive }) => (
                 <Button

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -15,6 +15,9 @@ export const featureFlags = {
   // engine is OFF until the user opts in via Settings (`ironsmithRuntimeEnabled`
   // preference) — the experimental engine ships dark in prod by default.
   ironsmithRuntime: true,
+  // Deck Hub (browse/publish shared decks + top decks). Ships dark until the
+  // api.manabrew.app service is deployed and the flow has had a manual pass.
+  deckHub: false,
 } as const;
 
 export type FeatureFlag = keyof typeof featureFlags;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from "react";
 import { createBrowserRouter, Navigate } from "react-router-dom";
 import { AppShell } from "@/components/layout/AppShell";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { isFeatureEnabled } from "@/featureFlags";
 import { DESIGN_SYSTEM_ENABLED } from "@/config/designSystem";
 
 const CardMockGallery = import.meta.env.DEV ? lazy(() => import("@/views/CardMockGallery")) : null;
@@ -85,14 +86,18 @@ export const router = createBrowserRouter([
           </ErrorBoundary>
         ),
       },
-      {
-        path: "hub",
-        element: (
-          <ErrorBoundary context="Deck Hub">
-            <DeckHub />
-          </ErrorBoundary>
-        ),
-      },
+      ...(isFeatureEnabled("deckHub")
+        ? [
+            {
+              path: "hub",
+              element: (
+                <ErrorBoundary context="Deck Hub">
+                  <DeckHub />
+                </ErrorBoundary>
+              ),
+            },
+          ]
+        : []),
       {
         path: "game/:gameId",
         element: (

--- a/src/views/DeckEditor.tsx
+++ b/src/views/DeckEditor.tsx
@@ -16,6 +16,7 @@ import {
 } from "@dnd-kit/core";
 import type { DragEndEvent, DragStartEvent } from "@dnd-kit/core";
 import { useDeckStore } from "@/stores/useDeckStore";
+import { isFeatureEnabled } from "@/featureFlags";
 import { DROP_ZONE, DEFAULT_DECK_NAME, DEFAULT_IMPORT_NAME } from "@/lib/constants";
 import { useEffect, useRef, useState } from "react";
 import type { DeckCard } from "@/protocol/deck";
@@ -469,7 +470,7 @@ export default function DeckEditor() {
                     onOpen={() => handleSelectDeck(s.id)}
                     onDelete={() => handleDelete(s.id)}
                     onRename={() => startRename(s.id, s.deck.name)}
-                    onPublish={() => setPublishingDeck(s)}
+                    onPublish={isFeatureEnabled("deckHub") ? () => setPublishingDeck(s) : undefined}
                   />
                 ))}
               </div>


### PR DESCRIPTION
## Summary

- Adds a `deckHub` flag (default `false`) to `src/featureFlags.ts` and gates the three Deck Hub surfaces on it: the sidebar entry, the `/hub` route, and the publish button on My Decks cards.
- No hub code is removed. Flip the flag to `true` to bring it back.

## Why

The hub merged to main before its backend is live in prod. `api.manabrew.app` is not deployed yet and the flow has not had a manual pass, so the UI would show a broken feature. This hides it from the release until the rollout checklist is done.

## Test plan

- `yarn lint` and `yarn test` (9 passed) clean.
- The route is excluded at build time when the flag is off (same pattern as the dev-only CardMockGallery route), the sidebar entry and publish button render conditionally. Verified by typecheck; worth a quick visual check on the preview build that the sidebar no longer shows Deck Hub.
