### PR TITLE
chore(ops): route staging hub api same-origin on the app host

### DIFF
--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -31,7 +31,8 @@ services:
       RELAY_PASSWORD: "${MANABREW_SERVER_KEY:?MANABREW_SERVER_KEY is required}"
       HOSTED_AI_ENABLED: "${HOSTED_AI_ENABLED:-true}"
       DESIGN_SYSTEM: "${DESIGN_SYSTEM:-}"
-      HUB_API_URL: "https://${STAGING_API_HOST}"
+      # Hub API is same-origin on staging (path-routed on the app host).
+      HUB_API_URL: "https://${STAGING_APP_HOST}"
     depends_on:
       - manabrew-server
 
@@ -73,10 +74,10 @@ services:
       HUB_DB_PATH: "/var/manabrew/hub/hub.db"
       EVENTS_DB_PATH: "/var/manabrew/events/events.db"
       RUST_LOG: "manabrew_hub=info"
-      # Auth (/api/auth/*). OAuth apps need callbacks on the staging api host;
-      # unset client ids disable that provider. No RESEND_API_KEY → magic-link
-      # codes are logged instead of emailed.
-      HUB_PUBLIC_URL: "https://${STAGING_API_HOST:?STAGING_API_HOST is required}"
+      # Auth (/api/auth/*). The hub is path-routed on the app host, so OAuth
+      # callbacks live there too; unset client ids disable that provider. No
+      # RESEND_API_KEY → magic-link codes are logged instead of emailed.
+      HUB_PUBLIC_URL: "https://${STAGING_APP_HOST:?STAGING_APP_HOST is required}"
       WEB_APP_URL: "https://${STAGING_APP_HOST:?STAGING_APP_HOST is required}"
       GITHUB_CLIENT_ID: "${GITHUB_CLIENT_ID:-}"
       GITHUB_CLIENT_SECRET: "${GITHUB_CLIENT_SECRET:-}"

--- a/ops/staging.Caddyfile
+++ b/ops/staging.Caddyfile
@@ -89,6 +89,27 @@ http://{$STAGING_APP_HOST} {
         header Cross-Origin-Resource-Policy "same-origin"
     }
 
+    # Deck hub + auth API, same-origin under the app host. The box edge only
+    # routes the app hostname reliably, so the api rides it as a path prefix
+    # instead of the {$STAGING_API_HOST} vhost below. /api/auth/callback/* is
+    # the hub's OAuth callback; the SPA's own /auth/callback is untouched.
+    @hub path /api/*
+    handle @hub {
+        reverse_proxy manabrew-hub:9500 {
+            health_uri /health
+            health_interval 15s
+            health_timeout 3s
+        }
+    }
+
+    @hubadmin path /admin/*
+    handle @hubadmin {
+        basic_auth {
+            admin {$HUB_ADMIN_PASSWORD_HASH:$2y$05$ln9aIQ9AeSFyHiuO0tKm1uXmTi0/DYR0HPN/nEsp184AWyvGvc7hu}
+        }
+        reverse_proxy manabrew-hub:9500
+    }
+
     handle {
         header {
             Cross-Origin-Opener-Policy "same-origin"


### PR DESCRIPTION
## Summary

The staging hub API moves from the `manabrew-api` vhost to a path prefix on the app host: `https://manabrew.federicovivaldo.com/api/*` (plus `/admin/*` behind the same basic auth). `HUB_PUBLIC_URL`, `WEB_APP_URL` and the web runtime `HUB_API_URL` all point at the app host now. The `STAGING_HUB_API_URL` repo variable is updated to match, so the built bundle agrees with the runtime config.

No `/v1` rename: shipped desktop clients pin `/api/hub/*`, and the SPA's own `/auth/callback` route does not collide with the hub's `/api/auth/callback/:provider`.

The api vhost block stays in the Caddyfile; it becomes unused on this box.

## Why

`manabrew-api.federicovivaldo.com` 502s at the box edge (a host-level nginx fronts the stack there and its upstream for the api hostname is dead; the failure predates the auth work). The app hostname is the one path through that edge that demonstrably works, so the API rides it same-origin. Bonus: same-origin means CORS stops mattering for staging entirely.

## Test plan

- `docker compose -f compose.staging.yml config` interpolates all three URLs to the app host.
- After deploy: `curl https://manabrew.federicovivaldo.com/api/auth/providers` returns the three-provider JSON; `/api/hub/decks` lists.
- OAuth callbacks on the staging GitHub/Discord apps must be updated to `https://manabrew.federicovivaldo.com/api/auth/callback/<provider>` before sign-in is exercised.