### PR TITLE
ci(staging): restore the staging slot topology on the prod box

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,8 +1,16 @@
 name: Staging deploy
 
-# Deploys the `staging` branch to staging.manabrew.app — a staging slot on the
-# PRODUCTION box (/opt/manabrew-staging, compose.staging.yml on the prod docker
-# network, fronted by prod Caddy's staging.manabrew.app / relay-staging vhosts):
+# Label-gated: a PR labelled `deploy-preview` takes the staging slot, the way
+# per-PR previews worked before #470 turned this into a branch auto-deploy.
+# Pushes to `staging` no longer deploy on their own — run this workflow from the
+# Actions tab (workflow_dispatch) to put the `staging` branch back on the slot.
+# There is ONE slot, so labelling a second PR replaces whatever is on it; the
+# slot is never torn down, it just holds the last thing deployed. Only the
+# `staging` branch gets a hosted-AI node (see deploy-staging.sh).
+#
+# Deploys to staging.manabrew.app — a staging slot on the PRODUCTION box
+# (/opt/manabrew-staging, compose.staging.yml on the prod docker network,
+# fronted by prod Caddy's staging.manabrew.app / relay-staging vhosts):
 #   1. build + push the self-hosting images tagged `staging` to ghcr
 #      (docker-images.yml does the same on v* tags for the release `latest`
 #      images),
@@ -21,13 +29,13 @@ name: Staging deploy
 # The optional standalone VM is not CI-driven: run deploy-local.sh on the VM
 # itself (compose.selfhost.yml — self-contained, builds from the checkout).
 on:
-  push:
-    branches: [staging]
+  pull_request:
+    types: [labeled, synchronize, reopened]
   workflow_dispatch:
 
 concurrency:
-  group: staging-deploy
-  cancel-in-progress: false
+  group: staging-deploy-${{ github.event.pull_request.number || 'manual' }}
+  cancel-in-progress: true
 
 jobs:
   # ── Build & push the :staging images ───────────────────────────────
@@ -36,9 +44,17 @@ jobs:
   # The web image bakes the hub endpoint (from the STAGING_HUB_API_URL repo
   # variable) and the same-origin symbol proxy; the relay is configured at
   # runtime (compose RELAY_HOST), like prod.
+  # Fork PRs are skipped: they get neither a package-write token nor the SSH
+  # secrets for the prod box.
   build-images:
     name: Build & push ${{ matrix.image }} (staging tag)
-    if: github.repository == 'witchesofthehill/manabrew'
+    if: |
+      github.repository == 'witchesofthehill/manabrew'
+      && (github.event_name == 'workflow_dispatch'
+          || (github.event.pull_request.head.repo.full_name == github.repository
+              && ((github.event.action == 'labeled' && github.event.label.name == 'deploy-preview')
+                  || (contains(fromJSON('["synchronize","reopened"]'), github.event.action)
+                      && contains(github.event.pull_request.labels.*.name, 'deploy-preview')))))
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
@@ -60,8 +76,11 @@ jobs:
           - image: manabrew-hub
             dockerfile: manabrew-rs/crates/manabrew-hub/Dockerfile
     steps:
+      # Build the PR head, not the pull_request merge commit — deploy-staging.sh
+      # checks the head branch out on the box, so the two must agree.
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
           submodules: recursive
 
       - name: Set up Docker Buildx
@@ -112,6 +131,11 @@ jobs:
           HOST: ${{ secrets.DEPLOY_HOST }}
           USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_STAGING_PATH || '/opt/manabrew-staging' }}
+          # The PR's head branch, so the box checks out what the images were
+          # built from. Empty on workflow_dispatch → deploy-staging.sh falls
+          # back to its `staging` default, which is also the only branch that
+          # gets a hosted-AI node.
+          DEPLOY_BRANCH: ${{ github.event.pull_request.head.ref }}
           # Synced into the slot's .env below. MANABREW_SERVER_KEY is included
           # because the slot's .env is standalone — it must NOT symlink prod's
           # secrets file. The STAGING_OAUTH_GITHUB_* names avoid GitHub
@@ -153,7 +177,7 @@ jobs:
               -o ServerAliveInterval=30 \
               -o ServerAliveCountMax=120 \
               "$USER@$HOST" \
-            "cd '$DEPLOY_PATH' && ./deploy-staging.sh 2>&1" 2>&1 | tee deploy.log
+            "cd '$DEPLOY_PATH' && DEPLOY_BRANCH='$DEPLOY_BRANCH' ./deploy-staging.sh 2>&1" 2>&1 | tee deploy.log
           exit ${PIPESTATUS[0]}
 
       - name: Fetch raw deploy log on failure

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,25 +1,25 @@
 name: Staging deploy
 
-# Deploys the `staging` branch to the dedicated staging VM, a standalone
-# mini-production that behaves exactly like the production rollout:
-#   1. build + push the four self-hosting images tagged `staging` to ghcr
+# Deploys the `staging` branch to staging.manabrew.app — a staging slot on the
+# PRODUCTION box (/opt/manabrew-staging, compose.staging.yml on the prod docker
+# network, fronted by prod Caddy's staging.manabrew.app / relay-staging vhosts):
+#   1. build + push the self-hosting images tagged `staging` to ghcr
 #      (docker-images.yml does the same on v* tags for the release `latest`
 #      images),
-#   2. connect to Twingate (the VM only accepts SSH through Twingate — no public
-#      SSH), then SSH in and run deploy-staging.sh — the lean sibling of
-#      production's deploy.sh (pull branch + :staging images + health-checked
-#      recreate + rollback, without the release/manifest machinery).
+#   2. SSH into the prod box (same DEPLOY_* secrets as publish.yml) and run
+#      deploy-staging.sh — the lean sibling of production's deploy.sh (pull
+#      branch + :staging images + health-checked recreate + rollback).
 #
-# No hostname is hardcoded here. The one build-time endpoint (the hub API URL
-# baked into the web bundle) comes from the repo variable STAGING_HUB_API_URL;
-# every other host is runtime and lives in the box .env (STAGING_APP_HOST /
-# STAGING_RELAY_HOST / STAGING_API_HOST), so the domain can change without
-# touching this workflow.
+# The web bundle bakes VITE_HUB_API_URL from the repo variable
+# STAGING_HUB_API_URL (= https://staging.manabrew.app).
 #
-# The staging VM is a separate machine reached via Twingate (TWINGATE_SERVICE_KEY
-# service-account key) with its own SSH key (STAGING_DEPLOY_* secrets). It needs
-# the repo checked out at STAGING_DEPLOY_PATH on the `staging` branch with a
-# box-local .env (MANABREW_SERVER_KEY, the STAGING_*_HOST trio, …).
+# The staging slot's /opt/manabrew-staging/.env is written by this workflow's
+# secret-sync step (MANABREW_SERVER_KEY + hub auth secrets) — it must NOT be a
+# symlink to prod's ops/production.secrets, so the slot never inherits prod's
+# OAuth apps or hub config.
+#
+# The optional standalone VM is not CI-driven: run deploy-local.sh on the VM
+# itself (compose.selfhost.yml — self-contained, builds from the checkout).
 on:
   push:
     branches: [staging]
@@ -86,17 +86,17 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}
 
-  # ── Deploy to the staging VM (over Twingate) ───────────────────────
-  # Connects the runner to Twingate with a service-account key, then runs the
-  # lean deploy-staging.sh over SSH (pull branch + :staging images + health-
-  # checked recreate + rollback — no production release machinery).
+  # ── Deploy the staging slot on the prod box ────────────────────────
+  # Direct SSH with the production deploy key, then runs the lean
+  # deploy-staging.sh in /opt/manabrew-staging (pull branch + :staging images +
+  # health-checked recreate + rollback — no production release machinery).
   deploy:
     name: Deploy staging
     needs: [build-images]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     concurrency:
-      group: staging-vm-deploy
+      group: staging-box-deploy
       cancel-in-progress: false
     steps:
       # The composite Discord action needs the repo present.
@@ -104,26 +104,22 @@ jobs:
         with:
           sparse-checkout: .github
 
-      # The VM only accepts SSH through Twingate; the connection stays up for the
-      # rest of the job, so the SSH step below reaches the internal host.
-      - name: Connect to Twingate
-        uses: twingate/github-action@v1
-        with:
-          service-key: ${{ secrets.TWINGATE_SERVICE_KEY }}
-
       - name: SSH and run deploy-staging.sh
         id: deploy
         continue-on-error: true
         env:
-          SSH_KEY: ${{ secrets.STAGING_DEPLOY_SSH_KEY }}
-          HOST: ${{ secrets.STAGING_DEPLOY_HOST }}
-          USER: ${{ secrets.STAGING_DEPLOY_USER }}
-          DEPLOY_PATH: ${{ secrets.STAGING_DEPLOY_PATH }}
-          # Hub auth (accounts) secrets, synced into the box .env below. The
-          # STAGING_OAUTH_GITHUB_* names avoid GitHub Actions' reserved GITHUB_
-          # secret prefix; on the box they land under the hub's env names. An
-          # unset secret leaves the box .env untouched for that key, so a
-          # provider stays off until its app is registered.
+          SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          HOST: ${{ secrets.DEPLOY_HOST }}
+          USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_STAGING_PATH || '/opt/manabrew-staging' }}
+          # Synced into the slot's .env below. MANABREW_SERVER_KEY is included
+          # because the slot's .env is standalone — it must NOT symlink prod's
+          # secrets file. The STAGING_OAUTH_GITHUB_* names avoid GitHub
+          # Actions' reserved GITHUB_ secret prefix; on the box they land under
+          # the hub's env names. An unset secret leaves the .env untouched for
+          # that key, so a provider stays off until its app is registered.
+          AUTH_MANABREW_SERVER_KEY: ${{ secrets.MANABREW_SERVER_KEY }}
+          AUTH_HUB_ADMIN_PASSWORD_HASH: ${{ secrets.HUB_ADMIN_PASSWORD_HASH }}
           AUTH_GITHUB_CLIENT_ID: ${{ secrets.STAGING_OAUTH_GITHUB_CLIENT_ID }}
           AUTH_GITHUB_CLIENT_SECRET: ${{ secrets.STAGING_OAUTH_GITHUB_CLIENT_SECRET }}
           AUTH_DISCORD_CLIENT_ID: ${{ secrets.STAGING_OAUTH_DISCORD_CLIENT_ID }}
@@ -137,6 +133,8 @@ jobs:
           ssh-keyscan -H "$HOST" >> ~/.ssh/known_hosts 2>/dev/null
           AUTH_ENV=""
           add_auth() { if [ -n "$2" ]; then AUTH_ENV="${AUTH_ENV}$1=$2"$'\n'; fi; }
+          add_auth MANABREW_SERVER_KEY "$AUTH_MANABREW_SERVER_KEY"
+          add_auth HUB_ADMIN_PASSWORD_HASH "$AUTH_HUB_ADMIN_PASSWORD_HASH"
           add_auth GITHUB_CLIENT_ID "$AUTH_GITHUB_CLIENT_ID"
           add_auth GITHUB_CLIENT_SECRET "$AUTH_GITHUB_CLIENT_SECRET"
           add_auth DISCORD_CLIENT_ID "$AUTH_DISCORD_CLIENT_ID"
@@ -146,7 +144,7 @@ jobs:
             printf '%s' "$AUTH_ENV" | ssh -i ~/.ssh/deploy_key \
                 -o StrictHostKeyChecking=yes \
                 "$USER@$HOST" \
-              "cd '$DEPLOY_PATH' && touch .env && while IFS= read -r line; do key=\${line%%=*}; { grep -v \"^\${key}=\" .env || true; } > .env.tmp; mv .env.tmp .env; printf '%s\n' \"\$line\" >> .env; done"
+              "cd '$DEPLOY_PATH' && { [ -L .env ] && rm .env || true; } && touch .env && chmod 600 .env && while IFS= read -r line; do key=\${line%%=*}; { grep -v \"^\${key}=\" .env || true; } > .env.tmp; mv .env.tmp .env; printf '%s\n' \"\$line\" >> .env; done && chmod 600 .env"
           fi
           # ServerAliveInterval/CountMax keep the SSH connection healthy while
           # deploy-staging.sh has quiet stretches (docker pulls, ghcr retry sleeps).
@@ -161,8 +159,8 @@ jobs:
       - name: Fetch raw deploy log on failure
         if: steps.deploy.outcome != 'success'
         env:
-          HOST: ${{ secrets.STAGING_DEPLOY_HOST }}
-          USER: ${{ secrets.STAGING_DEPLOY_USER }}
+          HOST: ${{ secrets.DEPLOY_HOST }}
+          USER: ${{ secrets.DEPLOY_USER }}
         continue-on-error: true
         run: |
           set -euo pipefail

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -119,12 +119,35 @@ jobs:
           HOST: ${{ secrets.STAGING_DEPLOY_HOST }}
           USER: ${{ secrets.STAGING_DEPLOY_USER }}
           DEPLOY_PATH: ${{ secrets.STAGING_DEPLOY_PATH }}
+          # Hub auth (accounts) secrets, synced into the box .env below. The
+          # STAGING_OAUTH_GITHUB_* names avoid GitHub Actions' reserved GITHUB_
+          # secret prefix; on the box they land under the hub's env names. An
+          # unset secret leaves the box .env untouched for that key, so a
+          # provider stays off until its app is registered.
+          AUTH_GITHUB_CLIENT_ID: ${{ secrets.STAGING_OAUTH_GITHUB_CLIENT_ID }}
+          AUTH_GITHUB_CLIENT_SECRET: ${{ secrets.STAGING_OAUTH_GITHUB_CLIENT_SECRET }}
+          AUTH_DISCORD_CLIENT_ID: ${{ secrets.STAGING_OAUTH_DISCORD_CLIENT_ID }}
+          AUTH_DISCORD_CLIENT_SECRET: ${{ secrets.STAGING_OAUTH_DISCORD_CLIENT_SECRET }}
+          AUTH_RESEND_API_KEY: ${{ secrets.STAGING_RESEND_API_KEY }}
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh
           printf '%s\n' "$SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H "$HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          AUTH_ENV=""
+          add_auth() { if [ -n "$2" ]; then AUTH_ENV="${AUTH_ENV}$1=$2"$'\n'; fi; }
+          add_auth GITHUB_CLIENT_ID "$AUTH_GITHUB_CLIENT_ID"
+          add_auth GITHUB_CLIENT_SECRET "$AUTH_GITHUB_CLIENT_SECRET"
+          add_auth DISCORD_CLIENT_ID "$AUTH_DISCORD_CLIENT_ID"
+          add_auth DISCORD_CLIENT_SECRET "$AUTH_DISCORD_CLIENT_SECRET"
+          add_auth RESEND_API_KEY "$AUTH_RESEND_API_KEY"
+          if [ -n "$AUTH_ENV" ]; then
+            printf '%s' "$AUTH_ENV" | ssh -i ~/.ssh/deploy_key \
+                -o StrictHostKeyChecking=yes \
+                "$USER@$HOST" \
+              "cd '$DEPLOY_PATH' && touch .env && while IFS= read -r line; do key=\${line%%=*}; { grep -v \"^\${key}=\" .env || true; } > .env.tmp; mv .env.tmp .env; printf '%s\n' \"\$line\" >> .env; done"
+          fi
           # ServerAliveInterval/CountMax keep the SSH connection healthy while
           # deploy-staging.sh has quiet stretches (docker pulls, ghcr retry sleeps).
           ssh -i ~/.ssh/deploy_key \

--- a/compose.production.yml
+++ b/compose.production.yml
@@ -84,6 +84,16 @@ services:
       HUB_DB_PATH: "/var/manabrew/hub/hub.db"
       EVENTS_DB_PATH: "/var/manabrew/events/events.db"
       RUST_LOG: "manabrew_hub=info"
+      # Auth (/api/auth/*). Client ids/secrets live in ops/production.secrets;
+      # an unset client id disables that provider. No RESEND_API_KEY →
+      # magic-link codes are logged instead of emailed.
+      HUB_PUBLIC_URL: "https://api.manabrew.app"
+      WEB_APP_URL: "https://play.manabrew.app"
+      GITHUB_CLIENT_ID: "${GITHUB_CLIENT_ID:-}"
+      GITHUB_CLIENT_SECRET: "${GITHUB_CLIENT_SECRET:-}"
+      DISCORD_CLIENT_ID: "${DISCORD_CLIENT_ID:-}"
+      DISCORD_CLIENT_SECRET: "${DISCORD_CLIENT_SECRET:-}"
+      RESEND_API_KEY: "${RESEND_API_KEY:-}"
     volumes:
       - ./ops/hub-data:/var/manabrew/hub
       - ./ops/observability/data/events:/var/manabrew/events:ro

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -38,6 +38,7 @@ services:
       RELAY_PASSWORD: "${MANABREW_SERVER_KEY:?MANABREW_SERVER_KEY is required}"
       HOSTED_AI_ENABLED: "${HOSTED_AI_ENABLED:-true}"
       DESIGN_SYSTEM: "${DESIGN_SYSTEM:-}"
+      HUB_API_URL: "https://${STAGING_API_HOST}"
     depends_on:
       - manabrew-server
 
@@ -79,6 +80,16 @@ services:
       HUB_DB_PATH: "/var/manabrew/hub/hub.db"
       EVENTS_DB_PATH: "/var/manabrew/events/events.db"
       RUST_LOG: "manabrew_hub=info"
+      # Auth (/api/auth/*). OAuth apps need callbacks on the staging api host;
+      # unset client ids disable that provider. No RESEND_API_KEY → magic-link
+      # codes are logged instead of emailed.
+      HUB_PUBLIC_URL: "https://${STAGING_API_HOST:?STAGING_API_HOST is required}"
+      WEB_APP_URL: "https://${STAGING_APP_HOST:?STAGING_APP_HOST is required}"
+      GITHUB_CLIENT_ID: "${GITHUB_CLIENT_ID:-}"
+      GITHUB_CLIENT_SECRET: "${GITHUB_CLIENT_SECRET:-}"
+      DISCORD_CLIENT_ID: "${DISCORD_CLIENT_ID:-}"
+      DISCORD_CLIENT_SECRET: "${DISCORD_CLIENT_SECRET:-}"
+      RESEND_API_KEY: "${RESEND_API_KEY:-}"
     volumes:
       - ./ops/hub-data:/var/manabrew/hub
       - ./ops/observability/data/events:/var/manabrew/events:ro

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -25,6 +25,7 @@ services:
       - "80"
     volumes:
       - ./ops/staging.Caddyfile:/etc/caddy/Caddyfile:ro
+    mem_limit: 128m
     depends_on:
       - manabrew-server-staging
 
@@ -42,8 +43,8 @@ services:
       - "9443"
       - "9444"
     restart: unless-stopped
-    mem_limit: 1g
-    cpus: 1.5
+    mem_limit: 512m
+    cpus: 1.0
     stop_grace_period: 30s
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:9444/health"]
@@ -89,6 +90,8 @@ services:
       SELF_HOSTED_NODE_MAX_PLAYERS: "${SELF_HOSTED_NODE_MAX_PLAYERS:-4}"
       SELF_HOSTED_NODE_MAX_GAMES: "${SELF_HOSTED_NODE_MAX_GAMES:-1}"
       RUST_LOG: "self_hosted_node=info"
+    mem_limit: 1g
+    cpus: 1.0
     depends_on:
       - manabrew-server-staging
     restart: unless-stopped

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -1,49 +1,34 @@
-# Staging stack — a standalone mini-production on the staging VM, tracking the
-# `staging` branch. Driven by .github/workflows/staging-deploy.yml, which builds
-# the `:staging` images in CI and rolls them out with the SAME deploy.sh as
-# production (DEPLOY_BRANCH=staging MANABREW_IMAGE_TAG=staging
-# COMPOSE_FILE=compose.staging.yml). It mirrors compose.production.yml service
-# for service; the only deltas are the default image tag (`staging`) and the
-# hostnames — which are NOT baked in: the app / relay / api hosts come from the
-# box .env (STAGING_APP_HOST / STAGING_RELAY_HOST / STAGING_API_HOST), consumed
-# by ops/staging.Caddyfile ({$...}) and the web runtime relay config. So moving
-# the stack to another domain is a .env edit, no code change.
+# Staging stack — tracks the `staging` branch, runs on the PRODUCTION box under
+# /opt/manabrew-staging and joins the prod docker network so the prod Caddy
+# (ops/Caddyfile) fronts it at staging.manabrew.app / relay-staging.manabrew.app.
+# Driven by .github/workflows/staging-deploy.yml over direct SSH via
+# deploy-staging.sh.
+#
+# No published ports: prod Caddy owns 80/443 on the box. Every service name
+# carries a -staging suffix because it shares docker DNS with the prod project.
+# Secrets come from /opt/manabrew-staging/.env, written by the workflow's
+# secret sync — never from prod's ops/production.secrets.
 services:
-  manabrew:
+  manabrew-staging:
     image: ghcr.io/witchesofthehill/manabrew-web:${MANABREW_IMAGE_TAG:-staging}
     restart: unless-stopped
-    # Caddy resolves cards./svgs.scryfall.io per proxied request; the deck-cover
-    # prefetch fires dozens at once, and Docker's embedded resolver forwarding to
-    # a constrained DNS drops that burst (dial tcp: lookup … i/o timeout → 502).
-    # Pin public resolvers so the Scryfall proxies survive the burst.
-    dns:
-      - 1.1.1.1
-      - 8.8.8.8
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - ./ops/staging.Caddyfile:/etc/caddy/Caddyfile:ro
-      - caddy-data:/data
-      - caddy-config:/config
     environment:
       HUB_ADMIN_PASSWORD_HASH:
-      # Caddy ({$...} in staging.Caddyfile) reads these for the site addresses
-      # + ACME certs; RELAY_HOST reuses the relay one for the app's config.js.
-      STAGING_APP_HOST: "${STAGING_APP_HOST:?STAGING_APP_HOST is required}"
-      STAGING_RELAY_HOST: "${STAGING_RELAY_HOST:?STAGING_RELAY_HOST is required}"
-      STAGING_API_HOST: "${STAGING_API_HOST:?STAGING_API_HOST is required}"
-      RELAY_HOST: "${STAGING_RELAY_HOST}"
+      RELAY_HOST: "relay-staging.manabrew.app"
       RELAY_PORT: "443"
       RELAY_PASSWORD: "${MANABREW_SERVER_KEY:?MANABREW_SERVER_KEY is required}"
       HOSTED_AI_ENABLED: "${HOSTED_AI_ENABLED:-true}"
-      DESIGN_SYSTEM: "${DESIGN_SYSTEM:-}"
-      # Hub API is same-origin on staging (path-routed on the app host).
-      HUB_API_URL: "https://${STAGING_APP_HOST}"
+      DESIGN_SYSTEM: "${DESIGN_SYSTEM:-1}"
+      # Hub API is same-origin (path-routed in ops/staging.Caddyfile).
+      HUB_API_URL: "https://staging.manabrew.app"
+    expose:
+      - "80"
+    volumes:
+      - ./ops/staging.Caddyfile:/etc/caddy/Caddyfile:ro
     depends_on:
-      - manabrew-server
+      - manabrew-server-staging
 
-  manabrew-server:
+  manabrew-server-staging:
     image: ghcr.io/witchesofthehill/manabrew-server:${MANABREW_IMAGE_TAG:-staging}
     environment:
       FORGE_HOST: "0.0.0.0"
@@ -53,12 +38,6 @@ services:
       MANABREW_SERVER_KEY: "${MANABREW_SERVER_KEY:?MANABREW_SERVER_KEY is required}"
       SECRET_MANABREW_KEY: "${SECRET_MANABREW_KEY:-}"
       RUST_LOG: "manabrew_server=info"
-      MANABREW_EVENTS_DIR: "/var/manabrew/events"
-      MANABREW_GAME_CAPTURE_DIR: "/var/manabrew/captures"
-      MANABREW_GAME_CAPTURE_MAX_GB: "${MANABREW_GAME_CAPTURE_MAX_GB:-20}"
-    volumes:
-      - ./ops/observability/data/events:/var/manabrew/events
-      - ./ops/observability/data/captures:/var/manabrew/captures
     expose:
       - "9443"
       - "9444"
@@ -73,19 +52,16 @@ services:
       retries: 3
       start_period: 5s
 
-  manabrew-hub:
+  manabrew-hub-staging:
     image: ghcr.io/witchesofthehill/manabrew-hub:${MANABREW_IMAGE_TAG:-staging}
     environment:
       HUB_HOST: "0.0.0.0"
       HUB_PORT: "9500"
+      # Own throwaway DB inside the staging tree — never prod's hub.db.
       HUB_DB_PATH: "/var/manabrew/hub/hub.db"
-      EVENTS_DB_PATH: "/var/manabrew/events/events.db"
       RUST_LOG: "manabrew_hub=info"
-      # Auth (/api/auth/*). The hub is path-routed on the app host, so OAuth
-      # callbacks live there too; unset client ids disable that provider. No
-      # RESEND_API_KEY → magic-link codes are logged instead of emailed.
-      HUB_PUBLIC_URL: "https://${STAGING_APP_HOST:?STAGING_APP_HOST is required}"
-      WEB_APP_URL: "https://${STAGING_APP_HOST:?STAGING_APP_HOST is required}"
+      HUB_PUBLIC_URL: "https://staging.manabrew.app"
+      WEB_APP_URL: "https://staging.manabrew.app"
       GITHUB_CLIENT_ID: "${GITHUB_CLIENT_ID:-}"
       GITHUB_CLIENT_SECRET: "${GITHUB_CLIENT_SECRET:-}"
       DISCORD_CLIENT_ID: "${DISCORD_CLIENT_ID:-}"
@@ -93,7 +69,6 @@ services:
       RESEND_API_KEY: "${RESEND_API_KEY:-}"
     volumes:
       - ./ops/hub-data:/var/manabrew/hub
-      - ./ops/observability/data/events:/var/manabrew/events:ro
     expose:
       - "9500"
     restart: unless-stopped
@@ -105,22 +80,22 @@ services:
       retries: 3
       start_period: 5s
 
-  self-hosted-node:
+  self-hosted-node-staging:
     profiles:
       - hosted-ai
     image: ghcr.io/witchesofthehill/manabrew-node:${MANABREW_IMAGE_TAG:-staging}
     environment:
-      SELF_HOSTED_NODE_RELAY_URL: "ws://manabrew-server:9443"
+      SELF_HOSTED_NODE_RELAY_URL: "ws://manabrew-server-staging:9443"
       SELF_HOSTED_NODE_SERVER_KEY: "${MANABREW_SERVER_KEY:?MANABREW_SERVER_KEY is required}"
-      SELF_HOSTED_NODE_FORMAT: "${SELF_HOSTED_NODE_FORMAT:-commander}"
-      SELF_HOSTED_NODE_MAX_PLAYERS: "${SELF_HOSTED_NODE_MAX_PLAYERS:-2}"
+      SELF_HOSTED_NODE_FORMAT: "${SELF_HOSTED_NODE_FORMAT:-Any}"
+      SELF_HOSTED_NODE_MAX_PLAYERS: "${SELF_HOSTED_NODE_MAX_PLAYERS:-4}"
       SELF_HOSTED_NODE_MAX_GAMES: "${SELF_HOSTED_NODE_MAX_GAMES:-1}"
-      SELF_HOSTED_NODE_METRICS_PUSH_URL: "${SELF_HOSTED_NODE_METRICS_PUSH_URL:-}"
       RUST_LOG: "self_hosted_node=info"
     depends_on:
-      - manabrew-server
+      - manabrew-server-staging
     restart: unless-stopped
 
-volumes:
-  caddy-data:
-  caddy-config:
+networks:
+  default:
+    external: true
+    name: manabrew_default

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -91,7 +91,7 @@ services:
       SELF_HOSTED_NODE_MAX_GAMES: "${SELF_HOSTED_NODE_MAX_GAMES:-1}"
       RUST_LOG: "self_hosted_node=info"
     mem_limit: 1g
-    cpus: 1.0
+    cpu_shares: 512
     depends_on:
       - manabrew-server-staging
     restart: unless-stopped

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -38,7 +38,8 @@ services:
       RELAY_PASSWORD: "${MANABREW_SERVER_KEY:?MANABREW_SERVER_KEY is required}"
       HOSTED_AI_ENABLED: "${HOSTED_AI_ENABLED:-true}"
       DESIGN_SYSTEM: "${DESIGN_SYSTEM:-}"
-      HUB_API_URL: "https://${STAGING_API_HOST}"
+      # Hub API is same-origin on staging (path-routed on the app host).
+      HUB_API_URL: "https://${STAGING_APP_HOST}"
     depends_on:
       - manabrew-server
 
@@ -80,10 +81,10 @@ services:
       HUB_DB_PATH: "/var/manabrew/hub/hub.db"
       EVENTS_DB_PATH: "/var/manabrew/events/events.db"
       RUST_LOG: "manabrew_hub=info"
-      # Auth (/api/auth/*). OAuth apps need callbacks on the staging api host;
-      # unset client ids disable that provider. No RESEND_API_KEY → magic-link
-      # codes are logged instead of emailed.
-      HUB_PUBLIC_URL: "https://${STAGING_API_HOST:?STAGING_API_HOST is required}"
+      # Auth (/api/auth/*). The hub is path-routed on the app host, so OAuth
+      # callbacks live there too; unset client ids disable that provider. No
+      # RESEND_API_KEY → magic-link codes are logged instead of emailed.
+      HUB_PUBLIC_URL: "https://${STAGING_APP_HOST:?STAGING_APP_HOST is required}"
       WEB_APP_URL: "https://${STAGING_APP_HOST:?STAGING_APP_HOST is required}"
       GITHUB_CLIENT_ID: "${GITHUB_CLIENT_ID:-}"
       GITHUB_CLIENT_SECRET: "${GITHUB_CLIENT_SECRET:-}"

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -82,6 +82,8 @@ services:
       start_period: 5s
 
   self-hosted-node-staging:
+    profiles:
+      - hosted-ai
     image: ghcr.io/witchesofthehill/manabrew-node:${MANABREW_IMAGE_TAG:-staging}
     environment:
       SELF_HOSTED_NODE_RELAY_URL: "ws://manabrew-server-staging:9443"

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -81,8 +81,6 @@ services:
       start_period: 5s
 
   self-hosted-node-staging:
-    profiles:
-      - hosted-ai
     image: ghcr.io/witchesofthehill/manabrew-node:${MANABREW_IMAGE_TAG:-staging}
     environment:
       SELF_HOSTED_NODE_RELAY_URL: "ws://manabrew-server-staging:9443"

--- a/deploy-staging.sh
+++ b/deploy-staging.sh
@@ -7,6 +7,9 @@
 # profiles) lives here — staging just tracks a branch and swaps in fresh
 # images. Driven by staging-deploy.yml over SSH.
 #
+# DEPLOY_BRANCH selects what lands in the slot: `staging` (the default, and the
+# only branch that gets a hosted-AI node) or a labelled PR's head branch.
+#
 # stdout = clean summary (captured by the workflow and posted to Discord).
 # Raw output goes to /tmp/deploy-staging-raw.log.
 set -euo pipefail
@@ -19,6 +22,20 @@ COMPOSE_FILE="${COMPOSE_FILE:-compose.staging.yml}"
 export MANABREW_IMAGE_TAG="${MANABREW_IMAGE_TAG:-staging}"
 RAW_LOG="/tmp/deploy-staging-raw.log"
 : > "$RAW_LOG"
+
+# ── Hosted AI: staging branch only ───────────────────────────────────
+# The self-hosted node is a Forge JVM — ~500 MiB resident and CPU-bound during
+# games, on a box that also runs production. The `staging` branch gets one; PR
+# previews (any other branch) do not, so a labelled PR costs web + relay + hub
+# only. The node sits behind the `hosted-ai` compose profile, and
+# `up --remove-orphans` below drops its container when the profile is off — so
+# switching the slot from staging to a preview reclaims it.
+PROFILE_FLAG=""
+HOSTED_AI_NOTE="off (preview — node not started)"
+if [ "$BRANCH" = "staging" ]; then
+    PROFILE_FLAG="--profile hosted-ai"
+    HOSTED_AI_NOTE="on (staging branch)"
+fi
 
 on_failure() {
     echo "💥 **Staging deploy FAILED** at $(date '+%H:%M:%S')"
@@ -77,7 +94,8 @@ fi
 # The deploy job needs build-images, so these normally exist already; the retry
 # is a safety net if ghcr is briefly behind.
 export DOCKER_BUILDKIT=1
-SERVICES="manabrew-staging manabrew-server-staging manabrew-hub-staging self-hosted-node-staging"
+SERVICES="manabrew-staging manabrew-server-staging manabrew-hub-staging"
+[ -n "$PROFILE_FLAG" ] && SERVICES="$SERVICES self-hosted-node-staging"
 WEB_SERVICE="manabrew-staging"
 echo "Pulling :${MANABREW_IMAGE_TAG} images ($SERVICES)…" >> "$RAW_LOG"
 PULLED=false
@@ -106,7 +124,8 @@ for svc in $SERVICES; do
     [ -n "$cid" ] && ROLLBACK_IMG[$svc]=$(docker inspect --format '{{.Image}}' "$cid" 2>/dev/null || true)
 done
 
-if docker compose -f "$COMPOSE_FILE" up -d --remove-orphans --wait --wait-timeout 180 >> "$RAW_LOG" 2>&1; then
+# shellcheck disable=SC2086
+if docker compose -f "$COMPOSE_FILE" $PROFILE_FLAG up -d --remove-orphans --wait --wait-timeout 180 >> "$RAW_LOG" 2>&1; then
     echo "✅ rollout healthy" >> "$RAW_LOG"
 else
     echo "⚠️ rollout unhealthy — rolling back to the previous images" | tee -a "$RAW_LOG"
@@ -128,6 +147,15 @@ docker compose -f "$COMPOSE_FILE" exec -T "$WEB_SERVICE" \
     caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile >> "$RAW_LOG" 2>&1 \
     || echo "caddy reload skipped/failed (see raw log)" >> "$RAW_LOG"
 
+# ── Reclaim superseded images ────────────────────────────────────────
+# Every deploy pulls a fresh `:staging` tag, which leaves the previous one
+# dangling (untagged, unreferenced). Nothing reclaimed them before, and this box
+# shares its docker volume with production. `image prune` (no -a) only touches
+# dangling images, so nothing tagged or in use by a running container can be
+# caught, and the rollback re-tag above has already happened by this point.
+RECLAIMED=$(docker image prune -f 2>> "$RAW_LOG" | tail -1)
+echo "🧹 ${RECLAIMED:-nothing to reclaim}" >> "$RAW_LOG"
+
 # No pipe here: `| head -c` SIGPIPEs git log on large merge ranges, and with
 # pipefail + the ERR trap that flagged an already-healthy rollout as failed.
 CHANGELOG=$(git log --pretty=format:'- %s (%h, %an)' "${PREV}..${CURR}" 2>/dev/null || true)
@@ -137,7 +165,9 @@ CHANGELOG=${CHANGELOG:0:1500}
 cat <<EOF
 🧪 **Staging deploy complete** (\`${PREV}\` → \`${CURR}\`)
 
-🔁 **Rolled out:** ${SERVICES} (tag \`${MANABREW_IMAGE_TAG}\`)
+🔁 **Rolled out:** ${SERVICES} (tag \`${MANABREW_IMAGE_TAG}\`, branch \`${BRANCH}\`)
+🤖 **Hosted AI:** ${HOSTED_AI_NOTE}
+🧹 **Reclaimed:** ${RECLAIMED:-nothing}
 📄 **Log:** \`${RAW_LOG}\`
 
 📝 **Changelog:**

--- a/deploy-staging.sh
+++ b/deploy-staging.sh
@@ -128,7 +128,10 @@ docker compose -f "$COMPOSE_FILE" exec -T "$WEB_SERVICE" \
     caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile >> "$RAW_LOG" 2>&1 \
     || echo "caddy reload skipped/failed (see raw log)" >> "$RAW_LOG"
 
-CHANGELOG=$(git log --pretty=format:'- %s (%h, %an)' "${PREV}..${CURR}" 2>/dev/null | head -c 1500)
+# No pipe here: `| head -c` SIGPIPEs git log on large merge ranges, and with
+# pipefail + the ERR trap that flagged an already-healthy rollout as failed.
+CHANGELOG=$(git log --pretty=format:'- %s (%h, %an)' "${PREV}..${CURR}" 2>/dev/null || true)
+CHANGELOG=${CHANGELOG:0:1500}
 [ -z "$CHANGELOG" ] && CHANGELOG="(no new commits — image-only redeploy)"
 
 cat <<EOF

--- a/deploy-staging.sh
+++ b/deploy-staging.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-# deploy-staging.sh — Lean rollout of the staging stack on the staging VM.
-# Pulls the staging branch + the CI-built `:staging` ghcr images and rolls them
-# out with a health-checked recreate + rollback. Deliberately NOT deploy.sh:
-# none of production's release machinery (manifest hold, --release-manifest,
-# sidestore, observability/parity profiles) lives here — staging just tracks a
-# branch and swaps in fresh images. Driven by staging-deploy.yml over SSH.
+# deploy-staging.sh — Lean rollout of the staging slot (/opt/manabrew-staging
+# on the prod box, staging.manabrew.app). Pulls the staging branch + the
+# CI-built `:staging` ghcr images and rolls them out with a health-checked
+# recreate + rollback. Deliberately NOT deploy.sh: none of production's release
+# machinery (manifest hold, --release-manifest, sidestore, observability/parity
+# profiles) lives here — staging just tracks a branch and swaps in fresh
+# images. Driven by staging-deploy.yml over SSH.
 #
 # stdout = clean summary (captured by the workflow and posted to Discord).
 # Raw output goes to /tmp/deploy-staging-raw.log.
@@ -16,7 +17,6 @@ cd "$REPO_DIR"
 BRANCH="${DEPLOY_BRANCH:-staging}"
 COMPOSE_FILE="${COMPOSE_FILE:-compose.staging.yml}"
 export MANABREW_IMAGE_TAG="${MANABREW_IMAGE_TAG:-staging}"
-GHCR_OWNER="witchesofthehill"
 RAW_LOG="/tmp/deploy-staging-raw.log"
 : > "$RAW_LOG"
 
@@ -27,8 +27,8 @@ on_failure() {
 }
 trap on_failure ERR
 
-# Box .env: MANABREW_SERVER_KEY, the STAGING_*_HOST trio, optional GITHUB_TOKEN
-# (git pull rate limits) and DISCORD_WEBHOOK_URL.
+# Slot .env: MANABREW_SERVER_KEY + hub auth secrets, written by the workflow's
+# secret sync; optional GITHUB_TOKEN (git pull rate limits).
 if [ -f "$REPO_DIR/.env" ]; then
     set -a
     # shellcheck disable=SC1091
@@ -68,11 +68,17 @@ if [ -z "${DEPLOY_STAGING_ORIG_PREV:-}" ] && [ "$PREV" != "$CURR" ] \
     exec bash "$0" "$@"
 fi
 
+if [ ! -f "$COMPOSE_FILE" ]; then
+    echo "❌ $COMPOSE_FILE does not exist on this ref — merge the branch that introduced it and redeploy."
+    exit 1
+fi
+
 # ── Pull the CI-built images ─────────────────────────────────────────
 # The deploy job needs build-images, so these normally exist already; the retry
 # is a safety net if ghcr is briefly behind.
 export DOCKER_BUILDKIT=1
-SERVICES="manabrew manabrew-server manabrew-hub"
+SERVICES="manabrew-staging manabrew-server-staging manabrew-hub-staging"
+WEB_SERVICE="manabrew-staging"
 echo "Pulling :${MANABREW_IMAGE_TAG} images ($SERVICES)…" >> "$RAW_LOG"
 PULLED=false
 for attempt in $(seq 1 20); do
@@ -87,13 +93,15 @@ $PULLED || { echo "❌ ghcr image pull failed after retries — aborting."; exit
 # ── Health-checked rollout with rollback ─────────────────────────────
 # Snapshot each running service's current image so an unhealthy rollout can be
 # re-tagged back. `up -d` only recreates services whose image/config changed.
+# The ghcr ref per service comes from the compose file itself.
+ghcr_ref() {
+    docker compose -f "$COMPOSE_FILE" config "$1" 2>/dev/null \
+        | awk '/^ *image:/ {print $2; exit}'
+}
 declare -A ROLLBACK_IMG=()
-declare -A GHCR_REF=(
-    [manabrew]="ghcr.io/${GHCR_OWNER}/manabrew-web:${MANABREW_IMAGE_TAG}"
-    [manabrew-server]="ghcr.io/${GHCR_OWNER}/manabrew-server:${MANABREW_IMAGE_TAG}"
-    [manabrew-hub]="ghcr.io/${GHCR_OWNER}/manabrew-hub:${MANABREW_IMAGE_TAG}"
-)
+declare -A GHCR_REF=()
 for svc in $SERVICES; do
+    GHCR_REF[$svc]=$(ghcr_ref "$svc")
     cid=$(docker compose -f "$COMPOSE_FILE" ps -q "$svc" 2>/dev/null || true)
     [ -n "$cid" ] && ROLLBACK_IMG[$svc]=$(docker inspect --format '{{.Image}}' "$cid" 2>/dev/null || true)
 done
@@ -116,7 +124,7 @@ fi
 
 # The Caddyfile is bind-mounted and caddy doesn't watch it; a recreate already
 # picks up changes, but reload covers the case where the web image was unchanged.
-docker compose -f "$COMPOSE_FILE" exec -T manabrew \
+docker compose -f "$COMPOSE_FILE" exec -T "$WEB_SERVICE" \
     caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile >> "$RAW_LOG" 2>&1 \
     || echo "caddy reload skipped/failed (see raw log)" >> "$RAW_LOG"
 

--- a/deploy-staging.sh
+++ b/deploy-staging.sh
@@ -77,7 +77,7 @@ fi
 # The deploy job needs build-images, so these normally exist already; the retry
 # is a safety net if ghcr is briefly behind.
 export DOCKER_BUILDKIT=1
-SERVICES="manabrew-staging manabrew-server-staging manabrew-hub-staging"
+SERVICES="manabrew-staging manabrew-server-staging manabrew-hub-staging self-hosted-node-staging"
 WEB_SERVICE="manabrew-staging"
 echo "Pulling :${MANABREW_IMAGE_TAG} images ($SERVICES)…" >> "$RAW_LOG"
 PULLED=false

--- a/docs/STAGING_WORKFLOW.md
+++ b/docs/STAGING_WORKFLOW.md
@@ -1,23 +1,25 @@
 # Staging Workflow
 
-Staging is a **mirror of production**. It runs on its own VM — a separate
-machine with its own SSH key and its own DNS — deployed the same shape as
-production: the same four ghcr images (built per-push, tagged `:staging` instead
-of the release `latest`), a `compose.staging.yml` that clones
-`compose.production.yml` service-for-service (web + relay + hub + hosted node,
-its own TLS edge), and a lean rollout script (`deploy-staging.sh`) that mirrors
-`deploy.sh`'s image-pull + health-checked recreate + rollback without the
-release-only machinery. The only differences are the branch it tracks, the image
-tag, and the hostnames — nothing behavioural.
+Staging is a **mirror of production that lives next to production**. It runs as
+a second compose project on the prod box (`/opt/manabrew-staging`,
+`compose.staging.yml`), joined to the prod docker network and fronted by the
+prod Caddy at **staging.manabrew.app** (relay at
+`relay-staging.manabrew.app`, hub API same-origin under
+`https://staging.manabrew.app/api/*`). Same ghcr images as a release would
+ship (built per-push, tagged `:staging`), same rollout mechanics
+(`deploy-staging.sh`: image pull with retry, health-checked `up --wait`,
+rollback), no release-only machinery. The differences are the branch it
+tracks, the image tag, the hostnames, and that prod's Caddy terminates TLS for
+it — nothing behavioural.
 
 Its purpose: give changes a production-shaped home to bake in **before** they
-reach real users, so a backend-breaking or infra-breaking change is caught on a
-box that looks exactly like prod but isn't prod.
+reach real users, so a backend-breaking or infra-breaking change is caught on
+infra that looks exactly like prod but isn't prod.
 
 ## The loop
 
 ```
-  local branch ──(PR / merge)──▶ staging ──(auto)──▶ staging environment
+  local branch ──(PR / merge)──▶ staging ──(auto)──▶ staging.manabrew.app
                                     ▲
                                     │ merge latest main in
                                     │
@@ -31,9 +33,8 @@ box that looks exactly like prod but isn't prod.
    still in flight.
 3. **`staging` deploys automatically.** Any push to `staging` triggers
    `.github/workflows/staging-deploy.yml`, which builds the `:staging` images,
-   connects the runner to **Twingate** (the VM only accepts SSH through
-   Twingate), then SSHes in and runs `deploy-staging.sh` against the `staging`
-   branch. Result lands on the staging hosts.
+   syncs the slot's secrets into `/opt/manabrew-staging/.env`, then SSHes into
+   the prod box (production `DEPLOY_*` secrets) and runs `deploy-staging.sh`.
 4. **Every merge to `main`, the latest `main` is merged into `staging`.** This
    keeps staging honest: it is always _`main` + whatever is still pending on
    staging_, never a stale fork that has silently drifted from production. The
@@ -53,16 +54,23 @@ git push origin staging
 
 ## What makes it a mirror, mechanically
 
-| Aspect        | Production               | Staging                                           |
-| ------------- | ------------------------ | ------------------------------------------------- |
-| Trigger       | `v*` tag (release)       | push to `staging` branch                          |
-| Deploy engine | `deploy.sh` over SSH     | `deploy-staging.sh` (lean sibling of `deploy.sh`) |
-| Deploy reach  | CI SSHes the box         | CI connects Twingate, then SSHes the box          |
-| Compose file  | `compose.production.yml` | `compose.staging.yml` (clone)                     |
-| Images        | ghcr `:latest`           | ghcr `:staging`                                   |
-| Edge / TLS    | `ops/Caddyfile`          | `ops/staging.Caddyfile`                           |
-| Hosts         | hardcoded `manabrew.app` | from env (`STAGING_APP/RELAY/API_HOST`)           |
-| Box           | production VM + key      | staging VM, SSH gated by Twingate                 |
+| Aspect        | Production               | Staging                                                    |
+| ------------- | ------------------------ | ---------------------------------------------------------- |
+| Trigger       | `v*` tag (release)       | push to `staging` branch                                   |
+| Deploy engine | `deploy.sh` over SSH     | `deploy-staging.sh` (lean sibling of `deploy.sh`)          |
+| Compose file  | `compose.production.yml` | `compose.staging.yml` (services `*-staging`)               |
+| Images        | ghcr `:latest`           | ghcr `:staging`                                            |
+| Edge / TLS    | `ops/Caddyfile`          | prod Caddy vhosts → in-stack `ops/staging.Caddyfile` (:80) |
+| Hosts         | `manabrew.app`           | `staging.manabrew.app` / `relay-staging.manabrew.app`      |
+| Box           | `/opt/manabrew` project  | `/opt/manabrew-staging` project, shared network            |
+| Secrets       | `ops/production.secrets` | `/opt/manabrew-staging/.env`, synced from repo secrets     |
+
+Every staging service name carries a `-staging` suffix (`manabrew-staging`,
+`manabrew-server-staging`, `manabrew-hub-staging`, `self-hosted-node-staging`)
+because it shares docker DNS with the prod project. The staging hub uses its
+own throwaway DB (`/opt/manabrew-staging/ops/hub-data/hub.db`) and its own
+OAuth apps — the slot's `.env` is a real file written by the workflow's
+secret-sync step, **never** a symlink to prod's `ops/production.secrets`.
 
 `deploy-staging.sh` keeps the parts of production's rollout that matter for a
 mirror — ghcr image pull with retry, a health-checked `compose up --wait`, and
@@ -72,70 +80,64 @@ updater + sidestore, observability/parity profiles, the relay binary-diff gate).
 On staging a relay recreate is fine, so `up -d` just recreates whatever image
 changed.
 
-## Deploy reach (Twingate)
+## Secrets and hosts
 
-The staging VM only accepts SSH through **Twingate**, so the GitHub-hosted runner
-can't SSH in directly. The `deploy` job first connects to Twingate with a
-service-account key, which brings the internal host into reach for the rest of
-the job, then SSHes in exactly as production does:
+- Deploy reach: the production `DEPLOY_SSH_KEY` / `DEPLOY_HOST` / `DEPLOY_USER`
+  secrets; the slot path defaults to `/opt/manabrew-staging`
+  (`DEPLOY_STAGING_PATH` secret overrides).
+- Slot `.env` (synced every deploy from repo secrets): `MANABREW_SERVER_KEY`,
+  `HUB_ADMIN_PASSWORD_HASH` (optional), and the hub auth secrets
+  `STAGING_OAUTH_GITHUB_*` / `STAGING_OAUTH_DISCORD_*` /
+  `STAGING_RESEND_API_KEY` (mapped to the hub's `GITHUB_CLIENT_ID` etc.).
+- The one build-time host (the hub API URL baked into the web bundle) comes
+  from the repo **variable** `STAGING_HUB_API_URL`
+  (= `https://staging.manabrew.app`).
+- The prod-edge vhosts (`staging.manabrew.app`, `relay-staging.manabrew.app`)
+  live in `ops/Caddyfile`, which the prod box serves from its `main` checkout —
+  a change there reaches the box with the next release (or a manual hot-sync).
 
-```yaml
-- uses: twingate/github-action@v1
-  with:
-    service-key: ${{ secrets.TWINGATE_SERVICE_KEY }}
-# subsequent SSH step reaches STAGING_DEPLOY_HOST over the tunnel
+## The optional VM (manual, self-contained)
+
+A separate VM can run the whole stack for experiments that shouldn't touch the
+staging slot (node fleets, relay tests). No CI drives it and it needs no
+dedicated compose/Caddyfile: it uses the **selfhost stack**, which builds from
+whatever is checked out on the VM:
+
+```bash
+cd <checkout>                    # the repo clone on the VM
+git fetch origin staging && git checkout -f -B staging FETCH_HEAD
+./deploy-local.sh                # own network, published ports, builds locally
 ```
 
-Create the key in the Twingate Admin Console under **Team → Service Accounts**,
-authorize it on the VM's SSH Resource, and store the downloaded JSON as the
-`TWINGATE_SERVICE_KEY` repo secret. `STAGING_DEPLOY_HOST` is the VM's _internal_
-address (as defined by the Twingate Resource). The tunnel stays up for the whole
-job and tears down when it ends.
-
-## Hosts are not hardcoded
-
-The staging stack is host-agnostic so the environment can move domains without a
-code change:
-
-- **Runtime hosts** (app / relay / api) come from the staging box's `.env` —
-  `STAGING_APP_HOST`, `STAGING_RELAY_HOST`, `STAGING_API_HOST` — consumed by
-  `ops/staging.Caddyfile` (`{$STAGING_APP_HOST}` etc., which also drives ACME
-  certs) and by the web runtime relay config.
-- **The one build-time host** (the hub API URL baked into the web bundle) comes
-  from the GitHub Actions repo **variable** `STAGING_HUB_API_URL`.
-
-Moving staging to a different domain is a `.env` edit plus that one repo
-variable — never a commit.
+See the header of `deploy-local.sh` for the env knobs (`RELAY_HOST`,
+`WEB_PORT`, `MANABREW_SERVER_KEY`, …) and the HTTPS caveat for LAN access. The
+VM's edge/env is maintained by hand; nothing in this repo references it.
 
 ## First-time setup (ops)
 
-Required before the first staging deploy can succeed:
+The staging slot needs, once:
 
-1. **GitHub secrets:** `TWINGATE_SERVICE_KEY` (Twingate service-account key JSON,
-   authorized on the VM's SSH Resource) and `STAGING_DEPLOY_SSH_KEY` /
-   `STAGING_DEPLOY_HOST` / `STAGING_DEPLOY_USER` / `STAGING_DEPLOY_PATH`
-   (`STAGING_DEPLOY_HOST` is the VM's Twingate-internal address).
-2. **GitHub repo variable:** `STAGING_HUB_API_URL` (e.g.
-   `https://api.<staging-domain>`). If unset, the web build falls back to the
-   **production** hub — set it before the first push.
-3. **DNS A records → staging VM** for the app / relay / api hosts you choose.
-4. **Provision the VM** like the prod box: docker + compose, the repo cloned at
-   `STAGING_DEPLOY_PATH` on the `staging` branch, and a box-local `.env` (see
-   `.env.example`) with its own `MANABREW_SERVER_KEY` plus the `STAGING_APP_HOST`
-   / `STAGING_RELAY_HOST` / `STAGING_API_HOST` trio (matching the DNS and the
-   `STAGING_HUB_API_URL` host).
+1. **DNS**: `staging.manabrew.app` and `relay-staging.manabrew.app` A records →
+   the prod box.
+2. **Prod Caddyfile** on the box containing the two staging vhosts (ships with
+   `ops/Caddyfile`; hot-sync + `caddy reload` if needed before a release lands).
+3. **Repo secrets**: `MANABREW_SERVER_KEY` (already used by other workflows)
+   plus the `STAGING_OAUTH_*` hub auth secrets; repo variable
+   `STAGING_HUB_API_URL`.
+4. `/opt/manabrew-staging` cloned on the `staging` branch (the workflow's
+   deploy script hard-resets it every run).
 
-The hosted Java "Play vs AI" node is under the `hosted-ai` compose profile and,
-exactly as in production, is not auto-started by `deploy.sh`. Start it once on
-the box (it restarts unless stopped):
+The hosted Java "Play vs AI" node is under the `hosted-ai` compose profile and
+is not auto-started. Start it once on the box:
 
 ```bash
-docker compose -f compose.staging.yml --profile hosted-ai up -d self-hosted-node
+cd /opt/manabrew-staging
+docker compose -f compose.staging.yml --profile hosted-ai up -d self-hosted-node-staging
 ```
 
 ## See also
 
 - `docs/DEPLOY.md` — production/operator deployment notes.
 - `.github/workflows/staging-deploy.yml` — the staging pipeline (build + deploy).
-- `deploy-staging.sh` — the staging rollout script (run on the VM over SSH).
+- `deploy-staging.sh` — the shared rollout script (staging slot; run by hand for the VM slot).
 - `deploy.sh` — production's rollout script (staging does **not** use it).

--- a/docs/STAGING_WORKFLOW.md
+++ b/docs/STAGING_WORKFLOW.md
@@ -127,13 +127,9 @@ The staging slot needs, once:
 4. `/opt/manabrew-staging` cloned on the `staging` branch (the workflow's
    deploy script hard-resets it every run).
 
-The hosted Java "Play vs AI" node is under the `hosted-ai` compose profile and
-is not auto-started. Start it once on the box:
-
-```bash
-cd /opt/manabrew-staging
-docker compose -f compose.staging.yml --profile hosted-ai up -d self-hosted-node-staging
-```
+The hosted "Play vs AI" node (`self-hosted-node-staging`) is a regular service
+in the staging compose — unlike production's profile-gated node, it deploys
+with the rest of the slot so the lobby always has its hosted room.
 
 ## See also
 

--- a/ops/staging.Caddyfile
+++ b/ops/staging.Caddyfile
@@ -1,18 +1,10 @@
-# Edge config for the staging VM (compose.staging.yml). Mirrors the
-# play/relay/api blocks of ops/Caddyfile, but served over plain HTTP on :80:
-# the staging VM sits behind an external reverse proxy (nginx) that terminates
-# TLS for the three hostnames and forwards to this Caddy — so the `http://`
-# prefix keeps Caddy from attempting ACME on a box that isn't publicly
-# reachable. The three hosts MUST be distinct (each is its own vhost); they come
-# from the box .env via compose (STAGING_APP_HOST / STAGING_RELAY_HOST /
-# STAGING_API_HOST), so moving domains is a .env edit. The fronting proxy must
-# preserve the app's COOP/COEP headers and upgrade websockets for the relay.
-# Release-only routes (/manifest.json, /tauri.json, /sidestore, /status.json)
-# are omitted — staging serves neither the updater manifest nor SideStore.
-#   {$STAGING_APP_HOST}   → wasm app  (/srv/manabrew)
-#   {$STAGING_RELAY_HOST} → relay
-#   {$STAGING_API_HOST}   → deck hub + stats API
-http://{$STAGING_APP_HOST} {
+# In-stack edge for the staging slot on the prod box (compose.staging.yml).
+# Plain :80 — the prod Caddy (ops/Caddyfile) terminates TLS for
+# staging.manabrew.app and proxies here by service name over the shared
+# docker network. Release-only routes (/manifest.json, /tauri.json,
+# /sidestore, /status.json) are omitted — staging serves neither the updater
+# manifest nor SideStore.
+:80 {
     root * /srv/manabrew
 
     encode zstd gzip
@@ -89,13 +81,12 @@ http://{$STAGING_APP_HOST} {
         header Cross-Origin-Resource-Policy "same-origin"
     }
 
-    # Deck hub + auth API, same-origin under the app host. The box edge only
-    # routes the app hostname reliably, so the api rides it as a path prefix
-    # instead of the {$STAGING_API_HOST} vhost below. /api/auth/callback/* is
-    # the hub's OAuth callback; the SPA's own /auth/callback is untouched.
+    # Deck hub + auth API, same-origin under the staging host. The hub's OAuth
+    # callback is /api/auth/callback/*; the SPA's own /auth/callback route is
+    # untouched.
     @hub path /api/*
     handle @hub {
-        reverse_proxy manabrew-hub:9500 {
+        reverse_proxy manabrew-hub-staging:9500 {
             health_uri /health
             health_interval 15s
             health_timeout 3s
@@ -107,7 +98,7 @@ http://{$STAGING_APP_HOST} {
         basic_auth {
             admin {$HUB_ADMIN_PASSWORD_HASH:$2y$05$ln9aIQ9AeSFyHiuO0tKm1uXmTi0/DYR0HPN/nEsp184AWyvGvc7hu}
         }
-        reverse_proxy manabrew-hub:9500
+        reverse_proxy manabrew-hub-staging:9500
     }
 
     handle {
@@ -118,28 +109,5 @@ http://{$STAGING_APP_HOST} {
         }
         try_files {path} /index.html
         file_server
-    }
-}
-
-http://{$STAGING_RELAY_HOST} {
-    reverse_proxy manabrew-server:9443 {
-        health_uri /health
-        health_port 9444
-        health_interval 15s
-        health_timeout 3s
-    }
-}
-
-# Deck hub + stats API. HUB_ADMIN_PASSWORD_HASH unset → the placeholder
-# default matches no password: /admin/* is locked, not broken config.
-http://{$STAGING_API_HOST} {
-    @admin path /admin/*
-    basic_auth @admin {
-        admin {$HUB_ADMIN_PASSWORD_HASH:$2y$05$ln9aIQ9AeSFyHiuO0tKm1uXmTi0/DYR0HPN/nEsp184AWyvGvc7hu}
-    }
-    reverse_proxy manabrew-hub:9500 {
-        health_uri /health
-        health_interval 15s
-        health_timeout 3s
     }
 }

--- a/ops/staging.Caddyfile
+++ b/ops/staging.Caddyfile
@@ -89,6 +89,27 @@ http://{$STAGING_APP_HOST} {
         header Cross-Origin-Resource-Policy "same-origin"
     }
 
+    # Deck hub + auth API, same-origin under the app host. The box edge only
+    # routes the app hostname reliably, so the api rides it as a path prefix
+    # instead of the {$STAGING_API_HOST} vhost below. /api/auth/callback/* is
+    # the hub's OAuth callback; the SPA's own /auth/callback is untouched.
+    @hub path /api/*
+    handle @hub {
+        reverse_proxy manabrew-hub:9500 {
+            health_uri /health
+            health_interval 15s
+            health_timeout 3s
+        }
+    }
+
+    @hubadmin path /admin/*
+    handle @hubadmin {
+        basic_auth {
+            admin {$HUB_ADMIN_PASSWORD_HASH:$2y$05$ln9aIQ9AeSFyHiuO0tKm1uXmTi0/DYR0HPN/nEsp184AWyvGvc7hu}
+        }
+        reverse_proxy manabrew-hub:9500
+    }
+
     handle {
         header {
             Cross-Origin-Opener-Policy "same-origin"

--- a/ops/web-entrypoint.sh
+++ b/ops/web-entrypoint.sh
@@ -9,6 +9,8 @@ set -e
 #     option, off in the published image.
 #   designSystem: from DESIGN_SYSTEM — exposes the dev-only /design-system
 #     reference route on a production build, off by default.
+#   hubApiUrl: from HUB_API_URL — deck hub + auth API origin; unset leaves the
+#     app on its compiled-in VITE_HUB_API_URL / api.manabrew.app default.
 {
 	echo 'window.__MANABREW_RUNTIME__ = {'
 	if [ -n "${RELAY_HOST:-}" ]; then
@@ -20,6 +22,9 @@ set -e
 	case "$(printf '%s' "${DESIGN_SYSTEM:-}" | tr '[:upper:]' '[:lower:]')" in
 	1 | true | yes | on) echo '  designSystem: true,' ;;
 	esac
+	if [ -n "${HUB_API_URL:-}" ]; then
+		echo "  hubApiUrl: \"${HUB_API_URL}\","
+	fi
 	echo '};'
 } >/srv/manabrew/config.js
 


### PR DESCRIPTION
## Summary

- Restores the staging slot topology: staging runs as a second compose project on the prod box (`/opt/manabrew-staging`), joined to the prod docker network and fronted by the prod Caddy.
- Rewires `staging-deploy.yml` from Twingate-to-a-dedicated-VM to direct SSH plus a `.env` secret sync, and updates `deploy-staging.sh` to match the `-staging` service names.
- Routes the staging hub API same-origin under `/api/*`, passes hub auth env through compose, and caps slot resources so prod always wins.

## Why

`main` is internally inconsistent today. `ops/Caddyfile` (added by #508) proxies `staging.manabrew.app` to `manabrew-staging:80` and `relay-staging.manabrew.app` to `manabrew-server-staging:9443`, but `main`'s own `compose.staging.yml` names those services `manabrew` and `manabrew-server`. Only the slot topology creates the names the Caddyfile points at, so main's ops config as a set cannot work.

The slot is what is actually deployed. The deploy workflow triggers on pushes to `staging`, so the file that ever executes is the one on that branch, and #508 was a production hotfix acknowledging the slot is live. This PR makes main match reality.

Landing this does not touch the production rollout. `compose.production.yml` gains only additive auth env, and `compose.staging.yml`, `staging.Caddyfile`, `deploy-staging.sh` and `staging-deploy.yml` are not read by the production deploy.

Two deliberate exclusions:

- `ops/manifest.json` stays at main's `version: 42` / `manabrew 1.12.4`. That is release-bot state and must not move backwards.
- The node stays at `SELF_HOSTED_NODE_MAX_GAMES=1` and `mem_limit: 1g`. Raising it to 4 games per JVM depends on the endstep concurrency patches, which ship separately. That flip is a follow-up once both have landed.

Known gap, filed as a follow-up rather than fixed here: the slot drops the events/captures observability config that main's standalone `compose.staging.yml` carries, so telemetry regressions of the #360 kind stop being catchable on staging. Restoring it means a second capture directory on the prod box disk, which is a resourcing decision worth taking on its own.

## Test plan

- `docker compose -f compose.staging.yml config` parses.
- Verified the service names now match the `reverse_proxy` targets in `ops/Caddyfile` (`manabrew-staging:80`, `manabrew-server-staging:9443`).
- Confirmed `ops/manifest.json` is unchanged from `main`.
- Diffed the result against `origin/staging`: `staging-deploy.yml`, `ops/staging.Caddyfile` and `deploy-staging.sh` are byte-identical to what is deployed. `compose.staging.yml` differs only by the intentionally-omitted endstep env block.
- No application code touched, so no typecheck or test run applies.
