### PR TITLE
chore(ops): pass hub auth env through compose

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -119,12 +119,35 @@ jobs:
           HOST: ${{ secrets.STAGING_DEPLOY_HOST }}
           USER: ${{ secrets.STAGING_DEPLOY_USER }}
           DEPLOY_PATH: ${{ secrets.STAGING_DEPLOY_PATH }}
+          # Hub auth (accounts) secrets, synced into the box .env below. The
+          # STAGING_OAUTH_GITHUB_* names avoid GitHub Actions' reserved GITHUB_
+          # secret prefix; on the box they land under the hub's env names. An
+          # unset secret leaves the box .env untouched for that key, so a
+          # provider stays off until its app is registered.
+          AUTH_GITHUB_CLIENT_ID: ${{ secrets.STAGING_OAUTH_GITHUB_CLIENT_ID }}
+          AUTH_GITHUB_CLIENT_SECRET: ${{ secrets.STAGING_OAUTH_GITHUB_CLIENT_SECRET }}
+          AUTH_DISCORD_CLIENT_ID: ${{ secrets.STAGING_OAUTH_DISCORD_CLIENT_ID }}
+          AUTH_DISCORD_CLIENT_SECRET: ${{ secrets.STAGING_OAUTH_DISCORD_CLIENT_SECRET }}
+          AUTH_RESEND_API_KEY: ${{ secrets.STAGING_RESEND_API_KEY }}
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh
           printf '%s\n' "$SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H "$HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          AUTH_ENV=""
+          add_auth() { if [ -n "$2" ]; then AUTH_ENV="${AUTH_ENV}$1=$2"$'\n'; fi; }
+          add_auth GITHUB_CLIENT_ID "$AUTH_GITHUB_CLIENT_ID"
+          add_auth GITHUB_CLIENT_SECRET "$AUTH_GITHUB_CLIENT_SECRET"
+          add_auth DISCORD_CLIENT_ID "$AUTH_DISCORD_CLIENT_ID"
+          add_auth DISCORD_CLIENT_SECRET "$AUTH_DISCORD_CLIENT_SECRET"
+          add_auth RESEND_API_KEY "$AUTH_RESEND_API_KEY"
+          if [ -n "$AUTH_ENV" ]; then
+            printf '%s' "$AUTH_ENV" | ssh -i ~/.ssh/deploy_key \
+                -o StrictHostKeyChecking=yes \
+                "$USER@$HOST" \
+              "cd '$DEPLOY_PATH' && touch .env && while IFS= read -r line; do key=\${line%%=*}; { grep -v \"^\${key}=\" .env || true; } > .env.tmp; mv .env.tmp .env; printf '%s\n' \"\$line\" >> .env; done"
+          fi
           # ServerAliveInterval/CountMax keep the SSH connection healthy while
           # deploy-staging.sh has quiet stretches (docker pulls, ghcr retry sleeps).
           ssh -i ~/.ssh/deploy_key \

--- a/compose.production.yml
+++ b/compose.production.yml
@@ -84,6 +84,16 @@ services:
       HUB_DB_PATH: "/var/manabrew/hub/hub.db"
       EVENTS_DB_PATH: "/var/manabrew/events/events.db"
       RUST_LOG: "manabrew_hub=info"
+      # Auth (/api/auth/*). Client ids/secrets live in ops/production.secrets;
+      # an unset client id disables that provider. No RESEND_API_KEY →
+      # magic-link codes are logged instead of emailed.
+      HUB_PUBLIC_URL: "https://api.manabrew.app"
+      WEB_APP_URL: "https://play.manabrew.app"
+      GITHUB_CLIENT_ID: "${GITHUB_CLIENT_ID:-}"
+      GITHUB_CLIENT_SECRET: "${GITHUB_CLIENT_SECRET:-}"
+      DISCORD_CLIENT_ID: "${DISCORD_CLIENT_ID:-}"
+      DISCORD_CLIENT_SECRET: "${DISCORD_CLIENT_SECRET:-}"
+      RESEND_API_KEY: "${RESEND_API_KEY:-}"
     volumes:
       - ./ops/hub-data:/var/manabrew/hub
       - ./ops/observability/data/events:/var/manabrew/events:ro

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -72,6 +72,16 @@ services:
       HUB_DB_PATH: "/var/manabrew/hub/hub.db"
       EVENTS_DB_PATH: "/var/manabrew/events/events.db"
       RUST_LOG: "manabrew_hub=info"
+      # Auth (/api/auth/*). OAuth apps need callbacks on the staging api host;
+      # unset client ids disable that provider. No RESEND_API_KEY → magic-link
+      # codes are logged instead of emailed.
+      HUB_PUBLIC_URL: "https://${STAGING_API_HOST:?STAGING_API_HOST is required}"
+      WEB_APP_URL: "https://${STAGING_APP_HOST:?STAGING_APP_HOST is required}"
+      GITHUB_CLIENT_ID: "${GITHUB_CLIENT_ID:-}"
+      GITHUB_CLIENT_SECRET: "${GITHUB_CLIENT_SECRET:-}"
+      DISCORD_CLIENT_ID: "${DISCORD_CLIENT_ID:-}"
+      DISCORD_CLIENT_SECRET: "${DISCORD_CLIENT_SECRET:-}"
+      RESEND_API_KEY: "${RESEND_API_KEY:-}"
     volumes:
       - ./ops/hub-data:/var/manabrew/hub
       - ./ops/observability/data/events:/var/manabrew/events:ro

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -31,6 +31,7 @@ services:
       RELAY_PASSWORD: "${MANABREW_SERVER_KEY:?MANABREW_SERVER_KEY is required}"
       HOSTED_AI_ENABLED: "${HOSTED_AI_ENABLED:-true}"
       DESIGN_SYSTEM: "${DESIGN_SYSTEM:-}"
+      HUB_API_URL: "https://${STAGING_API_HOST}"
     depends_on:
       - manabrew-server
 

--- a/ops/web-entrypoint.sh
+++ b/ops/web-entrypoint.sh
@@ -9,6 +9,8 @@ set -e
 #     option, off in the published image.
 #   designSystem: from DESIGN_SYSTEM — exposes the dev-only /design-system
 #     reference route on a production build, off by default.
+#   hubApiUrl: from HUB_API_URL — deck hub + auth API origin; unset leaves the
+#     app on its compiled-in VITE_HUB_API_URL / api.manabrew.app default.
 {
 	echo 'window.__MANABREW_RUNTIME__ = {'
 	if [ -n "${RELAY_HOST:-}" ]; then
@@ -20,6 +22,9 @@ set -e
 	case "$(printf '%s' "${DESIGN_SYSTEM:-}" | tr '[:upper:]' '[:lower:]')" in
 	1 | true | yes | on) echo '  designSystem: true,' ;;
 	esac
+	if [ -n "${HUB_API_URL:-}" ]; then
+		echo "  hubApiUrl: \"${HUB_API_URL}\","
+	fi
 	echo '};'
 } >/srv/manabrew/config.js
 


### PR DESCRIPTION
## Summary

Env plumbing for the hub auth service (#477). Production and staging compose gain the auth variables on `manabrew-hub`:

- `HUB_PUBLIC_URL` / `WEB_APP_URL`: hardcoded to the prod domains in production, derived from `STAGING_API_HOST` / `STAGING_APP_HOST` on staging.
- `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET`, `DISCORD_CLIENT_ID` / `DISCORD_CLIENT_SECRET`, `RESEND_API_KEY`: passed through from the box .env, all optional. An unset client id disables that provider; no Resend key means codes are logged, not emailed.

No Caddyfile changes. `api.` already proxies the whole subdomain on both prod and staging, and `/api/auth/*` rides through.

## Why

#477 reads these at startup. Without them every provider is off and links point at localhost.

## Test plan

- `docker compose -f compose.production.yml config -q` and the staging equivalent both parse with required env stubbed.
- After merge, staging deploy: `GET /api/auth/providers` returns `{"github":true,"discord":true,"email":true}` once the secrets below are on the box.

## Rollout checklist (manual, per environment)

Secrets to append to the box .env (`ops/production.secrets` on prod, the staging VM .env for staging):

- [ ] `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET`
- [ ] `DISCORD_CLIENT_ID` / `DISCORD_CLIENT_SECRET`
- [ ] `RESEND_API_KEY`

GitHub OAuth apps (one per environment, GitHub allows a single callback per app):

- [ ] Prod app, callback `https://api.manabrew.app/api/auth/callback/github`
- [ ] Staging app, callback `https://<staging api host>/api/auth/callback/github`
- [ ] Optional dev app, callback `http://localhost:9500/api/auth/callback/github`

Discord application (one app supports multiple redirect URIs):

- [ ] Add `https://api.manabrew.app/api/auth/callback/discord` and the staging + localhost equivalents under OAuth2 → Redirects

Resend:

- [ ] Add domain `manabrew.app`, publish the DKIM and SPF records it prescribes, plus DMARC `p=none` if absent
- [ ] Verify domain, create a sending API key
- [ ] Sender is `Manabrew <login@manabrew.app>` (`AUTH_EMAIL_FROM` overrides)