### PR TITLE
fix(server): read game outcome from the nested gameView envelope

### DIFF
--- a/manabrew-rs/crates/manabrew-server/src/replay.rs
+++ b/manabrew-rs/crates/manabrew-server/src/replay.rs
@@ -92,18 +92,21 @@ impl GameReplayCache {
     }
 
     fn observe_outcome(&mut self, envelope: &Value) {
-        let Some(state) = envelope.get("state") else {
+        let Some(game_view) = envelope
+            .get("state")
+            .and_then(|state| state.get("gameView"))
+        else {
             return;
         };
-        if state.get("gameOver").and_then(Value::as_bool) != Some(true) {
+        if game_view.get("gameOver").and_then(Value::as_bool) != Some(true) {
             return;
         }
         self.outcome.game_over = true;
-        self.outcome.winner_slot = state
+        self.outcome.winner_slot = game_view
             .get("winnerId")
             .and_then(Value::as_str)
             .map(str::to_string);
-        if let Some(players) = state.get("players").and_then(Value::as_array) {
+        if let Some(players) = game_view.get("players").and_then(Value::as_array) {
             self.outcome.conceded_slots = players
                 .iter()
                 .filter(|player| player.get("status").and_then(Value::as_str) == Some("conceded"))


### PR DESCRIPTION
## Summary

- Read `gameOver` / `winnerId` / `players` from `state.gameView` instead of `state` in `GameReplayCache::observe_outcome`.

## Why

The relay never recorded a single game outcome. `observe_outcome` peeked one nesting level too shallow: the broadcast envelope is `{kind: "state", state: StateUpdate}`, and `StateUpdate` serialises to `{"gameView": {...}}`, so `gameOver`, `winnerId` and the per-player `status` all live under `state.gameView`, not `state`. The lookup silently returned `None` on every state broadcast, so `outcome.game_over` stayed `false` for the entire lifetime of every game.

The downstream effect is in `analytics::emit_game_ended`, which picks its `GameEndReason` from `replay.outcome.game_over`. With that flag never set, a natural win fell through to the caller's fallback reason and `winner` was always `null`. In production every game since the relay analytics went live records `host_ended` / `abandoned` / `host_lost` and never `game_over`, which makes win rate and completion rate unusable.

This was previously read as a regression from the forced-end change in #377. It is not — the last `game_over=1` row in `events.db` (2026-07-06T10:49:59) is the cutoff of the historical backfill, not a behaviour change. This code path has never worked against live relay traffic.

Fixes #360.

No protocol or wire change: the envelope shape is unchanged and always had `gameView`: only the relay's reader was wrong. Nothing needs to ship in lockstep on the node or client side.

## Test plan

- `cargo check -p manabrew-server`, `cargo fmt -p manabrew-server -- --check` clean. (`cargo clippy` fails on pre-existing `large_enum_variant` drift in `manabrew-protocol`, unrelated to this change.)
- Replayed 315 real production capture files (`2026-07-15`, `2026-07-17`) and counted games whose state stream contains a terminal `gameOver: true`:

  | Day | Games | `state.gameOver` (before) | `state.gameView.gameOver` (after) | `winnerId` present |
  | --- | --- | --- | --- | --- |
  | 2026-07-15 | 183 | 0 | 120 | 119 |
  | 2026-07-17 | 132 | 0 | 95 | 95 |

- Drove `observe_outcome` with a verbatim game-over envelope lifted from a production capture: `game_over` is set and `winner_slot` resolves through `username_for_slot` to the winning player. Confirmed the same input fails on the pre-fix lookup, so the check discriminates rather than passing vacuously.

Historical data is recoverable: the capture files retain the full `gameView`, so the ~1,900 affected games can be backfilled into `events.db` without replaying anything.
