### PR TITLE
fix(ops): pin public DNS for staging web container

### DIFF
--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -12,6 +12,13 @@ services:
   manabrew:
     image: ghcr.io/witchesofthehill/manabrew-web:${MANABREW_IMAGE_TAG:-staging}
     restart: unless-stopped
+    # Caddy resolves cards./svgs.scryfall.io per proxied request; the deck-cover
+    # prefetch fires dozens at once, and Docker's embedded resolver forwarding to
+    # a constrained DNS drops that burst (dial tcp: lookup … i/o timeout → 502).
+    # Pin public resolvers so the Scryfall proxies survive the burst.
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
## Summary

Pin public DNS resolvers (`1.1.1.1`, `8.8.8.8`) on the **staging** web container in `compose.staging.yml`, mirroring the self-host pin merged in #488.

## Why

The staging web image's Caddy resolves `cards.scryfall.io` / `svgs.scryfall.io` on every proxied request (`/scryfall-img/`, `/scryfall-symbols/` — both routes already exist in `ops/staging.Caddyfile`). The deck-cover prefetch fires ~38 image requests at once, so Caddy issues that many DNS lookups concurrently. On a box whose resolver can't absorb the burst (Docker's embedded `127.0.0.11` forwarding to a home-lab / constrained DNS), the lookups time out and Caddy returns **502**:

```
dial tcp: lookup cards.scryfall.io: i/o timeout   (duration 3.0s, status 502)
```

Single lookups resolve fine — only the concurrent burst exhausts the resolver, so every mana symbol and card image 502s while the rest of the app loads. Pinning reliable public resolvers lets the Scryfall proxies survive the burst. Confirmed on a self-host box: a direct query to `1.1.1.1` from the container resolves instantly, and #488 fixed the identical issue for `compose.selfhost.yml`.

## Test plan

- `docker compose -f compose.staging.yml up -d --force-recreate manabrew` (compose-only change; prebuilt image + mounted Caddyfile, no rebuild).
- `docker inspect <web-container> --format '{{json .HostConfig.Dns}}'` → `["1.1.1.1","8.8.8.8"]`.
- Hard-reload the app; mana symbols and card images load.
- `docker compose -f compose.staging.yml logs manabrew | grep -c "i/o timeout"` stops growing.

## Follow-up (not in this PR)

`compose.production.yml`'s web service proxies Scryfall the same way; it could get the same pin for parity, but its host resolver is known-good, so leaving that as a separate call.
