### PR TITLE
fix(ops): restore staging tls edge

### DIFF
--- a/ops/Caddyfile
+++ b/ops/Caddyfile
@@ -190,6 +190,22 @@ api.manabrew.app {
     }
 }
 
+# Staging slot (compose.staging.yml under /opt/manabrew-staging, same docker
+# network) — deployed from the `staging` branch by staging-deploy.yml. 502s
+# while the slot is down.
+staging.manabrew.app {
+    reverse_proxy manabrew-staging:80
+}
+
+relay-staging.manabrew.app {
+    reverse_proxy manabrew-server-staging:9443 {
+        health_uri /health
+        health_port 9444
+        health_interval 15s
+        health_timeout 3s
+    }
+}
+
 # Observability ingress (`observability` compose profile). PUSHGATEWAY_PASSWORD_HASH
 # unset → the placeholder default matches no password: locked, not broken config.
 grafana.manabrew.app {


### PR DESCRIPTION
## Summary

- add production Caddy vhosts for `staging.manabrew.app` and `relay-staging.manabrew.app`
- proxy the staging app and relay to their services on the shared production Docker network

## Why

The staging stack moved onto the production box in `6b41f0029`, but its Caddy vhosts only landed on the `staging` branch. Production deploys load `ops/Caddyfile` from `main`, so Caddy treats both staging hostnames as unknown SNI names and aborts TLS without presenting a certificate.

Landing these vhosts on `main` lets production Caddy issue certificates and route traffic to the already-healthy staging containers.

## Test plan

- `docker run --rm -v "$PWD/ops/Caddyfile:/etc/caddy/Caddyfile:ro" caddy:2 caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile`
- `git diff --check`
- confirmed `ops/Caddyfile` matches the staging branch edge configuration
- `yarn lint:all` passes frontend lint, formatting, and typecheck; repository-wide clippy remains blocked by the pre-existing `unused_mut` warning in `manabrew-rs/crates/forge-foundation/src/phase.rs:127` on `origin/main`