### PR TITLE
fix(ops): proxy scryfall mana symbols same-origin in standalone deploy

### DIFF
--- a/compose.selfhost.yml
+++ b/compose.selfhost.yml
@@ -13,6 +13,11 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.web
+      args:
+        # Serve mana symbols same-origin through this box's Caddy
+        # (ops/standalone.Caddyfile) instead of fetching svgs.scryfall.io
+        # directly, so symbols don't depend on the box's outbound egress.
+        VITE_SCRYFALL_SYMBOL_BASE: /scryfall-symbols/
     restart: unless-stopped
     environment:
       # Address the browser uses to reach this box's relay (written into

--- a/ops/standalone.Caddyfile
+++ b/ops/standalone.Caddyfile
@@ -16,6 +16,21 @@
 		file_server
 	}
 
+	# Mana symbol proxy: served same-origin so symbols never depend on the
+	# box's direct egress to svgs.scryfall.io and stay COEP-clean. The app
+	# points here via VITE_SCRYFALL_SYMBOL_BASE=/scryfall-symbols/.
+	@scryfall path_regexp scryfall ^/scryfall-symbols/(.*)$
+	handle @scryfall {
+		rewrite * /card-symbols/{re.scryfall.1}
+		reverse_proxy https://svgs.scryfall.io {
+			header_up Host svgs.scryfall.io
+			header_down -Access-Control-Allow-Origin
+			header_down -Cross-Origin-Resource-Policy
+			header_down -Cache-Control
+		}
+		header Cache-Control "public, max-age=604800"
+		header Cross-Origin-Resource-Policy "same-origin"
+	}
 
 	# Card image proxy: cards.scryfall.io intermittently serves cached objects
 	# without CORS headers, which breaks the app's cors-mode fetches (WebGL


### PR DESCRIPTION
## Summary

The standalone / selfhost web image (`ops/standalone.Caddyfile`, used by `deploy-local.sh` + `compose.selfhost.yml`) only proxied card images (`/scryfall-img/`). Mana symbols had no route, so they fell back to fetching `svgs.scryfall.io/card-symbols/*.svg` **directly** from the browser. On any box whose outbound egress to Scryfall is blocked/proxied, those symbol requests 502.

This adds the `/scryfall-symbols/` → `svgs.scryfall.io/card-symbols/` proxy to `standalone.Caddyfile` (mirroring the production `ops/Caddyfile`) and points the selfhost build at it via `VITE_SCRYFALL_SYMBOL_BASE=/scryfall-symbols/`, so symbols load same-origin and COEP-clean — same path card images already use.

## Why

- Card images are already served same-origin through Caddy; mana symbols were the odd one out, depending on the box's direct egress to Scryfall.
- Same-origin symbols are also COEP-clean under the standalone image's `Cross-Origin-Embedder-Policy: credentialless` headers, avoiding cross-origin fetch pitfalls on LAN/HTTPS deploys.
- Restores parity with the production Caddyfile, which already has this route.

## Test plan

- `caddy validate --config ops/standalone.Caddyfile --adapter caddyfile` → **Valid configuration**; `caddy fmt` clean.
- Rebuild standalone stack (`./deploy-local.sh`); confirm mana symbols load from `/scryfall-symbols/*.svg` (same-origin, 200) in DevTools Network instead of `svgs.scryfall.io` directly.
