### PR TITLE
ci(staging): roll out with a lean deploy-staging.sh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,17 +16,12 @@ MANABREW_SERVER_KEY=
 SECRET_MANABREW_KEY=
 
 # ──────────────────────────────────────────────────────────────────
-# Staging box routing (staging VM only)
+# Staging hostnames (staging VM only)
 # ──────────────────────────────────────────────────────────────────
-# staging-deploy.yml passes these over SSH, so they are only needed here for a
-# manual `./deploy.sh` on the box to behave like the workflow. On production,
-# leave them unset — deploy.sh defaults to main / compose.production.yml /
-# ops/Caddyfile / latest.
-
-DEPLOY_BRANCH=staging
-COMPOSE_FILE=compose.staging.yml
-CADDYFILE_PATH=ops/staging.Caddyfile
-MANABREW_IMAGE_TAG=staging
+# deploy-staging.sh already defaults DEPLOY_BRANCH=staging,
+# COMPOSE_FILE=compose.staging.yml and MANABREW_IMAGE_TAG=staging, so those are
+# not needed here — set one only to override for a one-off (e.g. deploy a
+# different branch/tag to the box).
 
 # Hostnames the staging edge serves (required on the staging box). Consumed by
 # ops/staging.Caddyfile ({$...}, also drives ACME certs) and, via RELAY_HOST,

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -6,8 +6,9 @@ name: Staging deploy
 #      (docker-images.yml does the same on v* tags for the release `latest`
 #      images),
 #   2. connect to Twingate (the VM only accepts SSH through Twingate — no public
-#      SSH), then SSH in and run the SAME deploy.sh as production, pointed at the
-#      staging branch / staging compose / staging image tag.
+#      SSH), then SSH in and run deploy-staging.sh — the lean sibling of
+#      production's deploy.sh (pull branch + :staging images + health-checked
+#      recreate + rollback, without the release/manifest machinery).
 #
 # No hostname is hardcoded here. The one build-time endpoint (the hub API URL
 # baked into the web bundle) comes from the repo variable STAGING_HUB_API_URL;
@@ -87,9 +88,8 @@ jobs:
 
   # ── Deploy to the staging VM (over Twingate) ───────────────────────
   # Connects the runner to Twingate with a service-account key, then runs the
-  # identical production deploy.sh over SSH, with DEPLOY_BRANCH, COMPOSE_FILE,
-  # MANABREW_IMAGE_TAG and CADDYFILE_PATH pointing it at staging. deploy.sh's
-  # ghcr pull-retry waits out the image builds above.
+  # lean deploy-staging.sh over SSH (pull branch + :staging images + health-
+  # checked recreate + rollback — no production release machinery).
   deploy:
     name: Deploy staging
     needs: [build-images]
@@ -111,7 +111,7 @@ jobs:
         with:
           service-key: ${{ secrets.TWINGATE_SERVICE_KEY }}
 
-      - name: SSH and run deploy.sh (staging)
+      - name: SSH and run deploy-staging.sh
         id: deploy
         continue-on-error: true
         env:
@@ -126,13 +126,13 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H "$HOST" >> ~/.ssh/known_hosts 2>/dev/null
           # ServerAliveInterval/CountMax keep the SSH connection healthy while
-          # deploy.sh has quiet stretches (docker pulls, ghcr retry sleeps).
+          # deploy-staging.sh has quiet stretches (docker pulls, ghcr retry sleeps).
           ssh -i ~/.ssh/deploy_key \
               -o StrictHostKeyChecking=yes \
               -o ServerAliveInterval=30 \
               -o ServerAliveCountMax=120 \
               "$USER@$HOST" \
-            "cd '$DEPLOY_PATH' && DEPLOY_BRANCH=staging MANABREW_IMAGE_TAG=staging COMPOSE_FILE=compose.staging.yml CADDYFILE_PATH=ops/staging.Caddyfile ./deploy.sh 2>&1" 2>&1 | tee deploy.log
+            "cd '$DEPLOY_PATH' && ./deploy-staging.sh 2>&1" 2>&1 | tee deploy.log
           exit ${PIPESTATUS[0]}
 
       - name: Fetch raw deploy log on failure
@@ -144,7 +144,7 @@ jobs:
         run: |
           set -euo pipefail
           scp -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes \
-            "$USER@$HOST:/tmp/deploy-raw.log" deploy-raw.log || \
+            "$USER@$HOST:/tmp/deploy-staging-raw.log" deploy-raw.log || \
             echo "(raw log not retrievable from server)"
 
       - name: Post Discord embed (as bot)

--- a/deploy-staging.sh
+++ b/deploy-staging.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# deploy-staging.sh — Lean rollout of the staging stack on the staging VM.
+# Pulls the staging branch + the CI-built `:staging` ghcr images and rolls them
+# out with a health-checked recreate + rollback. Deliberately NOT deploy.sh:
+# none of production's release machinery (manifest hold, --release-manifest,
+# sidestore, observability/parity profiles) lives here — staging just tracks a
+# branch and swaps in fresh images. Driven by staging-deploy.yml over SSH.
+#
+# stdout = clean summary (captured by the workflow and posted to Discord).
+# Raw output goes to /tmp/deploy-staging-raw.log.
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_DIR"
+
+BRANCH="${DEPLOY_BRANCH:-staging}"
+COMPOSE_FILE="${COMPOSE_FILE:-compose.staging.yml}"
+export MANABREW_IMAGE_TAG="${MANABREW_IMAGE_TAG:-staging}"
+GHCR_OWNER="witchesofthehill"
+RAW_LOG="/tmp/deploy-staging-raw.log"
+: > "$RAW_LOG"
+
+on_failure() {
+    echo "💥 **Staging deploy FAILED** at $(date '+%H:%M:%S')"
+    echo "📄 Raw log: \`$RAW_LOG\`"
+    tail -20 "$RAW_LOG" 2>/dev/null | sed 's/^/> /'
+}
+trap on_failure ERR
+
+# Box .env: MANABREW_SERVER_KEY, the STAGING_*_HOST trio, optional GITHUB_TOKEN
+# (git pull rate limits) and DISCORD_WEBHOOK_URL.
+if [ -f "$REPO_DIR/.env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    source "$REPO_DIR/.env"
+    set +a
+fi
+
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+    git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPO:-witchesofthehill/manabrew}.git"
+fi
+
+# ── Pull the branch ──────────────────────────────────────────────────
+# Only the compose file + ops/ configs are used from the checkout (images come
+# prebuilt from ghcr), so no submodules and no local build.
+PREV=$(git rev-parse --short HEAD)
+git pull origin "$BRANCH" --ff-only >> "$RAW_LOG" 2>&1
+CURR=$(git rev-parse --short HEAD)
+
+# ── Pull the CI-built images ─────────────────────────────────────────
+# The deploy job needs build-images, so these normally exist already; the retry
+# is a safety net if ghcr is briefly behind.
+export DOCKER_BUILDKIT=1
+SERVICES="manabrew manabrew-server manabrew-hub"
+echo "Pulling :${MANABREW_IMAGE_TAG} images ($SERVICES)…" >> "$RAW_LOG"
+PULLED=false
+for attempt in $(seq 1 20); do
+    if docker compose -f "$COMPOSE_FILE" pull --quiet $SERVICES >> "$RAW_LOG" 2>&1; then
+        PULLED=true; break
+    fi
+    echo "  pull attempt $attempt failed (CI images not pushed yet?); retry in 30s" >> "$RAW_LOG"
+    sleep 30
+done
+$PULLED || { echo "❌ ghcr image pull failed after retries — aborting."; exit 1; }
+
+# ── Health-checked rollout with rollback ─────────────────────────────
+# Snapshot each running service's current image so an unhealthy rollout can be
+# re-tagged back. `up -d` only recreates services whose image/config changed.
+declare -A ROLLBACK_IMG=()
+declare -A GHCR_REF=(
+    [manabrew]="ghcr.io/${GHCR_OWNER}/manabrew-web:${MANABREW_IMAGE_TAG}"
+    [manabrew-server]="ghcr.io/${GHCR_OWNER}/manabrew-server:${MANABREW_IMAGE_TAG}"
+    [manabrew-hub]="ghcr.io/${GHCR_OWNER}/manabrew-hub:${MANABREW_IMAGE_TAG}"
+)
+for svc in $SERVICES; do
+    cid=$(docker compose -f "$COMPOSE_FILE" ps -q "$svc" 2>/dev/null || true)
+    [ -n "$cid" ] && ROLLBACK_IMG[$svc]=$(docker inspect --format '{{.Image}}' "$cid" 2>/dev/null || true)
+done
+
+if docker compose -f "$COMPOSE_FILE" up -d --remove-orphans --wait --wait-timeout 180 >> "$RAW_LOG" 2>&1; then
+    echo "✅ rollout healthy" >> "$RAW_LOG"
+else
+    echo "⚠️ rollout unhealthy — rolling back to the previous images" | tee -a "$RAW_LOG"
+    ROLLED=""
+    for svc in $SERVICES; do
+        ref="${GHCR_REF[$svc]:-}"; old="${ROLLBACK_IMG[$svc]:-}"
+        if [ -n "$ref" ] && [ -n "$old" ]; then
+            docker tag "$old" "$ref" >> "$RAW_LOG" 2>&1 && ROLLED="$ROLLED $svc"
+        fi
+    done
+    [ -n "$ROLLED" ] && docker compose -f "$COMPOSE_FILE" up -d --no-deps $ROLLED >> "$RAW_LOG" 2>&1 || true
+    echo "↩️ rolled back:$ROLLED" | tee -a "$RAW_LOG"
+    exit 1
+fi
+
+# The Caddyfile is bind-mounted and caddy doesn't watch it; a recreate already
+# picks up changes, but reload covers the case where the web image was unchanged.
+docker compose -f "$COMPOSE_FILE" exec -T manabrew \
+    caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile >> "$RAW_LOG" 2>&1 \
+    || echo "caddy reload skipped/failed (see raw log)" >> "$RAW_LOG"
+
+CHANGELOG=$(git log --pretty=format:'- %s (%h, %an)' "${PREV}..${CURR}" 2>/dev/null | head -c 1500)
+[ -z "$CHANGELOG" ] && CHANGELOG="(no new commits — image-only redeploy)"
+
+cat <<EOF
+🧪 **Staging deploy complete** (\`${PREV}\` → \`${CURR}\`)
+
+🔁 **Rolled out:** ${SERVICES} (tag \`${MANABREW_IMAGE_TAG}\`)
+📄 **Log:** \`${RAW_LOG}\`
+
+📝 **Changelog:**
+${CHANGELOG}
+EOF

--- a/deploy.sh
+++ b/deploy.sh
@@ -36,13 +36,6 @@ REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$REPO_DIR"
 
 COMPOSE_FILE="${COMPOSE_FILE:-compose.production.yml}"
-# Branch this host tracks. Production pulls main; the staging VM sets
-# DEPLOY_BRANCH=staging (staging-deploy.yml) to run the identical rollout off
-# the staging branch.
-DEPLOY_BRANCH="${DEPLOY_BRANCH:-main}"
-# Bind-mounted Caddyfile this host serves; the staging VM overrides it so a
-# staging.Caddyfile edit is detected and reloaded like ops/Caddyfile is on prod.
-CADDYFILE_PATH="${CADDYFILE_PATH:-ops/Caddyfile}"
 RAW_LOG="/tmp/deploy-raw.log"
 
 HOLD_MARKER="ops/.manifest-hold"
@@ -128,7 +121,7 @@ fi
 # below, so the re-run still deploys the right range instead of early-exiting as
 # "no new commits".
 PREV="${DEPLOY_ORIG_PREV:-$(git rev-parse --short HEAD)}"
-git pull origin "$DEPLOY_BRANCH" --ff-only >> "$RAW_LOG" 2>&1
+git pull origin main --ff-only >> "$RAW_LOG" 2>&1
 CURR=$(git rev-parse --short HEAD)
 
 # Self-update: the pull may have changed this very script. deploy.sh is already
@@ -276,7 +269,7 @@ while IFS= read -r file; do
             WEB_CHANGED=true ;;
     esac
     case "$file" in
-        "$CADDYFILE_PATH")
+        ops/Caddyfile)
             CADDYFILE_CHANGED=true ;;
     esac
     case "$file" in
@@ -434,7 +427,7 @@ if [ -n "$SERVICES_TO_RESTART" ]; then
 fi
 
 if $CADDYFILE_CHANGED; then
-    echo "Reloading caddy config ($CADDYFILE_PATH)..." >> "$RAW_LOG"
+    echo "Reloading caddy config..." >> "$RAW_LOG"
     docker compose -f "$COMPOSE_FILE" exec -T manabrew \
         caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile >> "$RAW_LOG" 2>&1
 fi

--- a/docs/STAGING_WORKFLOW.md
+++ b/docs/STAGING_WORKFLOW.md
@@ -1,13 +1,14 @@
 # Staging Workflow
 
 Staging is a **mirror of production**. It runs on its own VM — a separate
-machine with its own SSH key and its own DNS — but it is deployed by the exact
-same engine as production: the identical `deploy.sh` smart rollout, the same
-four ghcr images (built per-push, tagged `:staging` instead of the release
-`latest`), and a `compose.staging.yml` that clones `compose.production.yml`
-service-for-service (web + relay + hub + hosted node, its own TLS edge). The
-only differences are the branch it tracks, the image tag, and the hostnames —
-nothing behavioural.
+machine with its own SSH key and its own DNS — deployed the same shape as
+production: the same four ghcr images (built per-push, tagged `:staging` instead
+of the release `latest`), a `compose.staging.yml` that clones
+`compose.production.yml` service-for-service (web + relay + hub + hosted node,
+its own TLS edge), and a lean rollout script (`deploy-staging.sh`) that mirrors
+`deploy.sh`'s image-pull + health-checked recreate + rollback without the
+release-only machinery. The only differences are the branch it tracks, the image
+tag, and the hostnames — nothing behavioural.
 
 Its purpose: give changes a production-shaped home to bake in **before** they
 reach real users, so a backend-breaking or infra-breaking change is caught on a
@@ -31,8 +32,8 @@ box that looks exactly like prod but isn't prod.
 3. **`staging` deploys automatically.** Any push to `staging` triggers
    `.github/workflows/staging-deploy.yml`, which builds the `:staging` images,
    connects the runner to **Twingate** (the VM only accepts SSH through
-   Twingate), then SSHes in and runs the production `deploy.sh` against the
-   `staging` branch. Result lands on the staging hosts.
+   Twingate), then SSHes in and runs `deploy-staging.sh` against the `staging`
+   branch. Result lands on the staging hosts.
 4. **Every merge to `main`, the latest `main` is merged into `staging`.** This
    keeps staging honest: it is always _`main` + whatever is still pending on
    staging_, never a stale fork that has silently drifted from production. The
@@ -55,7 +56,7 @@ git push origin staging
 | Aspect        | Production               | Staging                                           |
 | ------------- | ------------------------ | ------------------------------------------------- |
 | Trigger       | `v*` tag (release)       | push to `staging` branch                          |
-| Deploy engine | `deploy.sh` over SSH     | **the same** `deploy.sh`, `DEPLOY_BRANCH=staging` |
+| Deploy engine | `deploy.sh` over SSH     | `deploy-staging.sh` (lean sibling of `deploy.sh`) |
 | Deploy reach  | CI SSHes the box         | CI connects Twingate, then SSHes the box          |
 | Compose file  | `compose.production.yml` | `compose.staging.yml` (clone)                     |
 | Images        | ghcr `:latest`           | ghcr `:staging`                                   |
@@ -63,10 +64,13 @@ git push origin staging
 | Hosts         | hardcoded `manabrew.app` | from env (`STAGING_APP/RELAY/API_HOST`)           |
 | Box           | production VM + key      | staging VM, SSH gated by Twingate                 |
 
-Because `deploy.sh` is shared, staging inherits production's change-detection,
-ghcr pull-retry, relay binary-diff gate (a relay restart drops live games, so
-it only restarts when the binary actually changed), and health-checked rollout
-with automatic rollback.
+`deploy-staging.sh` keeps the parts of production's rollout that matter for a
+mirror — ghcr image pull with retry, a health-checked `compose up --wait`, and
+automatic rollback to the previous images on an unhealthy deploy — but drops the
+release-only machinery `deploy.sh` carries (manifest hold / `--release-manifest`,
+updater + sidestore, observability/parity profiles, the relay binary-diff gate).
+On staging a relay recreate is fine, so `up -d` just recreates whatever image
+changed.
 
 ## Deploy reach (Twingate)
 
@@ -133,4 +137,5 @@ docker compose -f compose.staging.yml --profile hosted-ai up -d self-hosted-node
 
 - `docs/DEPLOY.md` — production/operator deployment notes.
 - `.github/workflows/staging-deploy.yml` — the staging pipeline (build + deploy).
-- `deploy.sh` — the shared rollout script (`DEPLOY_BRANCH` / `CADDYFILE_PATH`).
+- `deploy-staging.sh` — the staging rollout script (run on the VM over SSH).
+- `deploy.sh` — production's rollout script (staging does **not** use it).


### PR DESCRIPTION
## Summary

Follow-up to #470. The staging VM was running the production `deploy.sh`, which carries release-only machinery it has no business executing (manifest hold, `--release-manifest`, updater/sidestore, observability/parity profiles). This replaces it with a dedicated, lean `deploy-staging.sh` and restores `deploy.sh` to its untouched production form.

- **`deploy-staging.sh`** (new) — the staging rollout: load box `.env` → `git pull origin staging --ff-only` → pull the CI-built `:staging` ghcr images (with a short retry safety-net) → health-checked `docker compose -f compose.staging.yml up -d --wait` → **rollback to the previous images on an unhealthy deploy** → `caddy reload` → print a Discord-friendly summary. No submodules, no local build, no release/manifest logic.
- **`deploy.sh`** — reverted the `DEPLOY_BRANCH` / `CADDYFILE_PATH` params #470 added; it's byte-identical to production's original again.
- **`.github/workflows/staging-deploy.yml`** — the deploy job now runs `./deploy-staging.sh` (defaults everything, so no env passthrough) and fetches `/tmp/deploy-staging-raw.log` on failure. Twingate connect + image build are unchanged.
- **`docs/STAGING_WORKFLOW.md`, `.env.example`** — updated to describe `deploy-staging.sh` and drop the now-defaulted routing vars.

## Why

`deploy.sh` is production's script — coupling staging to it means every prod-only branch has to stay correctly gated forever, and a future prod-focused change could break staging (or vice-versa). A ~90-line staging script that does only what staging needs is easier to reason about and keeps the two deploy paths independent. It still mirrors the parts that matter for a production-shaped environment: pull prebuilt images, health-checked recreate, rollback.

## Test plan

- `bash -n deploy-staging.sh` — passes.
- `git diff origin/main -- deploy.sh` after revert — deploy.sh is back to production original (no staging params).
- YAML parse of `staging-deploy.yml` — passes; pre-commit `prettier` clean.
- End-to-end: next push to `staging` runs the deploy job → Twingate → `deploy-staging.sh`. (The prior #470 run got as far as SSH; the pending fix there is the SSH key, unrelated to this change.)

## Notes
- `deploy-staging.sh` intentionally omits the relay binary-diff gate — on staging a relay recreate is acceptable, and `compose up` only recreates a service whose image actually changed.
- Rollback re-tags the previous image over the `:staging` ref and re-`up`s the affected services.
