### PR TITLE
fix(ops): pin public DNS for standalone web container

### DIFF
--- a/compose.selfhost.yml
+++ b/compose.selfhost.yml
@@ -19,6 +19,13 @@ services:
         # directly, so symbols don't depend on the box's outbound egress.
         VITE_SCRYFALL_SYMBOL_BASE: /scryfall-symbols/
     restart: unless-stopped
+    # Caddy resolves cards./svgs.scryfall.io per proxied request; the deck-cover
+    # prefetch fires dozens at once, and Docker's embedded resolver forwarding to
+    # a home-lab DNS drops that burst (dial tcp: lookup … i/o timeout → 502).
+    # Pin public resolvers so the Scryfall proxies survive the burst.
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8
     environment:
       # Address the browser uses to reach this box's relay (written into
       # config.js on start). Port 443 → wss://, anything else → ws://.


### PR DESCRIPTION
## Summary

Pin public DNS resolvers (`1.1.1.1`, `8.8.8.8`) on the standalone web container in `compose.selfhost.yml`.

## Why

On a self-hosted box, the web container's Caddy resolves `cards.scryfall.io` / `svgs.scryfall.io` on **every** proxied request (`/scryfall-img/`, `/scryfall-symbols/`). The deck-cover prefetch fires ~38 image requests at once, so Caddy issues that many DNS lookups concurrently. Docker's embedded resolver (`127.0.0.11`) forwarding to a home-lab DNS (Pi-hole/router) drops the burst, and Caddy surfaces the failure as a **502**:

```
dial tcp: lookup cards.scryfall.io: i/o timeout   (duration 3.0s, status 502)
```

Single-request checks (`wget`/`curl` from inside the container) resolve fine — only the concurrent burst overwhelms the local resolver, which is why the symbols route (merged in #487) still 502'd for both symbols and card images. Pinning reliable public resolvers lets the Scryfall proxies survive the burst.

Follow-up to #487, which added the `/scryfall-symbols/` route but not this DNS fix.

## Test plan

- `docker compose -f compose.selfhost.yml up -d --force-recreate manabrew` (runtime-only change, no rebuild).
- Hard-reload the app; card images and mana symbols load.
- `docker compose -f compose.selfhost.yml logs manabrew | grep -c "i/o timeout"` stops growing after reload.
