### PR TITLE
fix(staging): serve staging.Caddyfile over HTTP behind the reverse proxy

### DIFF
--- a/ops/staging.Caddyfile
+++ b/ops/staging.Caddyfile
@@ -1,13 +1,18 @@
 # Edge config for the staging VM (compose.staging.yml). Mirrors the
-# play/relay/api blocks of ops/Caddyfile, with automatic HTTPS. Hostnames are
-# NOT hardcoded — they come from the box .env via compose (STAGING_APP_HOST /
-# STAGING_RELAY_HOST / STAGING_API_HOST), so moving domains is a .env edit.
+# play/relay/api blocks of ops/Caddyfile, but served over plain HTTP on :80:
+# the staging VM sits behind an external reverse proxy (nginx) that terminates
+# TLS for the three hostnames and forwards to this Caddy — so the `http://`
+# prefix keeps Caddy from attempting ACME on a box that isn't publicly
+# reachable. The three hosts MUST be distinct (each is its own vhost); they come
+# from the box .env via compose (STAGING_APP_HOST / STAGING_RELAY_HOST /
+# STAGING_API_HOST), so moving domains is a .env edit. The fronting proxy must
+# preserve the app's COOP/COEP headers and upgrade websockets for the relay.
 # Release-only routes (/manifest.json, /tauri.json, /sidestore, /status.json)
 # are omitted — staging serves neither the updater manifest nor SideStore.
 #   {$STAGING_APP_HOST}   → wasm app  (/srv/manabrew)
 #   {$STAGING_RELAY_HOST} → relay
 #   {$STAGING_API_HOST}   → deck hub + stats API
-{$STAGING_APP_HOST} {
+http://{$STAGING_APP_HOST} {
     root * /srv/manabrew
 
     encode zstd gzip
@@ -95,7 +100,7 @@
     }
 }
 
-{$STAGING_RELAY_HOST} {
+http://{$STAGING_RELAY_HOST} {
     reverse_proxy manabrew-server:9443 {
         health_uri /health
         health_port 9444
@@ -106,7 +111,7 @@
 
 # Deck hub + stats API. HUB_ADMIN_PASSWORD_HASH unset → the placeholder
 # default matches no password: /admin/* is locked, not broken config.
-{$STAGING_API_HOST} {
+http://{$STAGING_API_HOST} {
     @admin path /admin/*
     basic_auth @admin {
         admin {$HUB_ADMIN_PASSWORD_HASH:$2y$05$ln9aIQ9AeSFyHiuO0tKm1uXmTi0/DYR0HPN/nEsp184AWyvGvc7hu}


### PR DESCRIPTION
## Summary

The staging VM sits behind an external **nginx reverse proxy** (Proxmox host) that terminates TLS. `ops/staging.Caddyfile` was written for Caddy-as-edge (auto-HTTPS), which on a non-public box (a) attempts ACME it can never complete and (b) offers no clean HTTP for nginx to forward to. Prefixing the three site addresses with `http://` pins Caddy to `:80` and disables ACME, which is the correct shape behind a TLS-terminating proxy.

Also documents that the three `STAGING_*_HOST` must be **distinct** hostnames — each is its own vhost (app / relay / hub). A shared value (e.g. all set to the VM's IP) trips Caddy's `ambiguous site definition` error.

## Why

Bringing up the staging VM: after fixing the empty auth hash, Caddy crash-looped on `ambiguous site definition: 192.168.1.103` because all three hosts were the VM's LAN IP, and even with distinct hostnames Caddy would fail ACME on the private box.

## Test plan

- `caddy validate` semantics: `http://<host>` binds :80 only, no ACME. Distinct hostnames route by `Host`; nginx forwards to `<vm>:80` preserving `Host` + COOP/COEP + websocket upgrade for the relay.