### PR TITLE
fix(ops): proxy scryfall mana symbols same-origin in standalone deploy

### DIFF
--- a/compose.selfhost.yml
+++ b/compose.selfhost.yml
@@ -13,6 +13,11 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.web
+      args:
+        # Serve mana symbols same-origin through this box's Caddy
+        # (ops/standalone.Caddyfile) instead of fetching svgs.scryfall.io
+        # directly, so symbols don't depend on the box's outbound egress.
+        VITE_SCRYFALL_SYMBOL_BASE: /scryfall-symbols/
     restart: unless-stopped
     environment:
       # Address the browser uses to reach this box's relay (written into

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -93,8 +93,11 @@ services:
     environment:
       SELF_HOSTED_NODE_RELAY_URL: "ws://manabrew-server:9443"
       SELF_HOSTED_NODE_SERVER_KEY: "${MANABREW_SERVER_KEY:?MANABREW_SERVER_KEY is required}"
-      SELF_HOSTED_NODE_FORMAT: "${SELF_HOSTED_NODE_FORMAT:-commander}"
-      SELF_HOSTED_NODE_MAX_PLAYERS: "${SELF_HOSTED_NODE_MAX_PLAYERS:-2}"
+      # Play-vs-AI pool rooms must advertise format Any (the client's
+      # findHostedRoom only matches Any) and enough seats for commander pods.
+      SELF_HOSTED_NODE_FORMAT: "${SELF_HOSTED_NODE_FORMAT:-Any}"
+      SELF_HOSTED_NODE_MAX_PLAYERS: "${SELF_HOSTED_NODE_MAX_PLAYERS:-4}"
+
       SELF_HOSTED_NODE_MAX_GAMES: "${SELF_HOSTED_NODE_MAX_GAMES:-1}"
       SELF_HOSTED_NODE_METRICS_PUSH_URL: "${SELF_HOSTED_NODE_METRICS_PUSH_URL:-}"
       RUST_LOG: "self_hosted_node=info"

--- a/manabrew-rs/crates/manabrew-engine/src/card/card_assembly.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/card/card_assembly.rs
@@ -317,6 +317,7 @@ pub(crate) fn assemble_card(
 
             card.other_part = Some(CardOtherPart {
                 name: back_face.name.clone(),
+                is_modal: rules.split_type == forge_foundation::CardSplitType::Modal,
                 type_line: back_face.type_line.clone(),
                 mana_cost: back_face.mana_cost.clone(),
                 color: intrinsic_color(back_face),

--- a/manabrew-rs/crates/manabrew-engine/src/card/mod.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/card/mod.rs
@@ -95,6 +95,12 @@ pub fn parse_plotted_turn(kw: &str) -> Option<u32> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CardOtherPart {
     pub name: String,
+    /// True when the card's split type is `Modal` (MDFC). Only a modal back face
+    /// may be played from hand; transform/meld backs may not. Mirrors
+    /// `Card.isModal()` (`getRules().getSplitType() == CardSplitType.Modal`).
+    /// Invariant across `transform()`, so it is not swapped there.
+    #[serde(default)]
+    pub is_modal: bool,
     pub type_line: CardTypeLine,
     pub mana_cost: ManaCost,
     pub color: ColorSet,
@@ -3602,6 +3608,12 @@ impl Card {
     /// Swaps all face-dependent characteristics with `other_part`.
     /// No-op if `other_part` is `None`.
     /// Mirrors Java's `CardUtil.applyState(card, CardStateName.Backside)`.
+    /// Mirror of `Card.isModal()`: true only for MDFC (modal) cards, whose back
+    /// face may be played from hand. Transform / meld backs are not modal.
+    pub fn is_modal(&self) -> bool {
+        self.other_part.as_ref().is_some_and(|other| other.is_modal)
+    }
+
     pub fn transform(&mut self) {
         if let Some(other) = self.other_part.as_mut() {
             std::mem::swap(&mut self.card_name, &mut other.name);

--- a/manabrew-rs/crates/manabrew-engine/src/game_loop/playability.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/game_loop/playability.rs
@@ -131,7 +131,7 @@ impl GameLoop {
                     if card
                         .other_part
                         .as_ref()
-                        .is_some_and(|other| other.type_line.is_land())
+                        .is_some_and(|other| other.is_modal && other.type_line.is_land())
                     {
                         playable.push(crate::agent::PlayOption {
                             card_id,
@@ -142,11 +142,13 @@ impl GameLoop {
                 }
             } else {
                 // MDFC: emit both the back-face LAND and the front-face SPELL
-                // (Java `getPossibleActions`).
+                // (Java `getPossibleActions`). Only *modal* backs are playable;
+                // a transform back land (e.g. Search for Azcanta // Azcanta) is
+                // not — mirror `Card.hasPlayableLandFace` (gated on isModal).
                 if card
                     .other_part
                     .as_ref()
-                    .is_some_and(|other| other.type_line.is_land())
+                    .is_some_and(|other| other.is_modal && other.type_line.is_land())
                 {
                     let cant_play_land =
                         crate::staticability::static_ability_cant_be_cast::cant_play_land_ability(

--- a/manabrew-rs/crates/self-hosted-node/src/host.rs
+++ b/manabrew-rs/crates/self-hosted-node/src/host.rs
@@ -69,10 +69,9 @@ impl EngineSession {
     }
 }
 
-#[derive(Default)]
 struct BotState {
-    handle: Option<JoinHandle<()>>,
-    shutdown: Option<Arc<tokio::sync::Notify>>,
+    handle: JoinHandle<()>,
+    shutdown: Arc<tokio::sync::Notify>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -80,6 +79,8 @@ struct BotState {
 struct SpawnBotPayload {
     #[serde(default)]
     deck: Option<SpawnBotDeckPayload>,
+    #[serde(default)]
+    decks: Option<Vec<SpawnBotDeckPayload>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -105,7 +106,7 @@ fn registry_idle(registry: &SessionRegistry) -> bool {
         .unwrap_or(false)
 }
 
-type SharedBotState = Arc<Mutex<BotState>>;
+type SharedBotState = Arc<Mutex<Vec<BotState>>>;
 
 #[derive(Clone)]
 struct GameStart {
@@ -393,7 +394,7 @@ async fn host_one_room(
             registered.push(engine_session.clone());
         }
     }
-    let bot_state: SharedBotState = Arc::new(Mutex::new(BotState::default()));
+    let bot_state: SharedBotState = Arc::new(Mutex::new(Vec::new()));
     let (outbound_tx, mut outbound_rx) = tokio_mpsc::unbounded_channel::<ClientMessage>();
 
     let mut host =
@@ -405,7 +406,12 @@ async fn host_one_room(
     }
 
     if config.bot_enabled {
-        spawn_bot(&config, &config.bot_deck, room_id.clone(), &bot_state);
+        spawn_bots(
+            &config,
+            std::slice::from_ref(&config.bot_deck),
+            &room_id,
+            &bot_state,
+        );
     }
 
     loop {
@@ -422,7 +428,7 @@ async fn host_one_room(
         )
         .await;
         if matches!(exit, LoopExit::Cancelled) {
-            stop_bot(&bot_state);
+            stop_bots(&bot_state);
             host.close().await;
             return Ok(());
         }
@@ -435,7 +441,7 @@ async fn host_one_room(
                 _ = cancel.notified() => {
                     info!(username = %config.username, "room host cancelled while reconnecting");
                     cancel_engine(&engine_session);
-                    stop_bot(&bot_state);
+                    stop_bots(&bot_state);
                     return Ok(());
                 }
                 _ = time::sleep(Duration::from_secs(delay)) => {}
@@ -454,9 +460,14 @@ async fn host_one_room(
             match reestablish_room(&mut client, &config, &engine_session, &snapshot).await {
                 Ok(new_room_id) => {
                     if new_room_id != room_id {
-                        stop_bot(&bot_state);
+                        stop_bots(&bot_state);
                         if config.bot_enabled {
-                            spawn_bot(&config, &config.bot_deck, new_room_id.clone(), &bot_state);
+                            spawn_bots(
+                                &config,
+                                std::slice::from_ref(&config.bot_deck),
+                                &new_room_id,
+                                &bot_state,
+                            );
                         }
                         room_id = new_room_id;
                     }
@@ -703,7 +714,8 @@ fn end_game_without_humans(
     let _ = outbound_tx.send(ClientMessage::EndGame { game_id });
 }
 
-fn spawn_bot(config: &Config, deck: &DeckSelection, room_id: String, bot_state: &SharedBotState) {
+fn spawn_bots(config: &Config, decks: &[DeckSelection], room_id: &str, bot_state: &SharedBotState) {
+    stop_bots(bot_state);
     let mut guard = match bot_state.lock() {
         Ok(guard) => guard,
         Err(error) => {
@@ -711,49 +723,47 @@ fn spawn_bot(config: &Config, deck: &DeckSelection, room_id: String, bot_state: 
             return;
         }
     };
-    if guard.handle.is_some() {
-        debug!(room_id, "bot already spawned for room");
-        return;
+    let open_seats = config.max_players.saturating_sub(1) as usize;
+    for (index, deck) in decks.iter().take(open_seats).enumerate() {
+        let username = if index == 0 {
+            config.bot_username.clone()
+        } else {
+            format!("{} {}", config.bot_username, index + 1)
+        };
+        let relay_url = config.relay_url.clone();
+        let bot_config = BotConfig {
+            username,
+            password: config.password.clone(),
+            room_id: room_id.to_string(),
+            room_password: config.room_password.clone(),
+            deck_name: deck.name.clone(),
+            deck: deck.deck.clone(),
+            commander_name: deck.commander_name.clone(),
+            agent: AgentKind::Simple,
+            answer_delay_ms: None,
+        };
+        let shutdown = Arc::new(tokio::sync::Notify::new());
+        let bot_shutdown = shutdown.clone();
+        let handle = tokio::spawn(async move {
+            if let Err(error) = run_bot(relay_url, bot_config, bot_shutdown).await {
+                error!(%error, "bot task exited");
+            }
+        });
+        guard.push(BotState { handle, shutdown });
     }
-    let relay_url = config.relay_url.clone();
-    let bot_config = BotConfig {
-        username: config.bot_username.clone(),
-        password: config.password.clone(),
-        room_id,
-        room_password: config.room_password.clone(),
-        deck_name: deck.name.clone(),
-        deck: deck.deck.clone(),
-        commander_name: deck.commander_name.clone(),
-        agent: AgentKind::Simple,
-        answer_delay_ms: None,
-    };
-    let shutdown = Arc::new(tokio::sync::Notify::new());
-    let bot_shutdown = shutdown.clone();
-    let handle = tokio::spawn(async move {
-        if let Err(error) = run_bot(relay_url, bot_config, bot_shutdown).await {
-            error!(%error, "bot task exited");
-        }
-    });
-    guard.handle = Some(handle);
-    guard.shutdown = Some(shutdown);
 }
 
-fn stop_bot(bot_state: &SharedBotState) {
+fn stop_bots(bot_state: &SharedBotState) {
     match bot_state.lock() {
         Ok(mut state) => {
-            let Some(mut handle) = state.handle.take() else {
-                return;
-            };
-            match state.shutdown.take() {
-                Some(shutdown) => {
-                    shutdown.notify_one();
-                    tokio::spawn(async move {
-                        if time::timeout(BOT_STOP_TIMEOUT, &mut handle).await.is_err() {
-                            handle.abort();
-                        }
-                    });
-                }
-                None => handle.abort(),
+            for bot in state.drain(..) {
+                bot.shutdown.notify_one();
+                let mut handle = bot.handle;
+                tokio::spawn(async move {
+                    if time::timeout(BOT_STOP_TIMEOUT, &mut handle).await.is_err() {
+                        handle.abort();
+                    }
+                });
             }
         }
         Err(error) => warn!(%error, "bot state lock poisoned"),
@@ -1055,15 +1065,14 @@ async fn handle_state_update(
             match payload_type {
                 Some("removeBot") => {
                     info!(observer = %client.username, "received removeBot request");
-                    stop_bot(bot_state);
+                    stop_bots(bot_state);
                 }
                 Some("spawnBot") => {
                     let effective_room_id = requested_room_id.as_deref().unwrap_or(room_id);
                     if effective_room_id == room_id {
                         info!(observer = %client.username, room_id, "received spawnBot request");
-                        let bot_deck = bot_deck_from_payload(config, &payload);
-                        stop_bot(bot_state);
-                        spawn_bot(config, &bot_deck, room_id.to_string(), bot_state);
+                        let bot_decks = bot_decks_from_payload(config, &payload);
+                        spawn_bots(config, &bot_decks, room_id, bot_state);
                     } else {
                         debug!(
                             observer = %client.username,
@@ -1084,13 +1093,24 @@ async fn handle_state_update(
     }
 }
 
-fn bot_deck_from_payload(config: &Config, payload: &Value) -> DeckSelection {
-    let deck = serde_json::from_value::<SpawnBotPayload>(payload.clone())
-        .ok()
-        .and_then(|payload| payload.deck);
-    let Some(deck) = deck else {
-        return config.bot_deck.clone();
+fn bot_decks_from_payload(config: &Config, payload: &Value) -> Vec<DeckSelection> {
+    let parsed = serde_json::from_value::<SpawnBotPayload>(payload.clone()).ok();
+    let requested = match parsed {
+        Some(SpawnBotPayload {
+            decks: Some(decks), ..
+        }) if !decks.is_empty() => decks,
+        Some(SpawnBotPayload {
+            deck: Some(deck), ..
+        }) => vec![deck],
+        _ => return vec![config.bot_deck.clone()],
     };
+    requested
+        .into_iter()
+        .map(deck_selection_from_payload)
+        .collect()
+}
+
+fn deck_selection_from_payload(deck: SpawnBotDeckPayload) -> DeckSelection {
     info!(
         deck = %deck.deck_name,
         cards = deck.deck.cards.len(),

--- a/manabrew-rs/crates/wasm/src/wasm_api.rs
+++ b/manabrew-rs/crates/wasm/src/wasm_api.rs
@@ -134,7 +134,7 @@ use manabrew_agent_interface::agent_impl::PromptAgent;
 #[wasm_bindgen]
 pub fn run_interactive_game(
     human_deck_json: JsValue,
-    ai_deck_json: JsValue,
+    ai_decks_json: JsValue,
     config_json: JsValue,
     shared_buffer: JsValue,
 ) -> Result<JsValue, JsError> {
@@ -152,8 +152,11 @@ pub fn run_interactive_game(
 
     let human_deck: WireDeck = serde_wasm_bindgen::from_value(human_deck_json)
         .map_err(|e| JsError::new(&format!("Failed to parse human deck: {}", e)))?;
-    let ai_deck: WireDeck = serde_wasm_bindgen::from_value(ai_deck_json)
-        .map_err(|e| JsError::new(&format!("Failed to parse AI deck: {}", e)))?;
+    let ai_decks: Vec<WireDeck> = serde_wasm_bindgen::from_value(ai_decks_json)
+        .map_err(|e| JsError::new(&format!("Failed to parse AI decks: {}", e)))?;
+    if ai_decks.is_empty() {
+        return Err(JsError::new("At least one AI deck is required"));
+    }
 
     let config: GameConfig = if config_json.is_undefined() || config_json.is_null() {
         GameConfig::default()
@@ -167,17 +170,30 @@ pub fn run_interactive_game(
         .dyn_into()
         .map_err(|_| JsError::new("Expected SharedArrayBuffer"))?;
 
-    // Two seats: the human (seat 0, local) and an AI opponent (seat 1). Routed
+    // Seat 0 is the local human; every other seat is an in-process AI. Routed
     // through the shared host runtime so deck zoning, token setup, and the
     // final game-over prompt match the multiplayer + Tauri paths exactly —
     // single-player no longer dumps every card straight into the library.
-    let prepared_players = prepare_players(
-        &["You".to_string(), "AI Opponent".to_string()],
-        &[human_deck, ai_deck],
-        &[config.commander_name.clone(), None],
-        card_db,
-        starting_life,
-    );
+    let mut names = vec!["You".to_string()];
+    let mut decks = vec![human_deck];
+    let mut commander_names = vec![config.commander_name.clone()];
+    for (index, ai_deck) in ai_decks.into_iter().enumerate() {
+        names.push(if index == 0 {
+            "AI Opponent".to_string()
+        } else {
+            format!("AI Opponent {}", index + 1)
+        });
+        commander_names.push(
+            ai_deck
+                .commanders
+                .as_ref()
+                .and_then(|commanders| commanders.first())
+                .map(|commander| commander.identity.name.clone()),
+        );
+        decks.push(ai_deck);
+    }
+    let prepared_players =
+        prepare_players(&names, &decks, &commander_names, card_db, starting_life);
 
     let game_id = format!("wasm-interactive-{}", js_sys::Date::now() as u64);
     let game_id_for_agents = game_id.clone();

--- a/ops/standalone.Caddyfile
+++ b/ops/standalone.Caddyfile
@@ -16,6 +16,21 @@
 		file_server
 	}
 
+	# Mana symbol proxy: served same-origin so symbols never depend on the
+	# box's direct egress to svgs.scryfall.io and stay COEP-clean. The app
+	# points here via VITE_SCRYFALL_SYMBOL_BASE=/scryfall-symbols/.
+	@scryfall path_regexp scryfall ^/scryfall-symbols/(.*)$
+	handle @scryfall {
+		rewrite * /card-symbols/{re.scryfall.1}
+		reverse_proxy https://svgs.scryfall.io {
+			header_up Host svgs.scryfall.io
+			header_down -Access-Control-Allow-Origin
+			header_down -Cross-Origin-Resource-Policy
+			header_down -Cache-Control
+		}
+		header Cache-Control "public, max-age=604800"
+		header Cross-Origin-Resource-Policy "same-origin"
+	}
 
 	# Card image proxy: cards.scryfall.io intermittently serves cached objects
 	# without CORS headers, which breaks the app's cors-mode fetches (WebGL

--- a/src/components/deck/DeckGridCard.tsx
+++ b/src/components/deck/DeckGridCard.tsx
@@ -11,7 +11,7 @@ import {
 import { DeckLabelBadge } from "@/components/deck/DeckLabelBadge";
 import { FormatBadge } from "@/components/game/FormatBadge";
 import { ManaSymbols } from "@/components/game/ManaSymbols";
-import { Pencil, Share2, Trash2 } from "lucide-react";
+import { Pencil, Share2, Swords, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { SavedDeck } from "@/stores/useDeckStore";
 import { DeckCoverImage } from "@/components/deck/deckCover";
@@ -25,6 +25,7 @@ import {
 interface DeckGridCardProps {
   deck: SavedDeck;
   onOpen: () => void;
+  onPlaytest?: () => void;
   onDelete?: () => void;
   onRename?: () => void;
   onPublish?: () => void;
@@ -34,6 +35,7 @@ interface DeckGridCardProps {
 export function DeckGridCard({
   deck,
   onOpen,
+  onPlaytest,
   onDelete,
   onRename,
   onPublish,
@@ -60,9 +62,22 @@ export function DeckGridCard({
         <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-black/10" />
 
         {/* Action buttons — visible on hover */}
-        {!readOnly && (
+        {(onPlaytest || !readOnly) && (
           <div className="absolute top-1.5 right-1.5 flex gap-1 opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity z-10">
-            {onPublish && (
+            {onPlaytest && (
+              <Button
+                size="icon"
+                className="h-6 w-6"
+                title="Playtest vs AI"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onPlaytest();
+                }}
+              >
+                <Swords className="h-3 w-3" />
+              </Button>
+            )}
+            {!readOnly && onPublish && (
               <Button
                 size="icon"
                 variant="secondary"
@@ -76,7 +91,7 @@ export function DeckGridCard({
                 <Share2 className="h-3 w-3" />
               </Button>
             )}
-            {onRename && (
+            {!readOnly && onRename && (
               <Button
                 size="icon"
                 variant="secondary"
@@ -90,7 +105,7 @@ export function DeckGridCard({
                 <Pencil className="h-3 w-3" />
               </Button>
             )}
-            {onDelete && (
+            {!readOnly && onDelete && (
               <Button
                 size="icon"
                 variant="secondary"

--- a/src/components/deck/HubDeckCard.tsx
+++ b/src/components/deck/HubDeckCard.tsx
@@ -1,4 +1,5 @@
-import { Layers } from "lucide-react";
+import { Layers, Swords } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { FormatBadge } from "@/components/game/FormatBadge";
 import { ManaSymbols } from "@/components/game/ManaSymbols";
 import { DECK_NAME_SHADOW_CLASS } from "@/components/deck/deckDisplay.utils";
@@ -8,9 +9,10 @@ import type { HubDeckSummary } from "@/api/hubTypes";
 interface HubDeckCardProps {
   deck: HubDeckSummary;
   onOpen: () => void;
+  onPlaytest?: () => void;
 }
 
-export function HubDeckCard({ deck, onOpen }: HubDeckCardProps) {
+export function HubDeckCard({ deck, onOpen, onPlaytest }: HubDeckCardProps) {
   const colorCost = deck.colors
     .split("")
     .map((color) => `{${color}}`)
@@ -38,6 +40,22 @@ export function HubDeckCard({ deck, onOpen }: HubDeckCardProps) {
       )}
 
       <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-black/10" />
+
+      {onPlaytest && (
+        <div className="absolute top-1.5 right-1.5 flex gap-1 opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity z-10">
+          <Button
+            size="icon"
+            className="h-6 w-6"
+            title="Playtest vs AI"
+            onClick={(e) => {
+              e.stopPropagation();
+              onPlaytest();
+            }}
+          >
+            <Swords className="h-3 w-3" />
+          </Button>
+        </div>
+      )}
 
       <div className="absolute bottom-0 left-0 right-0 px-2 pt-6 pb-2 z-10">
         <p

--- a/src/components/deck/HubDeckPreviewDialog.tsx
+++ b/src/components/deck/HubDeckPreviewDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { Swords } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -13,6 +14,7 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { FormatBadge } from "@/components/game/FormatBadge";
 import { fetchHubDeck, unpublishDeck } from "@/api/hub";
+import { useQuickPlaytest } from "@/hooks/useQuickPlaytest";
 import { groupCards } from "@/views/myDecks.utils";
 import { useDeckStore } from "@/stores/useDeckStore";
 import { usePublishedDecksStore } from "@/stores/usePublishedDecksStore";
@@ -51,6 +53,7 @@ export function HubDeckPreviewDialog({
   onUnpublished,
 }: HubDeckPreviewDialogProps) {
   const navigate = useNavigate();
+  const { quickPlaytest, playtestDialog } = useQuickPlaytest();
   const addSavedDeck = useDeckStore((s) => s.addSavedDeck);
   const loadPresetDeck = useDeckStore((s) => s.loadPresetDeck);
   const published = usePublishedDecksStore((s) => s.published);
@@ -92,6 +95,19 @@ export function HubDeckPreviewDialog({
     navigate("/deck-editor");
   }
 
+  function handleCopyLink() {
+    if (!deckId) return;
+    const url = `${window.location.origin}/hub?deck=${encodeURIComponent(deckId)}`;
+    void navigator.clipboard.writeText(url);
+    toast.success("Share link copied — anyone can open and play this deck");
+  }
+
+  function handlePlaytest() {
+    if (!detail) return;
+    onClose();
+    quickPlaytest(detail.deck);
+  }
+
   async function handleUnpublish() {
     if (!mine) return;
     setBusy(true);
@@ -109,48 +125,58 @@ export function HubDeckPreviewDialog({
   }
 
   return (
-    <Dialog open={deckId !== null} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="max-w-lg">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <span className="truncate">{detail?.name ?? "Loading…"}</span>
-            {detail && <FormatBadge formatId={detail.format ?? "commander"} />}
-          </DialogTitle>
-          <DialogDescription>
-            {detail
-              ? `by ${detail.author}${detail.description ? ` — ${detail.description}` : ""}`
-              : (error ?? "Fetching deck from the hub…")}
-          </DialogDescription>
-        </DialogHeader>
-        {detail && (
-          <ScrollArea className="max-h-[50dvh] pr-3">
-            <div className="space-y-3">
-              <CardSection title="Commanders" cards={detail.deck.commanders ?? []} />
-              <CardSection title="Main deck" cards={detail.deck.cards} />
-              <CardSection title="Sideboard" cards={detail.deck.sideboard} />
-            </div>
-          </ScrollArea>
-        )}
-        <DialogFooter className="gap-2">
-          {mine && (
-            <Button
-              variant="destructive"
-              size="sm"
-              disabled={busy || !detail}
-              onClick={handleUnpublish}
-              className="mr-auto"
-            >
-              {busy ? "Removing…" : "Remove from hub"}
-            </Button>
+    <>
+      <Dialog open={deckId !== null} onOpenChange={(open) => !open && onClose()}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <span className="truncate">{detail?.name ?? "Loading…"}</span>
+              {detail && <FormatBadge formatId={detail.format ?? "commander"} />}
+            </DialogTitle>
+            <DialogDescription>
+              {detail
+                ? `by ${detail.author}${detail.description ? ` — ${detail.description}` : ""}`
+                : (error ?? "Fetching deck from the hub…")}
+            </DialogDescription>
+          </DialogHeader>
+          {detail && (
+            <ScrollArea className="max-h-[50dvh] pr-3">
+              <div className="space-y-3">
+                <CardSection title="Commanders" cards={detail.deck.commanders ?? []} />
+                <CardSection title="Main deck" cards={detail.deck.cards} />
+                <CardSection title="Sideboard" cards={detail.deck.sideboard} />
+              </div>
+            </ScrollArea>
           )}
-          <Button variant="outline" size="sm" disabled={!detail} onClick={handleOpen}>
-            Open read-only
-          </Button>
-          <Button size="sm" disabled={!detail} onClick={handleSave}>
-            Save to My Decks
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+          <DialogFooter className="gap-2">
+            {mine && (
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={busy || !detail}
+                onClick={handleUnpublish}
+                className="mr-auto"
+              >
+                {busy ? "Removing…" : "Remove from hub"}
+              </Button>
+            )}
+            <Button variant="outline" size="sm" disabled={!deckId} onClick={handleCopyLink}>
+              Copy link
+            </Button>
+            <Button variant="outline" size="sm" disabled={!detail} onClick={handleOpen}>
+              Open read-only
+            </Button>
+            <Button variant="outline" size="sm" disabled={!detail} onClick={handleSave}>
+              Save to My Decks
+            </Button>
+            <Button size="sm" disabled={!detail} onClick={handlePlaytest}>
+              <Swords className="mr-1 h-3.5 w-3.5" />
+              Playtest
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      {playtestDialog}
+    </>
   );
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   HeartPulse,
   Gamepad2,
   Hand,
+  House,
   Info,
   Layers,
   LibraryBig,
@@ -44,6 +45,17 @@ export function Sidebar({ className, onNavigate }: SidebarProps) {
             <ManaBrewLogo size={256} className="w-full h-auto rounded-xl" />
           </div>
           <div className="space-y-1">
+            <NavLink to="/home" onClick={onNavigate}>
+              {({ isActive }) => (
+                <Button
+                  variant={isActive ? "secondary" : "ghost"}
+                  className="w-full justify-start whitespace-nowrap"
+                >
+                  <House className="mr-2 h-4 w-4 shrink-0" />
+                  Home
+                </Button>
+              )}
+            </NavLink>
             <NavLink to="/play" onClick={onNavigate}>
               {({ isActive }) => (
                 <Button

--- a/src/components/lobby/DeckVsSelector.tsx
+++ b/src/components/lobby/DeckVsSelector.tsx
@@ -7,7 +7,7 @@ import { FormatBadge } from "@/components/game/FormatBadge";
 import { FormatPicker } from "./FormatPicker";
 import { DeckSelectionCard } from "./DeckSelectionCard";
 import { useIsShortScreen, useIsTouch } from "@/hooks/useBreakpoints";
-import { cn } from "@/lib/utils";
+import { cn, pickRandom } from "@/lib/utils";
 import { toast } from "sonner";
 import { getDeckFingerprint } from "@/lib/decks";
 import { getFormat, validateDeckSections } from "@/lib/formats";
@@ -39,14 +39,6 @@ interface DeckVsSelectorProps {
 
 type PickingSide = "player" | "opponent";
 type PlayFormatId = string;
-
-// Lift `Math.random` out of the component body. React's idempotency check
-// flags any impure call statically present in render scope, even when the
-// surrounding function only runs from an event handler.
-function pickRandom<T>(arr: readonly T[]): T | undefined {
-  if (arr.length === 0) return undefined;
-  return arr[Math.floor(Math.random() * arr.length)];
-}
 
 export function DeckVsSelector({ onStart, onStartTabletop }: DeckVsSelectorProps) {
   const presetDecks = usePresetDecks();

--- a/src/components/lobby/PlaytestPlayersDialog.tsx
+++ b/src/components/lobby/PlaytestPlayersDialog.tsx
@@ -1,0 +1,58 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Swords, Users } from "lucide-react";
+
+interface PlaytestPlayersDialogProps {
+  open: boolean;
+  onChoose: (opponentCount: number) => void;
+  onCancel: () => void;
+}
+
+export function PlaytestPlayersDialog({ open, onChoose, onCancel }: PlaytestPlayersDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onCancel();
+      }}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Playtest</DialogTitle>
+          <DialogDescription>How many players?</DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <button
+            onClick={() => onChoose(3)}
+            className="text-left rounded-lg border p-4 transition-colors hover:border-primary/40 hover:bg-muted/30"
+          >
+            <div className="flex items-center gap-2 mb-1.5">
+              <Users className="h-4 w-4 text-primary" />
+              <span className="font-semibold text-sm">4-player pod</span>
+            </div>
+            <p className="text-xs text-muted-foreground leading-snug">
+              You and three AI opponents. The real thing.
+            </p>
+          </button>
+          <button
+            onClick={() => onChoose(1)}
+            className="text-left rounded-lg border p-4 transition-colors hover:border-primary/40 hover:bg-muted/30"
+          >
+            <div className="flex items-center gap-2 mb-1.5">
+              <Swords className="h-4 w-4 text-primary" />
+              <span className="font-semibold text-sm">1v1</span>
+            </div>
+            <p className="text-xs text-muted-foreground leading-snug">
+              You and one AI opponent. Faster turns, quicker goldfishing.
+            </p>
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/game/hostedAiPlay.ts
+++ b/src/game/hostedAiPlay.ts
@@ -1,19 +1,27 @@
 import { getPlatform } from "@/platform";
-import { getHostedAiServerConnectionDefaults } from "@/config/webRuntimeConfig";
+import {
+  getHostedAiServerConnectionDefaults,
+  isHostedEngineAvailable,
+} from "@/config/webRuntimeConfig";
 import type { ServerConnectionDefaults } from "@/config/webRuntimeConfig";
 import { createRoomRelayEnvelope, SELF_HOSTED_NODE_RELAY_PROTOCOL } from "@/game/roomRelay";
 import { usePreferencesStore } from "@/stores/usePreferencesStore";
 import { useServerStore } from "@/stores/useServerStore";
-import type { GameFormat, GameStartedPayload, RoomInfo } from "@/types/server";
+import type { EngineKind, GameFormat, GameStartedPayload, RoomInfo } from "@/types/server";
 import type { RoomListPayload } from "@/types/server";
 import type {} from "@/protocol/game";
 import type { Deck } from "@/protocol/deck";
 
 const HOSTED_AI_TIMEOUT_MS = 20_000;
 
+export function getDefaultAiEngine(): EngineKind {
+  if (getPlatform().type === "tauri") return "Forge";
+  return isHostedEngineAvailable() ? "Forge" : "Manabrew";
+}
+
 interface HostedAiGameRequest {
   playerDeck: Deck;
-  opponentDeck: Deck;
+  opponentDecks: Deck[];
   formatId: string;
   commanderName: string | null;
 }
@@ -37,7 +45,7 @@ export async function startHostedAiGame(request: HostedAiGameRequest): Promise<H
   if (!username) throw new Error("Hosted AI play requires a server username.");
 
   const format = serverFormatFromId(request.formatId);
-  const room = await findHostedRoom(format);
+  const room = await findHostedRoom(format, 1 + request.opponentDecks.length);
   return joinHostedRoomAndPlay(room.room_id, format, request, username);
 }
 
@@ -62,7 +70,7 @@ export async function startTauriForgeAiGame(
   const format = serverFormatFromId(request.formatId);
   const roomId = await platform.server.createRoom({
     roomName: `${username}'s Forge game`,
-    maxPlayers: 2,
+    maxPlayers: 1 + request.opponentDecks.length,
     format,
     engine: "Forge",
   });
@@ -83,6 +91,26 @@ async function joinHostedRoomAndPlay(
 
   await leaveCurrentRoomIfNeeded(roomId);
   await platform.server.joinRoom({ roomId });
+  try {
+    return await setUpSeatsAndStart(roomId, format, request, username);
+  } catch (error) {
+    await platform.server.leaveRoom().catch(() => {});
+    useServerStore.setState({ currentRoom: null });
+    throw error;
+  }
+}
+
+async function setUpSeatsAndStart(
+  roomId: string,
+  format: GameFormat,
+  request: HostedAiGameRequest,
+  username: string,
+): Promise<HostedAiGameLaunch> {
+  const platform = getPlatform();
+  if (!platform.server) {
+    throw new Error("Hosted AI play requires a multiplayer server.");
+  }
+
   await waitForRoom((next) => next.room_id === roomId && hasPlayer(next, username));
 
   await platform.server.setDeckSelection({
@@ -93,25 +121,28 @@ async function joinHostedRoomAndPlay(
   });
   await platform.server.setReady({ ready: true });
 
+  const botDecks = request.opponentDecks.map((opponentDeck, index) => ({
+    deckName: opponentDeck.name || `AI Deck ${index + 1}`,
+    deck: opponentDeck,
+    commanderName: opponentDeck.commanders?.[0]?.identity.name ?? null,
+  }));
   await platform.server.sendRoomMessage(
     createRoomRelayEnvelope({
       protocol: SELF_HOSTED_NODE_RELAY_PROTOCOL,
       roomId,
       payload: {
         type: "spawnBot",
-        deck: {
-          deckName: request.opponentDeck.name || "AI Deck",
-          deck: request.opponentDeck,
-          commanderName: request.opponentDeck.commanders?.[0]?.identity.name ?? null,
-        },
+        deck: botDecks[0],
+        decks: botDecks,
       },
     }),
   );
 
+  const expectedPlayers = 1 + request.opponentDecks.length;
   await waitForRoom(
     (next) =>
       next.room_id === roomId &&
-      next.players.length >= 2 &&
+      next.players.length >= expectedPlayers &&
       next.players.every(
         (player) => player.connected && player.ready && !!player.selected_deck_name,
       ),
@@ -184,14 +215,15 @@ async function ensureServerConnection(localRelay?: ServerConnectionDefaults | nu
   });
 }
 
-async function findHostedRoom(format: GameFormat): Promise<RoomInfo> {
+async function findHostedRoom(format: GameFormat, requiredSeats: number): Promise<RoomInfo> {
   const rooms = await fetchRooms();
   const room = rooms.find(
     (candidate) =>
       candidate.hosted &&
       candidate.status === "Lobby" &&
       candidate.format === "Any" &&
-      candidate.players.length < candidate.max_players,
+      candidate.players.length === 0 &&
+      candidate.max_players >= requiredSeats,
   );
   if (!room) {
     throw new Error(`No self-hosted room is available for ${format}.`);

--- a/src/game/ironsmithRuntime.ts
+++ b/src/game/ironsmithRuntime.ts
@@ -147,7 +147,7 @@ export class IronsmithTrustedGameApi implements IGameApi {
   private concededPlayerSlots = new Set<string>();
 
   async startGame(params: StartGameParams): Promise<string> {
-    const opponentDeck = params.opponentDeck ?? params.deck;
+    const opponentDeck = params.opponentDecks?.[0] ?? params.deck;
     await this.startHost(
       {
         playerNames: ["You", "Opponent"],

--- a/src/game/manualTabletopApi.ts
+++ b/src/game/manualTabletopApi.ts
@@ -101,7 +101,7 @@ function createInitialGameView(params: StartGameParams): GameViewDto {
     "PlayerDto 2",
     false,
     params.startingLife,
-    params.opponentDeck?.cards.length ?? params.deck.cards.length,
+    params.opponentDecks?.[0]?.cards.length ?? params.deck.cards.length,
   );
 
   return {

--- a/src/hooks/useQuickPlaytest.tsx
+++ b/src/hooks/useQuickPlaytest.tsx
@@ -1,0 +1,70 @@
+import { useState, type ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import { fetchHubDeck } from "@/api/hub";
+import { PlaytestPlayersDialog } from "@/components/lobby/PlaytestPlayersDialog";
+import { getDefaultAiEngine } from "@/game/hostedAiPlay";
+import { pickRandomDistinct } from "@/lib/utils";
+import { useGameStore } from "@/stores/useGameStore";
+import { usePresetDecks } from "@/stores/usePresetDecksStore";
+import type { Deck } from "@/protocol/deck";
+
+export function useQuickPlaytest(): {
+  quickPlaytest: (deck: Deck) => void;
+  playtestDialog: ReactNode;
+} {
+  const navigate = useNavigate();
+  const startGame = useGameStore((s) => s.startGame);
+  const presetDecks = usePresetDecks();
+  const [pendingDeck, setPendingDeck] = useState<Deck | null>(null);
+
+  function start(deck: Deck, opponentCount: number) {
+    const formatId = deck.format ?? "standard";
+    const opponents = pickRandomDistinct(
+      presetDecks.filter((preset) => (preset.format ?? "standard") === formatId),
+      opponentCount,
+    );
+    void startGame(
+      deck,
+      formatId,
+      deck.commanders?.[0]?.identity.name,
+      opponents.length > 0 ? opponents : [deck],
+      getDefaultAiEngine(),
+    );
+    navigate("/play");
+  }
+
+  function quickPlaytest(deck: Deck) {
+    if (deck.cards.length === 0 && (deck.commanders?.length ?? 0) === 0) {
+      toast.error(`"${deck.name}" has no cards`);
+      return;
+    }
+    if ((deck.format ?? "standard") === "commander") {
+      setPendingDeck(deck);
+      return;
+    }
+    start(deck, 1);
+  }
+
+  const playtestDialog = pendingDeck ? (
+    <PlaytestPlayersDialog
+      open
+      onChoose={(opponentCount) => {
+        const deck = pendingDeck;
+        setPendingDeck(null);
+        start(deck, opponentCount);
+      }}
+      onCancel={() => setPendingDeck(null)}
+    />
+  ) : null;
+
+  return { quickPlaytest, playtestDialog };
+}
+
+export function useHubDeckPlaytest(quickPlaytest: (deck: Deck) => void): (deckId: string) => void {
+  return (deckId) => {
+    void fetchHubDeck(deckId)
+      .then((detail) => quickPlaytest(detail.deck))
+      .catch((err) => toast.error(err instanceof Error ? err.message : "Failed to load deck"));
+  };
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,19 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+// Module-level so React's idempotency check never sees an impure call in a
+// component's render scope, even when it only runs from an event handler.
+export function pickRandom<T>(arr: readonly T[]): T | undefined {
+  return pickRandomDistinct(arr, 1)[0];
+}
+
+export function pickRandomDistinct<T>(arr: readonly T[], count: number): T[] {
+  const remaining = [...arr];
+  const picks: T[] = [];
+  while (picks.length < count && remaining.length > 0) {
+    const index = Math.floor(Math.random() * remaining.length);
+    picks.push(remaining.splice(index, 1)[0]!);
+  }
+  return picks;
+}

--- a/src/pixi/board/BoardScene.ts
+++ b/src/pixi/board/BoardScene.ts
@@ -102,7 +102,7 @@ export interface BoardPlayerSpec {
 
 /** Delimiter auto-focus easing (tweak freely). `FACTOR` is the fraction of the
  *  remaining distance closed each frame; `SNAP` is the width-fraction threshold
-
+test
  *  at which the ease finishes and pins to the target. */
 const DELIMITER_EASE = { FACTOR: 0.25, SNAP: 0.0005 } as const;
 

--- a/src/pixi/board/BoardScene.ts
+++ b/src/pixi/board/BoardScene.ts
@@ -102,6 +102,7 @@ export interface BoardPlayerSpec {
 
 /** Delimiter auto-focus easing (tweak freely). `FACTOR` is the fraction of the
  *  remaining distance closed each frame; `SNAP` is the width-fraction threshold
+
  *  at which the ease finishes and pins to the target. */
 const DELIMITER_EASE = { FACTOR: 0.25, SNAP: 0.0005 } as const;
 

--- a/src/pixi/board/HandController.ts
+++ b/src/pixi/board/HandController.ts
@@ -159,6 +159,7 @@ export class HandController {
 
     // The fan only reshapes for a drag that originates from the hand. A card
     // dragged from the command zone sets `draggingCardId` too, but must not sink
+    // .
     // the hand out of the way.
     const draggingInHand =
       state.draggingCardId != null && state.cards.some((c) => c.id === state.draggingCardId);

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -24,7 +24,7 @@ export interface StartGameParams {
   deck: Deck;
   startingLife: number;
   commanderName: string | null;
-  opponentDeck: Deck | null;
+  opponentDecks: Deck[] | null;
 }
 
 export interface StartMultiplayerGameParams {

--- a/src/platform/web.ts
+++ b/src/platform/web.ts
@@ -535,7 +535,7 @@ class WebGameApi implements IGameApi {
       deck: params.deck,
       startingLife: params.startingLife,
       commanderName: params.commanderName,
-      opponentDeck: params.opponentDeck,
+      opponentDecks: params.opponentDecks,
     });
   }
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -24,6 +24,7 @@ import Settings from "@/views/Settings";
 import About from "@/views/About";
 import Search from "@/views/Search";
 import DeckHub from "@/views/DeckHub";
+import Home from "@/views/Home";
 
 export const router = createBrowserRouter([
   {
@@ -43,7 +44,15 @@ export const router = createBrowserRouter([
     children: [
       {
         index: true,
-        element: <Navigate to="/lobby" replace />,
+        element: <Navigate to="/home" replace />,
+      },
+      {
+        path: "home",
+        element: (
+          <ErrorBoundary context="Home">
+            <Home />
+          </ErrorBoundary>
+        ),
       },
       {
         path: "play",

--- a/src/stores/gameStore.types.ts
+++ b/src/stores/gameStore.types.ts
@@ -76,7 +76,7 @@ export interface GameState {
     deck: Deck,
     formatId?: string,
     commanderName?: string,
-    opponentDeck?: Deck,
+    opponentDecks?: Deck[],
     engine?: EngineKind,
   ) => Promise<void>;
   startManualTabletopGame: (deck: Deck, formatId?: string, commanderName?: string) => Promise<void>;

--- a/src/stores/useGameStore.ts
+++ b/src/stores/useGameStore.ts
@@ -95,14 +95,14 @@ function seedManualDeck(
 
 async function initializeGame({
   deck,
-  opponentDeck,
+  opponentDecks,
   formatId,
   set,
   commanderName,
   engine,
 }: {
   deck: Deck;
-  opponentDeck?: Deck;
+  opponentDecks?: Deck[];
   formatId?: string;
   commanderName?: string;
   engine?: EngineKind;
@@ -122,7 +122,7 @@ async function initializeGame({
   const platformType = getPlatform().type;
   if (
     engine === "Forge" &&
-    opponentDeck &&
+    opponentDecks?.length &&
     (platformType === "tauri" || (platformType === "web" && isHostedEngineAvailable()))
   ) {
     const launchForge = platformType === "tauri" ? startTauriForgeAiGame : startHostedAiGame;
@@ -144,7 +144,7 @@ async function initializeGame({
     try {
       const hosted = await launchForge({
         playerDeck: deck,
-        opponentDeck,
+        opponentDecks,
         formatId: selectedFormatId,
         commanderName: commanderName ?? null,
       });
@@ -172,7 +172,6 @@ async function initializeGame({
       set({ debugInfo: "Forge game started.", isPrefetchingCards: false });
       return;
     } catch (error) {
-      if (platformType !== "tauri") throw error;
       console.error("[store] Forge host unavailable; falling back to Manabrew:", error);
       toast.error("Forge engine unavailable — using the Manabrew engine.");
       resetSelectedGameRuntime();
@@ -181,7 +180,9 @@ async function initializeGame({
   }
 
   const gameDecks: Record<string, Deck> = { "player-0": deck };
-  if (opponentDeck) gameDecks["player-1"] = opponentDeck;
+  (opponentDecks ?? []).forEach((opponentDeck, index) => {
+    gameDecks[`player-${index + 1}`] = opponentDeck;
+  });
   const runtime = getSelectedGameRuntime();
 
   set({
@@ -207,7 +208,7 @@ async function initializeGame({
     deck,
     startingLife,
     commanderName: commanderName ?? null,
-    opponentDeck: opponentDeck ?? null,
+    opponentDecks: opponentDecks ?? null,
   });
   set({ debugInfo: `Game started: ${result}.` });
 }
@@ -250,9 +251,9 @@ export const useGameStore = create<GameState>()(
 
       dismissIronsmithDeckError: () => set({ ironsmithDeckError: null }),
 
-      startGame: async (deck, formatId, commanderName, opponentDeck, engine) => {
+      startGame: async (deck, formatId, commanderName, opponentDecks, engine) => {
         try {
-          await initializeGame({ deck, opponentDeck, formatId, commanderName, engine, set, get });
+          await initializeGame({ deck, opponentDecks, formatId, commanderName, engine, set, get });
         } catch (e) {
           set({ isGameActive: false, debugInfo: `Start failed: ${e}`, isPrefetchingCards: false });
           console.error("[store] Failed to start game:", e);

--- a/src/stores/usePreferencesStore.ts
+++ b/src/stores/usePreferencesStore.ts
@@ -82,6 +82,9 @@ interface PreferencesState {
   ironsmithRuntimeEnabled: boolean;
   setIronsmithRuntimeEnabled: (value: boolean) => void;
 
+  askEngineOnAiPlay: boolean;
+  setAskEngineOnAiPlay: (value: boolean) => void;
+
   cardPreviewMode: CardPreviewMode;
   setCardPreviewMode: (mode: CardPreviewMode) => void;
 
@@ -115,6 +118,7 @@ const PERSISTED_PREFERENCE_KEYS = [
   "battlefieldCardStyle",
   "inGameAnimations",
   "ironsmithRuntimeEnabled",
+  "askEngineOnAiPlay",
   "cardPreviewMode",
   "cardHoverDelayMs",
   "appThemeColorOverrides",
@@ -215,6 +219,9 @@ export const usePreferencesStore = create<PreferencesState>()(
 
           ironsmithRuntimeEnabled: false,
           setIronsmithRuntimeEnabled: (ironsmithRuntimeEnabled) => set({ ironsmithRuntimeEnabled }),
+
+          askEngineOnAiPlay: false,
+          setAskEngineOnAiPlay: (askEngineOnAiPlay) => set({ askEngineOnAiPlay }),
 
           cardPreviewMode: "hover",
           setCardPreviewMode: (cardPreviewMode) => set({ cardPreviewMode }),

--- a/src/views/DeckEditor.tsx
+++ b/src/views/DeckEditor.tsx
@@ -43,9 +43,10 @@ import { NewDeckChoiceDialog } from "@/components/editor/NewDeckChoiceDialog";
 import { inferImportedFormat, type ParsedDeckEntry } from "@/lib/deckImport";
 import { fetchCardCollection, fetchCardByFuzzyName } from "@/api/scryfall";
 import { scryfallToDeckCard } from "@/lib/scryfall.utils";
-import { applyDeckFilters } from "@/views/myDecks.utils";
+import { applyDeckFilters, presetDeckParamId, PRESET_DECK_ID_PREFIX } from "@/views/myDecks.utils";
 import type { SortBy } from "@/views/myDecks.utils";
 import { usePresetDecks } from "@/stores/usePresetDecksStore";
+import { useQuickPlaytest } from "@/hooks/useQuickPlaytest";
 import { useNavigate } from "react-router";
 import type { SavedDeck } from "@/stores/useDeckStore";
 
@@ -71,21 +72,25 @@ export default function DeckEditor() {
   const isReadOnly = useDeckStore((s) => s.isReadOnly);
   const loadPresetDeck = useDeckStore((s) => s.loadPresetDeck);
   const presetDecks = usePresetDecks();
+  const { quickPlaytest, playtestDialog } = useQuickPlaytest();
   const navigate = useNavigate();
 
   function handleOpenPreset(deck: DeckType) {
-    setSearchParams({ deck: `preset:${deck.id ?? deck.name}` });
+    setSearchParams({ deck: presetDeckParamId(deck) });
   }
 
   const presetSavedDecksUnfiltered: SavedDeck[] = presetDecks.map((deck) => ({
-    id: `preset:${deck.id ?? deck.name}`,
+    id: presetDeckParamId(deck),
     deck,
     savedAt: 0,
   }));
+  const location = useLocation();
   const [draggedCard, setDraggedCard] = useState<DeckCard | null>(null);
   const [showSearch, setShowSearch] = useState(false);
   const [searchFocusSignal, setSearchFocusSignal] = useState(0);
-  const [importDialogOpen, setImportDialogOpen] = useState(false);
+  const [importDialogOpen, setImportDialogOpen] = useState(() =>
+    Boolean((location.state as { openImport?: boolean } | null)?.openImport),
+  );
   const [choiceDialogOpen, setChoiceDialogOpen] = useState(false);
   const [publishingDeck, setPublishingDeck] = useState<SavedDeck | null>(null);
 
@@ -113,7 +118,6 @@ export default function DeckEditor() {
     });
   }
   const hasUnsavedChanges = useDeckUnsavedChanges();
-  const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   const currentDeckId = useDeckStore((s) => s.currentDeckId);
 
@@ -161,8 +165,8 @@ export default function DeckEditor() {
     }
     if (restoredParamRef.current === deckParam) return;
 
-    if (deckParam.startsWith("preset:")) {
-      const presetId = deckParam.slice("preset:".length);
+    if (deckParam.startsWith(PRESET_DECK_ID_PREFIX)) {
+      const presetId = deckParam.slice(PRESET_DECK_ID_PREFIX.length);
       const preset = presetDecks.find((d) => (d.id ?? d.name) === presetId);
       if (!preset) return;
       loadPresetDeck(preset);
@@ -467,6 +471,7 @@ export default function DeckEditor() {
                     key={s.id}
                     deck={s}
                     onOpen={() => handleSelectDeck(s.id)}
+                    onPlaytest={() => quickPlaytest(s.deck)}
                     onDelete={() => handleDelete(s.id)}
                     onRename={() => startRename(s.id, s.deck.name)}
                     onPublish={() => setPublishingDeck(s)}
@@ -520,6 +525,7 @@ export default function DeckEditor() {
                         deck={s}
                         readOnly
                         onOpen={() => handleOpenPreset(s.deck)}
+                        onPlaytest={() => quickPlaytest(s.deck)}
                       />
                     ))}
                   </div>
@@ -556,6 +562,8 @@ export default function DeckEditor() {
           onOpenChange={setImportDialogOpen}
           onImport={handleTextImport}
         />
+
+        {playtestDialog}
 
         {publishingDeck && (
           <PublishDeckDialog

--- a/src/views/DeckHub.tsx
+++ b/src/views/DeckHub.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { ChevronLeft, ChevronRight, Search, Trophy } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -6,6 +7,7 @@ import { HubDeckCard } from "@/components/deck/HubDeckCard";
 import { HubDeckPreviewDialog } from "@/components/deck/HubDeckPreviewDialog";
 import { HubTopDecks } from "@/components/deck/HubTopDecks";
 import type { HubSort } from "@/api/hub";
+import { useHubDeckPlaytest, useQuickPlaytest } from "@/hooks/useQuickPlaytest";
 import { useHubStore } from "@/stores/useHubStore";
 import { FORMAT_DISPLAY } from "@/lib/constants";
 
@@ -40,10 +42,14 @@ export default function DeckHub() {
   const [page, setPage] = useState(1);
   const [previewId, setPreviewId] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const urlDeckId = searchParams.get("deck");
 
   const list = useHubStore((s) => s.list);
   const listError = useHubStore((s) => s.listError);
   const fetchDecks = useHubStore((s) => s.fetchDecks);
+  const { quickPlaytest, playtestDialog } = useQuickPlaytest();
+  const hubPlaytest = useHubDeckPlaytest(quickPlaytest);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -131,7 +137,12 @@ export default function DeckHub() {
               ) : (
                 <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
                   {list.decks.map((deck) => (
-                    <HubDeckCard key={deck.id} deck={deck} onOpen={() => setPreviewId(deck.id)} />
+                    <HubDeckCard
+                      key={deck.id}
+                      deck={deck}
+                      onOpen={() => setPreviewId(deck.id)}
+                      onPlaytest={() => hubPlaytest(deck.id)}
+                    />
                   ))}
                 </div>
               )}
@@ -172,10 +183,14 @@ export default function DeckHub() {
       )}
 
       <HubDeckPreviewDialog
-        deckId={previewId}
-        onClose={() => setPreviewId(null)}
+        deckId={previewId ?? urlDeckId}
+        onClose={() => {
+          setPreviewId(null);
+          if (urlDeckId) setSearchParams({}, { replace: true });
+        }}
         onUnpublished={() => setRefreshKey((k) => k + 1)}
       />
+      {playtestDialog}
     </div>
   );
 }

--- a/src/views/Gauntlet.tsx
+++ b/src/views/Gauntlet.tsx
@@ -112,7 +112,7 @@ export default function Gauntlet() {
         ),
       ]);
       armGauntletReturn(gauntletId, activeGauntlet.currentRound);
-      await startGame(human, formatId, undefined, opponent);
+      await startGame(human, formatId, undefined, [opponent]);
       navigate(ROUTES.PLAY);
     } catch (err) {
       toast.error(`Failed to launch match: ${err}`);

--- a/src/views/Home.tsx
+++ b/src/views/Home.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { ArrowRight, ClipboardPaste, Globe, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { DeckGridCard } from "@/components/deck/DeckGridCard";
+import { HubDeckCard } from "@/components/deck/HubDeckCard";
+import { HubDeckPreviewDialog } from "@/components/deck/HubDeckPreviewDialog";
+import { useDeckStore } from "@/stores/useDeckStore";
+import { usePresetDecks } from "@/stores/usePresetDecksStore";
+import { useHubStore } from "@/stores/useHubStore";
+import { useHubDeckPlaytest, useQuickPlaytest } from "@/hooks/useQuickPlaytest";
+import { presetDeckParamId } from "@/views/myDecks.utils";
+import type { SavedDeck } from "@/stores/useDeckStore";
+
+const DECK_GRID_CLASS =
+  "grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-3";
+const PRESET_PREVIEW_COUNT = 12;
+const HUB_PREVIEW_COUNT = 6;
+
+function SectionHeader({ title, to, linkLabel }: { title: string; to: string; linkLabel: string }) {
+  return (
+    <div className="flex items-baseline justify-between pb-2">
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        {title}
+      </h3>
+      <Link
+        to={to}
+        className="inline-flex items-center gap-0.5 text-xs text-primary hover:underline"
+      >
+        {linkLabel}
+        <ArrowRight className="h-3 w-3" />
+      </Link>
+    </div>
+  );
+}
+
+export default function Home() {
+  const navigate = useNavigate();
+  const { quickPlaytest, playtestDialog } = useQuickPlaytest();
+  const hubPlaytest = useHubDeckPlaytest(quickPlaytest);
+  const savedDecks = useDeckStore((s) => s.savedDecks);
+  const clearDeck = useDeckStore((s) => s.clearDeck);
+  const presetDecks = usePresetDecks();
+  const hubList = useHubStore((s) => s.list);
+  const hubError = useHubStore((s) => s.listError);
+  const fetchDecks = useHubStore((s) => s.fetchDecks);
+  const [previewId, setPreviewId] = useState<string | null>(null);
+  const [showAllPresets, setShowAllPresets] = useState(false);
+
+  useEffect(() => {
+    void fetchDecks({ sort: "newest", page: 1, pageSize: HUB_PREVIEW_COUNT });
+  }, [fetchDecks]);
+
+  const myDecks = [...savedDecks].sort((a, b) => b.savedAt - a.savedAt);
+  const presetEntries: SavedDeck[] = presetDecks.map((deck) => ({
+    id: presetDeckParamId(deck),
+    deck,
+    savedAt: 0,
+  }));
+  const visiblePresets = showAllPresets
+    ? presetEntries
+    : presetEntries.slice(0, PRESET_PREVIEW_COUNT);
+
+  function handleNewDeck() {
+    clearDeck();
+    navigate("/deck-editor", { state: { directToEditor: true } });
+  }
+
+  function handleImportDeck() {
+    navigate("/deck-editor", { state: { openImport: true } });
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="p-4 space-y-8">
+        <div className="flex items-center gap-2 flex-wrap">
+          <h2 className="text-lg font-semibold flex-1">Home</h2>
+          <Button size="sm" variant="outline" onClick={handleImportDeck}>
+            <ClipboardPaste className="mr-1 h-4 w-4" />
+            Import deck
+          </Button>
+          <Button size="sm" variant="outline" onClick={handleNewDeck}>
+            <Plus className="mr-1 h-4 w-4" />
+            New deck
+          </Button>
+          <Button size="sm" asChild>
+            <Link to="/lobby">
+              <Globe className="mr-1 h-4 w-4" />
+              Play online
+            </Link>
+          </Button>
+        </div>
+
+        <section>
+          <SectionHeader title="Your decks" to="/deck-editor" linkLabel="My Decks" />
+          {myDecks.length === 0 ? (
+            <div className="rounded-lg border border-dashed px-6 py-10 text-center space-y-3">
+              <p className="text-lg font-semibold">No decks yet</p>
+              <p className="text-sm text-muted-foreground">
+                Paste a decklist from Moxfield or anywhere, pick a starter deck below, or build your
+                own brew.
+              </p>
+              <div className="flex items-center justify-center gap-2">
+                <Button size="sm" onClick={handleImportDeck}>
+                  <ClipboardPaste className="mr-1 h-4 w-4" />
+                  Import a deck
+                </Button>
+                <Button size="sm" variant="outline" onClick={handleNewDeck}>
+                  <Plus className="mr-1 h-4 w-4" />
+                  Build from scratch
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className={DECK_GRID_CLASS}>
+              {myDecks.map((saved) => (
+                <DeckGridCard
+                  key={saved.id}
+                  deck={saved}
+                  onOpen={() => navigate(`/deck-editor?deck=${encodeURIComponent(saved.id)}`)}
+                  onPlaytest={() => quickPlaytest(saved.deck)}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section>
+          <SectionHeader title="Starter decks" to="/play" linkLabel="Play" />
+          <div className={DECK_GRID_CLASS}>
+            {visiblePresets.map((preset) => (
+              <DeckGridCard
+                key={preset.id}
+                deck={preset}
+                readOnly
+                onOpen={() => navigate(`/deck-editor?deck=${encodeURIComponent(preset.id)}`)}
+                onPlaytest={() => quickPlaytest(preset.deck)}
+              />
+            ))}
+          </div>
+          {presetEntries.length > PRESET_PREVIEW_COUNT && (
+            <div className="pt-2 text-center">
+              <Button variant="ghost" size="sm" onClick={() => setShowAllPresets((v) => !v)}>
+                {showAllPresets ? "Show fewer" : `Show all ${presetEntries.length}`}
+              </Button>
+            </div>
+          )}
+        </section>
+
+        <section>
+          <SectionHeader title="Fresh from the Deck Hub" to="/hub" linkLabel="Deck Hub" />
+          {hubError ? (
+            <p className="text-sm text-muted-foreground">The Deck Hub is unreachable right now.</p>
+          ) : hubList === null ? (
+            <p className="text-sm text-muted-foreground">Loading decks…</p>
+          ) : hubList.decks.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              Nothing published yet — share one of yours from My Decks.
+            </p>
+          ) : (
+            <div className={DECK_GRID_CLASS}>
+              {hubList.decks.slice(0, HUB_PREVIEW_COUNT).map((deck) => (
+                <HubDeckCard
+                  key={deck.id}
+                  deck={deck}
+                  onOpen={() => setPreviewId(deck.id)}
+                  onPlaytest={() => hubPlaytest(deck.id)}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+
+      <HubDeckPreviewDialog deckId={previewId} onClose={() => setPreviewId(null)} />
+      {playtestDialog}
+    </div>
+  );
+}

--- a/src/views/Play.tsx
+++ b/src/views/Play.tsx
@@ -6,7 +6,9 @@ import { EngineChoiceModal } from "@/components/lobby/EngineChoiceModal";
 import Game from "./Game";
 import { getPlatform } from "@/platform";
 import { isLiveEngineGameRouteState } from "@/game/engineGameLaunch";
+import { getDefaultAiEngine } from "@/game/hostedAiPlay";
 import { isHostedEngineAvailable } from "@/config/webRuntimeConfig";
+import { usePreferencesStore } from "@/stores/usePreferencesStore";
 import type { Deck } from "@/protocol/deck";
 import type { EngineKind } from "@/types/server";
 
@@ -120,13 +122,11 @@ export default function Play() {
       <div className="relative h-full">
         <DeckVsSelector
           onStart={(playerDeck, opponentDeck, formatId, commanderName) => {
-            if (getPlatform().type === "web") {
+            if (getPlatform().type === "web" && usePreferencesStore.getState().askEngineOnAiPlay) {
               setPendingAiStart({ playerDeck, opponentDeck, formatId, commanderName });
-            } else {
-              // Tauri (graalvm build) defaults to the bundled Forge engine; the
-              // store falls back to Manabrew if the local Forge host can't start.
-              startGame(playerDeck, formatId, commanderName, opponentDeck, "Forge");
+              return;
             }
+            startGame(playerDeck, formatId, commanderName, [opponentDeck], getDefaultAiEngine());
           }}
         />
       </div>
@@ -140,7 +140,7 @@ export default function Play() {
               pending.playerDeck,
               pending.formatId,
               pending.commanderName,
-              pending.opponentDeck,
+              [pending.opponentDeck],
               engine,
             );
           }}

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -7,6 +7,7 @@ import {
   type ZonePanelItem,
 } from "@/stores/usePreferencesStore";
 import { isFeatureEnabled } from "@/featureFlags";
+import { getPlatform } from "@/platform";
 import { IRONSMITH_WASM_AVAILABLE } from "@/game/ironsmithWasmAvailable";
 import { stripUsernameTag } from "@/lib/username";
 import { normalizeToWebp, ImageTooLargeError, AVATAR_IMAGE_BUDGET } from "@/lib/imageEncode";
@@ -1066,6 +1067,33 @@ export default function Settings() {
                   Adds the experimental Ironsmith trusted engine as a Create Room option. Card
                   support is partial and games may be rough — off by default. Leave this off unless
                   you're testing Ironsmith.
+                </p>
+              </div>
+            )}
+
+            {getPlatform().type === "web" && (
+              <div className="rounded-lg border bg-card/40 p-4 space-y-2">
+                <Label>Ask which engine before AI games</Label>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant={prefs.askEngineOnAiPlay ? "default" : "outline"}
+                    size="sm"
+                    onClick={() => prefs.setAskEngineOnAiPlay(true)}
+                  >
+                    On
+                  </Button>
+                  <Button
+                    variant={!prefs.askEngineOnAiPlay ? "default" : "outline"}
+                    size="sm"
+                    onClick={() => prefs.setAskEngineOnAiPlay(false)}
+                  >
+                    Off
+                  </Button>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Games vs AI normally pick the best available engine automatically. Turn this on to
+                  choose between the hosted Forge engine and the in-browser Manabrew engine on every
+                  launch.
                 </p>
               </div>
             )}

--- a/src/views/Tabletop.tsx
+++ b/src/views/Tabletop.tsx
@@ -81,7 +81,7 @@ export default function Tabletop() {
     <div className="relative h-full min-h-0">
       <DeckVsSelector
         onStart={(playerDeck, opponentDeck, formatId, commanderName) => {
-          startGame(playerDeck, formatId, commanderName, opponentDeck);
+          startGame(playerDeck, formatId, commanderName, [opponentDeck]);
         }}
         onStartTabletop={(deck, formatId, commanderName) => {
           void startManualTabletopGame(deck, formatId, commanderName);

--- a/src/views/myDecks.utils.ts
+++ b/src/views/myDecks.utils.ts
@@ -1,7 +1,13 @@
-import type { DeckCard } from "@/protocol/deck";
+import type { Deck, DeckCard } from "@/protocol/deck";
 import type { SavedDeck } from "@/stores/useDeckStore";
 import { getDeckColors } from "@/components/deck/deckDisplay.utils";
 export { type CardGroup, groupCards } from "@/components/editor/deckBuilder.utils";
+
+export const PRESET_DECK_ID_PREFIX = "preset:";
+
+export function presetDeckParamId(deck: Deck): string {
+  return `${PRESET_DECK_ID_PREFIX}${deck.id ?? deck.name}`;
+}
 
 //
 export function categorize(

--- a/src/workers/game-engine.worker.ts
+++ b/src/workers/game-engine.worker.ts
@@ -344,8 +344,9 @@ function runInteractiveGame(requestId: string, args?: Record<string, unknown>): 
   }
 
   const humanDeck = args?.deck as Deck | undefined;
-  const aiDeck = (args?.opponentDeck as Deck | undefined) ?? humanDeck;
-  if (!humanDeck || !aiDeck) {
+  const requestedAiDecks = args?.opponentDecks as Deck[] | undefined;
+  const aiDecks = requestedAiDecks?.length ? requestedAiDecks : humanDeck ? [humanDeck] : [];
+  if (!humanDeck || aiDecks.length === 0) {
     postError(requestId, "start_game requires a deck and opponent deck");
     return;
   }
@@ -358,7 +359,7 @@ function runInteractiveGame(requestId: string, args?: Record<string, unknown>): 
     "[GameWorker] Starting interactive game:",
     humanDeck.cards.length,
     "vs",
-    aiDeck.cards.length,
+    aiDecks.map((deck) => deck.cards.length).join("/"),
   );
 
   // Allocate SharedArrayBuffer for prompt/response communication
@@ -373,7 +374,7 @@ function runInteractiveGame(requestId: string, args?: Record<string, unknown>): 
 
   // Run the game — this BLOCKS the worker thread!
   try {
-    const result = run_interactive_game(humanDeck, aiDeck, config, gameSharedBuffer);
+    const result = run_interactive_game(humanDeck, aiDecks, config, gameSharedBuffer);
 
     console.log("[GameWorker] Game completed:", result);
     gameRunning = false;


### PR DESCRIPTION
## Summary

The standalone / selfhost web image (`ops/standalone.Caddyfile`, used by `deploy-local.sh` + `compose.selfhost.yml`) only proxied card images (`/scryfall-img/`). Mana symbols had no route, so they fell back to fetching `svgs.scryfall.io/card-symbols/*.svg` **directly** from the browser. On any box whose outbound egress to Scryfall is blocked/proxied, those symbol requests 502.

This adds the `/scryfall-symbols/` → `svgs.scryfall.io/card-symbols/` proxy to `standalone.Caddyfile` (mirroring the production `ops/Caddyfile`) and points the selfhost build at it via `VITE_SCRYFALL_SYMBOL_BASE=/scryfall-symbols/`, so symbols load same-origin and COEP-clean — same path card images already use.

## Why

- Card images are already served same-origin through Caddy; mana symbols were the odd one out, depending on the box's direct egress to Scryfall.
- Same-origin symbols are also COEP-clean under the standalone image's `Cross-Origin-Embedder-Policy: credentialless` headers, avoiding cross-origin fetch pitfalls on LAN/HTTPS deploys.
- Restores parity with the production Caddyfile, which already has this route.

## Test plan

- `caddy validate --config ops/standalone.Caddyfile --adapter caddyfile` → **Valid configuration**; `caddy fmt` clean.
- Rebuild standalone stack (`./deploy-local.sh`); confirm mana symbols load from `/scryfall-symbols/*.svg` (same-origin, 200) in DevTools Network instead of `svgs.scryfall.io` directly.
