### PR TITLE
feat(engine): endstep concurrency patches for multi-game forge

### DIFF
--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -88,9 +88,14 @@ services:
       SELF_HOSTED_NODE_SERVER_KEY: "${MANABREW_SERVER_KEY:?MANABREW_SERVER_KEY is required}"
       SELF_HOSTED_NODE_FORMAT: "${SELF_HOSTED_NODE_FORMAT:-Any}"
       SELF_HOSTED_NODE_MAX_PLAYERS: "${SELF_HOSTED_NODE_MAX_PLAYERS:-4}"
-      SELF_HOSTED_NODE_MAX_GAMES: "${SELF_HOSTED_NODE_MAX_GAMES:-1}"
+      SELF_HOSTED_NODE_MAX_GAMES: "${SELF_HOSTED_NODE_MAX_GAMES:-4}"
+      # One engine process serves every staging game slot. GAMES_PER_JVM drives
+      # the java-forge image in use today; SHARED_ISOLATE is inert there and
+      # takes over if the image ever flips to the graal-forge build.
+      SELF_HOSTED_NODE_GAMES_PER_JVM: "${SELF_HOSTED_NODE_GAMES_PER_JVM:-4}"
+      SELF_HOSTED_NODE_SHARED_ISOLATE: "${SELF_HOSTED_NODE_SHARED_ISOLATE:-1}"
       RUST_LOG: "self_hosted_node=info"
-    mem_limit: 1g
+    mem_limit: 2g
     cpu_shares: 512
     depends_on:
       - manabrew-server-staging

--- a/forge-harness/src/main/java/forge/harness/Main.java
+++ b/forge-harness/src/main/java/forge/harness/Main.java
@@ -278,8 +278,10 @@ public final class Main {
 
     /**
      * Interactive server mode: per-game JSON-RPC over stdin/stdout dispatching
-     * to a long-lived {@link ManaBrewEngineAdapter}. One process owns one game
-     * at a time; pool callers send `reset` between games and `quit` to exit.
+     * to a long-lived {@link ManaBrewEngineAdapter}. Sessions are routed by
+     * sessionId and each runs on its own game thread, so one process can host
+     * several concurrent games; pool callers send `reset` only while the
+     * process is idle and `quit` to exit.
      *
      * Request shape:  {"command":"startGame","payload":"<json>"}  (sessionId
      * goes in `sessionId`; payload is the inner JSON string).

--- a/forge-harness/src/main/java/forge/harness/common/ForgeEngineReset.java
+++ b/forge-harness/src/main/java/forge/harness/common/ForgeEngineReset.java
@@ -32,7 +32,11 @@ public final class ForgeEngineReset {
             Class<?> clazz = Class.forName(className);
             Field field = clazz.getDeclaredField(fieldName);
             field.setAccessible(true);
-            field.setInt(null, 0);
+            if (field.get(null) instanceof java.util.concurrent.atomic.AtomicInteger counter) {
+                counter.set(0);
+            } else {
+                field.setInt(null, 0);
+            }
         } catch (ClassNotFoundException | NoSuchFieldException e) {
             // Class or field absent in this Forge build — nothing to reset.
         } catch (Exception e) {

--- a/forge-harness/src/main/java/forge/harness/common/ForgeEngineReset.java
+++ b/forge-harness/src/main/java/forge/harness/common/ForgeEngineReset.java
@@ -1,47 +1,66 @@
 package forge.harness.common;
 
 import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Reflection-based reset of private static ID counters in forge-game classes.
  * Used by both harness engines (parity batches and the hosted session pool) to
  * isolate cross-game state without modifying forge-game.
+ *
+ * <p>Every failure is fatal by design: a counter this class claims to reset
+ * but silently cannot (class renamed, field moved, shape changed by an
+ * upstream bump) breaks cross-game id isolation invisibly. Each reset is
+ * verified by reading the counter back; callers treat a throw as an unusable
+ * engine process.
  */
 public final class ForgeEngineReset {
     private ForgeEngineReset() {}
 
+    private static final String[][] COUNTERS = {
+        {"forge.game.spellability.SpellAbility", "maxId"},
+        {"forge.game.spellability.SpellAbilityStackInstance", "maxId"},
+        {"forge.game.trigger.Trigger", "maxId"},
+        {"forge.game.replacement.ReplacementEffect", "maxId"},
+        {"forge.game.staticability.StaticAbility", "maxId"},
+        {"forge.game.Game", "maxId"},
+    };
+
     private static boolean logged = false;
 
-    /** Reset all known static ID counters in forge-game to 0. */
+    /** Reset all known static ID counters in forge-game to 0, verifying each. */
     public static void resetAllIdCounters() {
         if (!logged) {
             System.err.println("[manabrew-engine-reset] Resetting all forge-game ID counters via reflection");
             logged = true;
         }
-        resetStaticInt("forge.game.spellability.SpellAbility", "maxId");
-        resetStaticInt("forge.game.spellability.SpellAbilityStackInstance", "maxId");
-        resetStaticInt("forge.game.trigger.Trigger", "maxId");
-        resetStaticInt("forge.game.cost.IndividualCostPaymentInstance", "maxId");
-        resetStaticInt("forge.game.replacement.ReplacementEffect", "maxId");
-        resetStaticInt("forge.game.staticability.StaticAbility", "maxId");
-        resetStaticInt("forge.game.Game", "maxId");
+        for (final String[] target : COUNTERS) {
+            resetCounter(target[0], target[1]);
+        }
     }
 
-    private static void resetStaticInt(String className, String fieldName) {
+    private static void resetCounter(String className, String fieldName) {
         try {
-            Class<?> clazz = Class.forName(className);
-            Field field = clazz.getDeclaredField(fieldName);
+            Field field = Class.forName(className).getDeclaredField(fieldName);
             field.setAccessible(true);
-            if (field.get(null) instanceof java.util.concurrent.atomic.AtomicInteger counter) {
+            Object value = field.get(null);
+            if (value instanceof AtomicInteger counter) {
                 counter.set(0);
-            } else {
+                if (counter.get() != 0) {
+                    throw new IllegalStateException(className + "." + fieldName + " did not reset to 0");
+                }
+            } else if (field.getType() == int.class) {
                 field.setInt(null, 0);
+                if (field.getInt(null) != 0) {
+                    throw new IllegalStateException(className + "." + fieldName + " did not reset to 0");
+                }
+            } else {
+                throw new IllegalStateException(
+                    className + "." + fieldName + " has unsupported counter shape " + field.getType());
             }
-        } catch (ClassNotFoundException | NoSuchFieldException e) {
-            // Class or field absent in this Forge build — nothing to reset.
-        } catch (Exception e) {
-            System.err.printf("[manabrew-engine-reset] WARNING: Failed to reset %s.%s: %s%n",
-                className, fieldName, e.getMessage());
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(
+                "cannot reset " + className + "." + fieldName + "; engine id isolation would silently break", e);
         }
     }
 }

--- a/forge-harness/src/main/java/forge/harness/common/HarnessCostPlumbing.java
+++ b/forge-harness/src/main/java/forge/harness/common/HarnessCostPlumbing.java
@@ -20,7 +20,6 @@ import forge.game.zone.ZoneType;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 public final class HarnessCostPlumbing {
@@ -708,13 +707,13 @@ public final class HarnessCostPlumbing {
             final GameEntityCounterTable table = new GameEntityCounterTable();
             int remaining = amount;
             for (final Card card : list) {
-                for (final Map.Entry<CounterType, Integer> e : card.getCounters().entrySet()) {
+                for (final com.google.common.collect.Multiset.Entry<CounterType> e : card.getCounters().entrySet()) {
                     if (remaining <= 0) {
                         break;
                     }
-                    final int remove = Math.min(remaining, e.getValue());
+                    final int remove = Math.min(remaining, e.getCount());
                     if (remove > 0) {
-                        table.put(null, card, e.getKey(), remove);
+                        table.put(null, card, e.getElement(), remove);
                         remaining -= remove;
                     }
                 }
@@ -761,9 +760,9 @@ public final class HarnessCostPlumbing {
                         return PaymentDecision.counters(table);
                     }
                 } else {
-                    for (final Map.Entry<CounterType, Integer> e : card.getCounters().entrySet()) {
-                        if (e.getValue() >= amount) {
-                            table.put(null, card, e.getKey(), amount);
+                    for (final com.google.common.collect.Multiset.Entry<CounterType> e : card.getCounters().entrySet()) {
+                        if (e.getCount() >= amount) {
+                            table.put(null, card, e.getElement(), amount);
                             return PaymentDecision.counters(table);
                         }
                     }
@@ -879,6 +878,11 @@ public final class HarnessCostPlumbing {
         @Override
         public PaymentDecision visit(final CostBlight cost) {
             return visit((CostPutCounter) cost);
+        }
+
+        @Override
+        public PaymentDecision visit(final CostPutCounterYou cost) {
+            return PaymentDecision.number(cost.getAbilityAmount(ability));
         }
 
         @Override

--- a/forge-harness/src/main/java/forge/harness/common/HeadlessGuiBase.java
+++ b/forge-harness/src/main/java/forge/harness/common/HeadlessGuiBase.java
@@ -64,7 +64,6 @@ public class HeadlessGuiBase implements IGuiBase {
     @Override public String showFileDialog(String title, String defaultDir) { return null; }
     @Override public File getSaveFile(File defaultFile) { return null; }
     @Override public void download(GuiDownloadService service, Consumer<Boolean> callback) { if (callback != null) callback.accept(false); }
-    @Override public void refreshSkin() {}
     @Override public void showCardList(String title, String message, List<PaperCard> list) {}
     @Override public boolean showBoxedProduct(String title, String message, List<PaperCard> list) { return false; }
     @Override public PaperCard chooseCard(String title, String message, List<PaperCard> list) { return list != null && !list.isEmpty() ? list.get(0) : null; }

--- a/forge-harness/src/main/java/forge/harness/common/SnapshotExtractor.java
+++ b/forge-harness/src/main/java/forge/harness/common/SnapshotExtractor.java
@@ -89,9 +89,9 @@ public final class SnapshotExtractor {
                 .thenComparing(c -> {
                     // Deterministic counter string matching Rust BTreeMap order
                     TreeMap<String, Integer> counters = new TreeMap<>();
-                    for (Map.Entry<CounterType, Integer> entry : c.getCounters().entrySet()) {
-                        if (entry.getValue() > 0) {
-                            counters.put(counterTypeName(entry.getKey()), entry.getValue());
+                    for (com.google.common.collect.Multiset.Entry<CounterType> entry : c.getCounters().entrySet()) {
+                        if (entry.getCount() > 0) {
+                            counters.put(counterTypeName(entry.getElement()), entry.getCount());
                         }
                     }
                     return counters.toString();
@@ -183,9 +183,9 @@ public final class SnapshotExtractor {
 
         // Counters — sorted by counter type name
         Map<String, Integer> counters = new TreeMap<>();
-        for (Map.Entry<CounterType, Integer> entry : c.getCounters().entrySet()) {
-            if (entry.getValue() > 0) {
-                counters.put(counterTypeName(entry.getKey()), entry.getValue());
+        for (com.google.common.collect.Multiset.Entry<CounterType> entry : c.getCounters().entrySet()) {
+            if (entry.getCount() > 0) {
+                counters.put(counterTypeName(entry.getElement()), entry.getCount());
             }
         }
         cs.put("counters", counters);

--- a/forge-harness/src/main/java/forge/harness/host/InteractiveSnapshotExtractor.java
+++ b/forge-harness/src/main/java/forge/harness/host/InteractiveSnapshotExtractor.java
@@ -537,9 +537,9 @@ public final class InteractiveSnapshotExtractor {
 
     private static Map<String, Integer> counterMap(final Card card) {
         final Map<String, Integer> counters = new TreeMap<>();
-        for (final Map.Entry<CounterType, Integer> entry : card.getCounters().entrySet()) {
-            if (entry.getValue() > 0) {
-                counters.put(uiCounterName(entry.getKey()), entry.getValue());
+        for (final com.google.common.collect.Multiset.Entry<CounterType> entry : card.getCounters().entrySet()) {
+            if (entry.getCount() > 0) {
+                counters.put(uiCounterName(entry.getElement()), entry.getCount());
             }
         }
         return counters;

--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewEngineAdapter.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewEngineAdapter.java
@@ -78,7 +78,11 @@ public final class ManaBrewEngineAdapter {
         rules.setAppliedVariants(variants);
         rules.setSimTimeout(120);
 
-        ForgeEngineReset.resetAllIdCounters();
+        // Resetting global counters under a live session would collide its ids;
+        // multiplexed processes only reset between idle periods.
+        if (sessions.isEmpty()) {
+            ForgeEngineReset.resetAllIdCounters();
+        }
         final ManaBrewInteractiveSession session =
                 new ManaBrewInteractiveSession(request.getGameId());
         final List<RegisteredPlayer> registeredPlayers = new ArrayList<>();

--- a/manabrew-rs/crates/self-hosted-node/src/engine_backend/java_backend.rs
+++ b/manabrew-rs/crates/self-hosted-node/src/engine_backend/java_backend.rs
@@ -232,10 +232,17 @@ pub fn run_self_play(
 type SharedBridge = Arc<Mutex<SubprocessBridge>>;
 
 #[cfg(feature = "java-forge")]
+struct PoolSlot {
+    bridge: SharedBridge,
+    active: usize,
+}
+
+#[cfg(feature = "java-forge")]
 pub struct JavaEnginePool {
     config: JavaRuntimeConfig,
-    max_size: usize,
-    free: Mutex<Vec<SharedBridge>>,
+    max_sessions: usize,
+    sessions_per_process: usize,
+    slots: Mutex<Vec<PoolSlot>>,
     in_use: Mutex<HashMap<String, SharedBridge>>,
 }
 
@@ -247,18 +254,31 @@ pub struct JavaEngineHandle {
 
 #[cfg(feature = "java-forge")]
 impl JavaEnginePool {
-    pub fn start(config: &JavaRuntimeConfig, max_size: usize) -> Result<Arc<Self>, String> {
-        let max_size = max_size.max(1);
-        let mut free = Vec::with_capacity(max_size);
-        for slot in 0..max_size {
-            info!(slot, max_size, "pre-warming java subprocess");
+    pub fn start(
+        config: &JavaRuntimeConfig,
+        max_sessions: usize,
+        sessions_per_process: usize,
+    ) -> Result<Arc<Self>, String> {
+        let max_sessions = max_sessions.max(1);
+        let sessions_per_process = sessions_per_process.max(1);
+        let processes = max_sessions.div_ceil(sessions_per_process);
+        let mut slots = Vec::with_capacity(processes);
+        for slot in 0..processes {
+            info!(
+                slot,
+                processes, sessions_per_process, "pre-warming java subprocess"
+            );
             let bridge = SubprocessBridge::spawn(config)?;
-            free.push(Arc::new(Mutex::new(bridge)));
+            slots.push(PoolSlot {
+                bridge: Arc::new(Mutex::new(bridge)),
+                active: 0,
+            });
         }
         Ok(Arc::new(Self {
             config: config.clone(),
-            max_size,
-            free: Mutex::new(free),
+            max_sessions,
+            sessions_per_process,
+            slots: Mutex::new(slots),
             in_use: Mutex::new(HashMap::new()),
         }))
     }
@@ -273,9 +293,9 @@ impl JavaEnginePool {
 #[cfg(feature = "java-forge")]
 impl Drop for JavaEnginePool {
     fn drop(&mut self) {
-        let free = self.free.get_mut().map(std::mem::take).unwrap_or_default();
-        for bridge in free {
-            if let Ok(mutex) = Arc::try_unwrap(bridge) {
+        let slots = self.slots.get_mut().map(std::mem::take).unwrap_or_default();
+        for slot in slots {
+            if let Ok(mutex) = Arc::try_unwrap(slot.bridge) {
                 if let Ok(inner) = mutex.into_inner() {
                     inner.shutdown();
                 }
@@ -289,14 +309,22 @@ impl JavaEnginePool {
     fn acquire(&self) -> Result<SharedBridge, String> {
         let deadline = Instant::now() + Duration::from_secs(60);
         loop {
-            let popped = {
-                let mut free = self
-                    .free
+            let claimed = {
+                let mut slots = self
+                    .slots
                     .lock()
-                    .map_err(|_| "java engine free queue poisoned".to_string())?;
-                free.pop()
+                    .map_err(|_| "java engine slots poisoned".to_string())?;
+                let mut claimed = None;
+                for slot in slots.iter_mut() {
+                    if slot.active < self.sessions_per_process {
+                        slot.active += 1;
+                        claimed = Some(Arc::clone(&slot.bridge));
+                        break;
+                    }
+                }
+                claimed
             };
-            if let Some(bridge) = popped {
+            if let Some(bridge) = claimed {
                 let alive = bridge
                     .lock()
                     .ok()
@@ -306,18 +334,13 @@ impl JavaEnginePool {
                     return Ok(bridge);
                 }
                 warn!("discarding dead java subprocess from pool");
-                drop(bridge);
-                if let Ok(replacement) = SubprocessBridge::spawn(&self.config) {
-                    if let Ok(mut free) = self.free.lock() {
-                        free.push(Arc::new(Mutex::new(replacement)));
-                    }
-                }
+                self.replace_slot(&bridge);
                 continue;
             }
             if Instant::now() >= deadline {
                 return Err(format!(
-                    "java engine pool exhausted (max_size={}); no free subprocess after 60s",
-                    self.max_size
+                    "java engine pool exhausted (max_sessions={}); no free session slot after 60s",
+                    self.max_sessions
                 ));
             }
             std::thread::sleep(Duration::from_millis(50));
@@ -325,6 +348,22 @@ impl JavaEnginePool {
     }
 
     fn release(&self, bridge: SharedBridge) {
+        let now_idle = {
+            let mut slots = match self.slots.lock() {
+                Ok(slots) => slots,
+                Err(_) => return,
+            };
+            match slots.iter_mut().find(|s| Arc::ptr_eq(&s.bridge, &bridge)) {
+                Some(slot) => {
+                    slot.active = slot.active.saturating_sub(1);
+                    slot.active == 0
+                }
+                None => return,
+            }
+        };
+        if !now_idle {
+            return;
+        }
         let healthy = {
             let mut guard = match bridge.lock() {
                 Ok(guard) => guard,
@@ -332,21 +371,29 @@ impl JavaEnginePool {
             };
             guard.is_alive() && guard.reset().is_ok()
         };
-        if healthy {
-            if let Ok(mut free) = self.free.lock() {
-                free.push(bridge);
-                return;
-            }
+        if !healthy {
+            warn!("java subprocess unhealthy at idle; respawning");
+            self.replace_slot(&bridge);
         }
-        drop(bridge);
+    }
+
+    fn replace_slot(&self, dead: &SharedBridge) {
+        let Ok(mut slots) = self.slots.lock() else {
+            return;
+        };
+        let Some(index) = slots.iter().position(|s| Arc::ptr_eq(&s.bridge, dead)) else {
+            return;
+        };
         match SubprocessBridge::spawn(&self.config) {
             Ok(replacement) => {
-                if let Ok(mut free) = self.free.lock() {
-                    free.push(Arc::new(Mutex::new(replacement)));
-                }
+                slots[index] = PoolSlot {
+                    bridge: Arc::new(Mutex::new(replacement)),
+                    active: 0,
+                };
             }
             Err(error) => {
-                warn!(%error, "failed to respawn java subprocess after release");
+                warn!(%error, "failed to respawn java subprocess; retiring pool slot");
+                slots.remove(index);
             }
         }
     }
@@ -497,15 +544,22 @@ pub fn init_engine() -> Result<(), String> {
         return Ok(());
     }
     let config = JavaRuntimeConfig::from_env();
-    // SELF_HOSTED_NODE_MAX_GAMES doubles as the subprocess pool size: each room
-    // checks out one java subprocess for its lifetime, so the pool ceiling is
-    // also the concurrent-room ceiling for this node.
-    let max_size = env::var("SELF_HOSTED_NODE_MAX_GAMES")
+    // SELF_HOSTED_NODE_MAX_GAMES is the concurrent-session ceiling for this node.
+    // SELF_HOSTED_NODE_GAMES_PER_JVM multiplexes that many sessions into each
+    // subprocess (the engine is concurrency-safe since the endstep patches), so
+    // the pool spawns ceil(max_games / games_per_jvm) processes. Default 1 keeps
+    // the historical one-subprocess-per-game shape.
+    let max_sessions = env::var("SELF_HOSTED_NODE_MAX_GAMES")
         .ok()
         .and_then(|value| value.parse::<usize>().ok())
         .filter(|n| *n >= 1)
         .unwrap_or(1);
-    let pool = JavaEnginePool::start(&config, max_size)?;
+    let sessions_per_process = env::var("SELF_HOSTED_NODE_GAMES_PER_JVM")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|n| *n >= 1)
+        .unwrap_or(1);
+    let pool = JavaEnginePool::start(&config, max_sessions, sessions_per_process)?;
     JAVA_ENGINE
         .set(pool)
         .map_err(|_| "java engine already initialized".to_string())
@@ -754,7 +808,12 @@ pub fn run_concurrent_self_play(
     concurrency: usize,
 ) -> Result<(), String> {
     let config = JavaRuntimeConfig::from_env();
-    let pool = JavaEnginePool::start(&config, concurrency.max(1))?;
+    let games_per_process = env::var("SELF_HOSTED_NODE_GAMES_PER_JVM")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|n| *n >= 1)
+        .unwrap_or(1);
+    let pool = JavaEnginePool::start(&config, concurrency.max(1), games_per_process)?;
     info!(
         concurrency,
         "java-engine started; launching concurrent games"

--- a/manabrew-rs/crates/self-hosted-node/src/engine_backend/java_backend.rs
+++ b/manabrew-rs/crates/self-hosted-node/src/engine_backend/java_backend.rs
@@ -618,6 +618,11 @@ mod graal_ffi {
             thread: *mut *mut graal_isolatethread_t,
         ) -> c_int;
         pub fn graal_tear_down_isolate(thread: *mut graal_isolatethread_t) -> c_int;
+        pub fn graal_attach_thread(
+            isolate: *mut graal_isolate_t,
+            thread: *mut *mut graal_isolatethread_t,
+        ) -> c_int;
+        pub fn graal_detach_thread(thread: *mut graal_isolatethread_t) -> c_int;
         pub fn forge_initialize(
             thread: *mut graal_isolatethread_t,
             assets_dir: *const c_char,
@@ -667,13 +672,24 @@ struct ForgeReply {
     error: Option<String>,
 }
 
-// One GraalVM isolate hosts the in-process Forge engine. It is created on, and
-// confined to, the hosted-engine thread (isolate threads are not portable), so
-// the handle is Rc/!Send by design.
+// A GraalVM isolate hosts the in-process Forge engine. The `thread` handle is
+// bound to the hosted-engine thread that created or attached it (isolate
+// threads are not portable), so the handle is Rc/!Send by design. In shared
+// mode one isolate serves all rooms: the first creator initializes Forge, later
+// rooms attach their own thread to it and sessions coexist in the adapter.
 #[cfg(feature = "graal-forge")]
 struct GraalBridge {
     thread: *mut graal_ffi::graal_isolatethread_t,
+    attached: bool,
 }
+
+#[cfg(feature = "graal-forge")]
+struct SharedIsolate(*mut graal_ffi::graal_isolate_t);
+#[cfg(feature = "graal-forge")]
+unsafe impl Send for SharedIsolate {}
+
+#[cfg(feature = "graal-forge")]
+static SHARED_GRAAL_ISOLATE: std::sync::Mutex<Option<SharedIsolate>> = std::sync::Mutex::new(None);
 
 #[cfg(feature = "graal-forge")]
 impl GraalBridge {
@@ -686,7 +702,45 @@ impl GraalBridge {
         if rc != 0 {
             return Err(format!("graal_create_isolate failed with code {rc}"));
         }
-        Ok(Self { thread })
+        Ok(Self {
+            thread,
+            attached: false,
+        })
+    }
+
+    fn create_in_shared_isolate(assets_dir: &Path) -> Result<Self, String> {
+        let mut guard = SHARED_GRAAL_ISOLATE
+            .lock()
+            .map_err(|_| "shared graal isolate poisoned".to_string())?;
+        if let Some(shared) = guard.as_ref() {
+            let mut thread: *mut graal_ffi::graal_isolatethread_t = std::ptr::null_mut();
+            let rc = unsafe { graal_ffi::graal_attach_thread(shared.0, &mut thread) };
+            if rc != 0 {
+                return Err(format!("graal_attach_thread failed with code {rc}"));
+            }
+            return Ok(Self {
+                thread,
+                attached: true,
+            });
+        }
+        let mut isolate: *mut graal_ffi::graal_isolate_t = std::ptr::null_mut();
+        let mut thread: *mut graal_ffi::graal_isolatethread_t = std::ptr::null_mut();
+        let rc = unsafe {
+            graal_ffi::graal_create_isolate(std::ptr::null_mut(), &mut isolate, &mut thread)
+        };
+        if rc != 0 {
+            return Err(format!("graal_create_isolate failed with code {rc}"));
+        }
+        let mut bridge = Self {
+            thread,
+            attached: false,
+        };
+        let assets = cstring(&assets_dir.to_string_lossy())?;
+        bridge.decode(unsafe { graal_ffi::forge_initialize(bridge.thread, assets.as_ptr()) })?;
+        bridge.attached = true;
+        *guard = Some(SharedIsolate(isolate));
+        info!("shared graal isolate initialized");
+        Ok(bridge)
     }
 
     fn decode(&self, raw: *mut std::os::raw::c_char) -> Result<String, String> {
@@ -712,7 +766,11 @@ impl GraalBridge {
 #[cfg(feature = "graal-forge")]
 impl Drop for GraalBridge {
     fn drop(&mut self) {
-        unsafe { graal_ffi::graal_tear_down_isolate(self.thread) };
+        if self.attached {
+            unsafe { graal_ffi::graal_detach_thread(self.thread) };
+        } else {
+            unsafe { graal_ffi::graal_tear_down_isolate(self.thread) };
+        }
     }
 }
 
@@ -725,9 +783,21 @@ struct GraalEngineHandle {
 #[cfg(feature = "graal-forge")]
 impl GraalEngineHandle {
     fn create(assets_dir: &Path) -> Result<Self, String> {
-        let bridge = GraalBridge::create()?;
-        let assets = cstring(&assets_dir.to_string_lossy())?;
-        bridge.decode(unsafe { graal_ffi::forge_initialize(bridge.thread, assets.as_ptr()) })?;
+        // SELF_HOSTED_NODE_SHARED_ISOLATE=1 hosts every room's game in one
+        // isolate (safe since the endstep concurrency patches), so the card db
+        // loads once. Default keeps the historical isolate-per-game shape.
+        let shared = env::var("SELF_HOSTED_NODE_SHARED_ISOLATE")
+            .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        let bridge = if shared {
+            GraalBridge::create_in_shared_isolate(assets_dir)?
+        } else {
+            let bridge = GraalBridge::create()?;
+            let assets = cstring(&assets_dir.to_string_lossy())?;
+            bridge
+                .decode(unsafe { graal_ffi::forge_initialize(bridge.thread, assets.as_ptr()) })?;
+            bridge
+        };
         Ok(Self {
             bridge: std::rc::Rc::new(bridge),
         })
@@ -773,7 +843,7 @@ impl GraalEngineHandle {
 
     fn get_snapshot(&self, session_id: &str, viewer: Option<usize>) -> Result<String, String> {
         let session = cstring(session_id)?;
-        let viewer = viewer.map_or(-1, |v| v as c_int);
+        let viewer = viewer.map_or(-1, |v| v as std::os::raw::c_int);
         self.bridge.decode(unsafe {
             graal_ffi::forge_get_snapshot(self.bridge.thread, session.as_ptr(), viewer)
         })

--- a/manabrew-rs/crates/self-hosted-node/tests/hosted_smoke.rs
+++ b/manabrew-rs/crates/self-hosted-node/tests/hosted_smoke.rs
@@ -242,20 +242,10 @@ async fn play_game(
                             .all(|p| p.connected && p.ready && p.selected_deck_name.is_some())
                     {
                         sent_start = true;
-                        let start = StateEnvelope::RoomRelay {
-                            protocol: "self-hosted-node".to_string(),
-                            version: 1,
-                            message_id: uuid::Uuid::new_v4().to_string(),
-                            from_player: Some(username.clone()),
-                            target_player: None,
-                            room_id: Some(room_id.to_string()),
-                            payload: json!({ "type": "startGame", "format": "Standard" }),
-                        };
                         send(
                             &mut write,
-                            &ClientMessage::BroadcastState {
-                                state: serde_json::to_value(&start).map_err(|e| e.to_string())?,
-                                target_player: None,
+                            &ClientMessage::StartGame {
+                                format: Some(GameFormat::Standard),
                             },
                         )
                         .await?;
@@ -295,7 +285,7 @@ fn basic_deck(name: &str, land: &str, creature: &str) -> Value {
 }
 
 fn card(id: String, name: &str) -> Value {
-    json!({ "id": id, "name": name, "setCode": "", "cardNumber": "0" })
+    json!({ "identity": { "id": id, "name": name, "setCode": "", "cardNumber": "0" } })
 }
 
 async fn connect(relay: &str) -> Result<(WsWrite, WsRead), String> {


### PR DESCRIPTION
## Summary

- Make `ForgeEngineReset` honest. The reflection reset swallowed every failure: on the patched engine it warned to stderr and did nothing (it cannot `setInt` a `static final AtomicInteger`), and on the staging pin it had been "resetting" `IndividualCostPaymentInstance` — a class upstream deleted in Card-Forge#10980 — without anyone noticing. It now handles both counter shapes, reads every counter back after zeroing, and throws on any absent class, absent field, unknown shape, or failed verify. Callers already treat a failed reset as an unusable process (the pool respawns it), so a lying reset becomes a loud respawn instead of silent cross-game id corruption. The hardened version caught a second live bug on its first stress run: `ManaBrewEngineAdapter.startGame` reset the global counters on every game start, which under multiplexing would zero them beneath games already in flight; it now resets only when no sessions are live.
- Pin the forge submodule to `witchesofthehill/forge@manabrew-staging`: latest upstream master (242 commits, includes Card-Forge#11203 GameCopier state-fidelity fixes) merged with the Endstep concurrency patch series (16-24): atomic id counters, concurrent shared caches, thread-local AI state, an overridable priority-loop cap, a per-turn runaway cap that force-ends the game as a draw, and a mana-pool persistence fix. Patch source: [Neur0nz/endstep-forge-patches](https://github.com/Neur0nz/endstep-forge-patches); only the format-agnostic concurrency fixes are included. Upstream un-staticked `Match.removedCards`, superseding patch 17's fix for it; #11203's `dangerouslySyncCardIdCounters` uses instance counters and does not touch the patched statics.
- Adapt `forge-harness` to the upstream API drift: counters are a Guava `Multiset` now, `ICostVisitor` grew `CostPutCounterYou`, and `IGuiBase.refreshSkin` is gone.
- Add session multiplexing to the node's JVM pool. `SELF_HOSTED_NODE_GAMES_PER_JVM` (default 1, no behavior change) packs that many concurrent games into each subprocess; the pool spawns `ceil(max_games / games_per_jvm)` processes, tracks per-slot session counts, and only sends `reset` to an idle subprocess.
- Add a shared-isolate mode to the graal backend. `SELF_HOSTED_NODE_SHARED_ISOLATE=1` (default off) hosts every room's game in one GraalVM isolate: the first room creates and initializes it, later rooms attach via `graal_attach_thread`, so the card db loads once. Also fixes a latent compile error in the graal feature (`c_int` out of scope) that CI never catches because it does not build graal features.
- Default the staging node to multiplexed concurrency: `MAX_GAMES=4`, `GAMES_PER_JVM=4` (one engine process for all staging slots), `SHARED_ISOLATE=1` (inert on the current java-forge image, effective if the image flips to graal), memory limit raised to 2g accordingly.
- Repair the hosted smoke test: deck cards use the identity wire shape, and the game starts via the relay `StartGame` message sent as the room controller.

## Why

The engine can now run multiple concurrent games in one JVM or one Graal isolate, and the knobs turn that into operations. All measured on this exact pin with the real e2e path (relay, websocket clients, bots):

| Shape | Games | Engine processes | Peak RSS | Wall | Result |
| --- | --- | --- | --- | --- | --- |
| Today (`GAMES_PER_JVM=1`) | 10 | 10 JVMs | 8.37 GB | 80s | 10/10 |
| Multiplexed | 10 | 1 JVM | 1.12 GB | 39s | 10/10 |
| Multiplexed | 40 | 4 JVMs | 5.1 GB | 62s | 40/40 |
| Multiplexed | 40 | 1 JVM | 3.5 GB | 112s | 40/40 |
| Graal shared isolate | 40 | 1 process | 2.45 GB | 110s | 40/40 |

The head-to-head control (rows 1-2, identical workload) shows the current process-per-game shape is strictly dominated: 7.5x the memory and 2x the wall for the same games. The graal shared isolate is the leanest configuration overall and also serves the Tauri desktop default backend, where the win is skipping repeated card-db loads between games rather than concurrency.

Patch 24 also protects single-game nodes today: a runaway turn (25k trigger fires or card creations) ends as a draw instead of hanging the room. Related history: #377, #419.

### Determinism under multiplexing

Patch 16 makes the id counters monotonic for the process lifetime, and our determinism story assumed games start from known counter values. The contract after this PR: a game is reproducible by seed whenever it starts on an idle process (the pool resets and verifies counters between idle periods), and games running concurrently in one process are not reproducible by seed, because they interleave on the shared id sequence. Measured, not assumed: same seed on a cold JVM vs a warm JVM that had already played a different game produced byte-identical traces (timestamps aside). Parity tooling keeps its guarantees because it runs one game per process; hosted games never needed seed-replay.

### Follow-up

Three codebases now maintain the same workaround for Forge's private static id counters (this fork, Endstep's patches, and #11203's snapshot sync brushes against it). An official counter-reset/counter-scope API upstream would retire the reflection entirely; worth raising with Tyrathalis as a joint proposal.

## Test plan

- `yarn parity:test` passes on the staging pin with the hardened reset, 0 divergences against the Rust engine.
- Fleet stress and controls: see the table above; every row is a completed hosted_play_vs_ai_smoke run on this pin, including the 40-game graal shared-isolate round (isolate initialized once, 40 sessions attached).
- The hardened reset's read-back verification is exercised on every reset in those runs; its throw path was proven live when it exposed the deleted-class and reset-under-live-sessions bugs during round one of the stress.
- Cold-vs-warm same-seed trace comparison: identical (see determinism section).
- `hosted_play_vs_ai_smoke` 2-game rounds pass on both backends with both knobs on and off; `GAMES_PER_JVM=2` spawned exactly one subprocess and survived a second round through the same JVM after the idle reset; `SHARED_ISOLATE=1` initialized the isolate once and attached the second room.
- Single-game latency is unchanged vs the unpatched engine (4-seed benchmark, ~1% delta, within noise).
