### PR TITLE
fix(ops): make deploy-local always build the local checkout

### DIFF
--- a/deploy-local.sh
+++ b/deploy-local.sh
@@ -26,7 +26,6 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$REPO_DIR"
 
-COMPOSE_FILE="${COMPOSE_FILE:-compose.selfhost.yml}"
 export RELAY_HOST="${RELAY_HOST:-localhost}"
 export RELAY_PORT="${RELAY_PORT:-9443}"
 export WEB_PORT="${WEB_PORT:-80}"
@@ -39,6 +38,14 @@ if [ -f "$REPO_DIR/.env" ]; then
     source "$REPO_DIR/.env"
     set +a
 fi
+
+# deploy-local always builds and runs THIS checkout. A box that also runs the
+# staging/prod deploy keeps COMPOSE_FILE=compose.staging.yml + MANABREW_IMAGE_TAG
+# in .env; sourced above they would silently redirect us to the prebuilt-image
+# stack instead of building the local branch. Pin the self-host compose (and drop
+# the image tag) after .env so that never happens.
+export COMPOSE_FILE="compose.selfhost.yml"
+unset MANABREW_IMAGE_TAG
 
 # The web image builds the card dataset from the forge submodule's res/ tree.
 git submodule sync --recursive || true


### PR DESCRIPTION
## Summary

Make `deploy-local.sh` always build and run the **local checkout** via `compose.selfhost.yml`, regardless of what the box's `.env` sets for `COMPOSE_FILE` / `MANABREW_IMAGE_TAG`.

## Why

`deploy-local.sh` defaulted `COMPOSE_FILE=compose.selfhost.yml` **before** sourcing `.env`, then sourced `.env`. On a box that also runs the staging/prod deploy, `.env` carries `COMPOSE_FILE=compose.staging.yml` (and `MANABREW_IMAGE_TAG=staging`) for `deploy.sh`/`deploy-staging.sh`. Sourcing it silently overrode the default, so `deploy-local.sh`:

- pulled the prebuilt `ghcr…:staging` images instead of building the checked-out branch, and
- ran `compose.staging.yml` (staging ports/Caddyfile), not the self-host stack.

Net effect: `./deploy-local.sh` never deployed your local code — the one thing it exists to do. This pins `compose.selfhost.yml` and unsets the image tag **after** `.env` is sourced, so genuine overrides (RELAY_HOST, WEB_PORT, secrets) still apply but the compose target can't be hijacked.

## Test plan

- On a box whose `.env` contains `COMPOSE_FILE=compose.staging.yml`: `./deploy-local.sh` → `docker compose -f compose.selfhost.yml ps` shows **locally-built `manabrew-*`** images (not `ghcr…:staging`), built from the current branch.
- `bash -n deploy-local.sh` passes.
