### PR TITLE
fix(staging): don't ship empty auth-hash vars in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,14 +46,17 @@ DESIGN_SYSTEM=
 # ──────────────────────────────────────────────────────────────────
 # Ingress auth hashes (optional — bcrypt, note the `$`; single-quote in shells)
 # ──────────────────────────────────────────────────────────────────
-# Unset → the Caddyfile's locked placeholder applies (route is locked, not
-# broken). Generate with `caddy hash-password`.
+# Leave these UNSET (commented) to get the Caddyfile's locked placeholder
+# (route locked, not broken). Caddy's {$VAR:default} only falls back to the
+# default when the var is unset — an EMPTY value (e.g. `HUB_ADMIN_PASSWORD_HASH=`)
+# is passed through and crashes caddy with "username and password cannot be
+# empty". So set a real hash (`caddy hash-password`) or keep it commented.
 
 # Locks /admin/* on the deck hub (api / api-staging host).
-HUB_ADMIN_PASSWORD_HASH=
+# HUB_ADMIN_PASSWORD_HASH=
 
 # Locks the pushgateway + loki ingress (observability profile only).
-PUSHGATEWAY_PASSWORD_HASH=
+# PUSHGATEWAY_PASSWORD_HASH=
 
 # ──────────────────────────────────────────────────────────────────
 # Relay game-capture (optional)


### PR DESCRIPTION
## Summary

`.env.example` shipped `HUB_ADMIN_PASSWORD_HASH=` / `PUSHGATEWAY_PASSWORD_HASH=` as **empty assignments**. Copied to a box `.env`, they set the vars to empty strings, which `deploy-staging.sh` exports and compose passes into the caddy container. Caddy's `{$VAR:default}` only falls back to the default when the var is **unset** — an empty value is passed straight through, so `basic_auth` crashes with *"username and password cannot be empty or missing"* and the web container restart-loops.

Commenting the two optional hash vars so copying the file leaves them **unset**, which triggers the Caddyfile's locked-placeholder default (route locked, not broken) — the documented intent.

## Why

Caught bringing up the staging VM: the web/Caddy container crash-looped on `ops/staging.Caddyfile:112` (`admin {$HUB_ADMIN_PASSWORD_HASH:…}`). Same footgun would hit production if its `.env` ever set these empty.

## Test plan

- With the vars unset, caddy adapts the Caddyfile and locks `/admin/*` behind the placeholder default (verified against the `{$VAR:default}` semantics). Setting a real `caddy hash-password` value still works.