### PR TITLE
feat(engine): double-faced deck faces and endstep concurrency patches

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,7 @@ forge/
 
 # release-please owns this file; reformatting it churns every release PR.
 CHANGELOG.md
+
+# gen-protocol-doc-types.mjs owns this file; CI diffs it against the raw
+# generator output, so a prettier pass makes the check permanently stale.
+website/src/generated/

--- a/forge-harness/src/main/java/forge/harness/Main.java
+++ b/forge-harness/src/main/java/forge/harness/Main.java
@@ -278,8 +278,10 @@ public final class Main {
 
     /**
      * Interactive server mode: per-game JSON-RPC over stdin/stdout dispatching
-     * to a long-lived {@link ManaBrewEngineAdapter}. One process owns one game
-     * at a time; pool callers send `reset` between games and `quit` to exit.
+     * to a long-lived {@link ManaBrewEngineAdapter}. Sessions are routed by
+     * sessionId and each runs on its own game thread, so one process can host
+     * several concurrent games; pool callers send `reset` only while the
+     * process is idle and `quit` to exit.
      *
      * Request shape:  {"command":"startGame","payload":"<json>"}  (sessionId
      * goes in `sessionId`; payload is the inner JSON string).

--- a/forge-harness/src/main/java/forge/harness/common/ForgeEngineReset.java
+++ b/forge-harness/src/main/java/forge/harness/common/ForgeEngineReset.java
@@ -1,43 +1,66 @@
 package forge.harness.common;
 
 import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Reflection-based reset of private static ID counters in forge-game classes.
  * Used by both harness engines (parity batches and the hosted session pool) to
  * isolate cross-game state without modifying forge-game.
+ *
+ * <p>Every failure is fatal by design: a counter this class claims to reset
+ * but silently cannot (class renamed, field moved, shape changed by an
+ * upstream bump) breaks cross-game id isolation invisibly. Each reset is
+ * verified by reading the counter back; callers treat a throw as an unusable
+ * engine process.
  */
 public final class ForgeEngineReset {
     private ForgeEngineReset() {}
 
+    private static final String[][] COUNTERS = {
+        {"forge.game.spellability.SpellAbility", "maxId"},
+        {"forge.game.spellability.SpellAbilityStackInstance", "maxId"},
+        {"forge.game.trigger.Trigger", "maxId"},
+        {"forge.game.replacement.ReplacementEffect", "maxId"},
+        {"forge.game.staticability.StaticAbility", "maxId"},
+        {"forge.game.Game", "maxId"},
+    };
+
     private static boolean logged = false;
 
-    /** Reset all known static ID counters in forge-game to 0. */
+    /** Reset all known static ID counters in forge-game to 0, verifying each. */
     public static void resetAllIdCounters() {
         if (!logged) {
             System.err.println("[manabrew-engine-reset] Resetting all forge-game ID counters via reflection");
             logged = true;
         }
-        resetStaticInt("forge.game.spellability.SpellAbility", "maxId");
-        resetStaticInt("forge.game.spellability.SpellAbilityStackInstance", "maxId");
-        resetStaticInt("forge.game.trigger.Trigger", "maxId");
-        resetStaticInt("forge.game.cost.IndividualCostPaymentInstance", "maxId");
-        resetStaticInt("forge.game.replacement.ReplacementEffect", "maxId");
-        resetStaticInt("forge.game.staticability.StaticAbility", "maxId");
-        resetStaticInt("forge.game.Game", "maxId");
+        for (final String[] target : COUNTERS) {
+            resetCounter(target[0], target[1]);
+        }
     }
 
-    private static void resetStaticInt(String className, String fieldName) {
+    private static void resetCounter(String className, String fieldName) {
         try {
-            Class<?> clazz = Class.forName(className);
-            Field field = clazz.getDeclaredField(fieldName);
+            Field field = Class.forName(className).getDeclaredField(fieldName);
             field.setAccessible(true);
-            field.setInt(null, 0);
-        } catch (ClassNotFoundException | NoSuchFieldException e) {
-            // Class or field absent in this Forge build — nothing to reset.
-        } catch (Exception e) {
-            System.err.printf("[manabrew-engine-reset] WARNING: Failed to reset %s.%s: %s%n",
-                className, fieldName, e.getMessage());
+            Object value = field.get(null);
+            if (value instanceof AtomicInteger counter) {
+                counter.set(0);
+                if (counter.get() != 0) {
+                    throw new IllegalStateException(className + "." + fieldName + " did not reset to 0");
+                }
+            } else if (field.getType() == int.class) {
+                field.setInt(null, 0);
+                if (field.getInt(null) != 0) {
+                    throw new IllegalStateException(className + "." + fieldName + " did not reset to 0");
+                }
+            } else {
+                throw new IllegalStateException(
+                    className + "." + fieldName + " has unsupported counter shape " + field.getType());
+            }
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(
+                "cannot reset " + className + "." + fieldName + "; engine id isolation would silently break", e);
         }
     }
 }

--- a/forge-harness/src/main/java/forge/harness/common/HarnessCostPlumbing.java
+++ b/forge-harness/src/main/java/forge/harness/common/HarnessCostPlumbing.java
@@ -20,7 +20,6 @@ import forge.game.zone.ZoneType;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 public final class HarnessCostPlumbing {
@@ -716,13 +715,13 @@ public final class HarnessCostPlumbing {
             final GameEntityCounterTable table = new GameEntityCounterTable();
             int remaining = amount;
             for (final Card card : list) {
-                for (final Map.Entry<CounterType, Integer> e : card.getCounters().entrySet()) {
+                for (final com.google.common.collect.Multiset.Entry<CounterType> e : card.getCounters().entrySet()) {
                     if (remaining <= 0) {
                         break;
                     }
-                    final int remove = Math.min(remaining, e.getValue());
+                    final int remove = Math.min(remaining, e.getCount());
                     if (remove > 0) {
-                        table.put(null, card, e.getKey(), remove);
+                        table.put(null, card, e.getElement(), remove);
                         remaining -= remove;
                     }
                 }
@@ -769,9 +768,9 @@ public final class HarnessCostPlumbing {
                         return PaymentDecision.counters(table);
                     }
                 } else {
-                    for (final Map.Entry<CounterType, Integer> e : card.getCounters().entrySet()) {
-                        if (e.getValue() >= amount) {
-                            table.put(null, card, e.getKey(), amount);
+                    for (final com.google.common.collect.Multiset.Entry<CounterType> e : card.getCounters().entrySet()) {
+                        if (e.getCount() >= amount) {
+                            table.put(null, card, e.getElement(), amount);
                             return PaymentDecision.counters(table);
                         }
                     }
@@ -887,6 +886,11 @@ public final class HarnessCostPlumbing {
         @Override
         public PaymentDecision visit(final CostBlight cost) {
             return visit((CostPutCounter) cost);
+        }
+
+        @Override
+        public PaymentDecision visit(final CostPutCounterYou cost) {
+            return PaymentDecision.number(cost.getAbilityAmount(ability));
         }
 
         @Override

--- a/forge-harness/src/main/java/forge/harness/common/HeadlessGuiBase.java
+++ b/forge-harness/src/main/java/forge/harness/common/HeadlessGuiBase.java
@@ -64,7 +64,6 @@ public class HeadlessGuiBase implements IGuiBase {
     @Override public String showFileDialog(String title, String defaultDir) { return null; }
     @Override public File getSaveFile(File defaultFile) { return null; }
     @Override public void download(GuiDownloadService service, Consumer<Boolean> callback) { if (callback != null) callback.accept(false); }
-    @Override public void refreshSkin() {}
     @Override public void showCardList(String title, String message, List<PaperCard> list) {}
     @Override public boolean showBoxedProduct(String title, String message, List<PaperCard> list) { return false; }
     @Override public PaperCard chooseCard(String title, String message, List<PaperCard> list) { return list != null && !list.isEmpty() ? list.get(0) : null; }

--- a/forge-harness/src/main/java/forge/harness/common/SnapshotExtractor.java
+++ b/forge-harness/src/main/java/forge/harness/common/SnapshotExtractor.java
@@ -89,9 +89,9 @@ public final class SnapshotExtractor {
                 .thenComparing(c -> {
                     // Deterministic counter string matching Rust BTreeMap order
                     TreeMap<String, Integer> counters = new TreeMap<>();
-                    for (Map.Entry<CounterType, Integer> entry : c.getCounters().entrySet()) {
-                        if (entry.getValue() > 0) {
-                            counters.put(counterTypeName(entry.getKey()), entry.getValue());
+                    for (com.google.common.collect.Multiset.Entry<CounterType> entry : c.getCounters().entrySet()) {
+                        if (entry.getCount() > 0) {
+                            counters.put(counterTypeName(entry.getElement()), entry.getCount());
                         }
                     }
                     return counters.toString();
@@ -183,9 +183,9 @@ public final class SnapshotExtractor {
 
         // Counters — sorted by counter type name
         Map<String, Integer> counters = new TreeMap<>();
-        for (Map.Entry<CounterType, Integer> entry : c.getCounters().entrySet()) {
-            if (entry.getValue() > 0) {
-                counters.put(counterTypeName(entry.getKey()), entry.getValue());
+        for (com.google.common.collect.Multiset.Entry<CounterType> entry : c.getCounters().entrySet()) {
+            if (entry.getCount() > 0) {
+                counters.put(counterTypeName(entry.getElement()), entry.getCount());
             }
         }
         cs.put("counters", counters);

--- a/forge-harness/src/main/java/forge/harness/host/InteractiveSnapshotExtractor.java
+++ b/forge-harness/src/main/java/forge/harness/host/InteractiveSnapshotExtractor.java
@@ -537,9 +537,9 @@ public final class InteractiveSnapshotExtractor {
 
     private static Map<String, Integer> counterMap(final Card card) {
         final Map<String, Integer> counters = new TreeMap<>();
-        for (final Map.Entry<CounterType, Integer> entry : card.getCounters().entrySet()) {
-            if (entry.getValue() > 0) {
-                counters.put(uiCounterName(entry.getKey()), entry.getValue());
+        for (final com.google.common.collect.Multiset.Entry<CounterType> entry : card.getCounters().entrySet()) {
+            if (entry.getCount() > 0) {
+                counters.put(uiCounterName(entry.getElement()), entry.getCount());
             }
         }
         return counters;

--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewEngineAdapter.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewEngineAdapter.java
@@ -78,7 +78,11 @@ public final class ManaBrewEngineAdapter {
         rules.setAppliedVariants(variants);
         rules.setSimTimeout(120);
 
-        ForgeEngineReset.resetAllIdCounters();
+        // Resetting global counters under a live session would collide its ids;
+        // multiplexed processes only reset between idle periods.
+        if (sessions.isEmpty()) {
+            ForgeEngineReset.resetAllIdCounters();
+        }
         final ManaBrewInteractiveSession session =
                 new ManaBrewInteractiveSession(request.getGameId());
         final List<RegisteredPlayer> registeredPlayers = new ArrayList<>();

--- a/manabrew-rs/crates/manabrew-engine/src/card/card_assembly.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/card/card_assembly.rs
@@ -317,6 +317,7 @@ pub(crate) fn assemble_card(
 
             card.other_part = Some(CardOtherPart {
                 name: back_face.name.clone(),
+                is_modal: rules.split_type == forge_foundation::CardSplitType::Modal,
                 type_line: back_face.type_line.clone(),
                 mana_cost: back_face.mana_cost.clone(),
                 color: intrinsic_color(back_face),

--- a/manabrew-rs/crates/manabrew-engine/src/card/mod.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/card/mod.rs
@@ -95,6 +95,12 @@ pub fn parse_plotted_turn(kw: &str) -> Option<u32> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CardOtherPart {
     pub name: String,
+    /// True when the card's split type is `Modal` (MDFC). Only a modal back face
+    /// may be played from hand; transform/meld backs may not. Mirrors
+    /// `Card.isModal()` (`getRules().getSplitType() == CardSplitType.Modal`).
+    /// Invariant across `transform()`, so it is not swapped there.
+    #[serde(default)]
+    pub is_modal: bool,
     pub type_line: CardTypeLine,
     pub mana_cost: ManaCost,
     pub color: ColorSet,
@@ -3602,6 +3608,12 @@ impl Card {
     /// Swaps all face-dependent characteristics with `other_part`.
     /// No-op if `other_part` is `None`.
     /// Mirrors Java's `CardUtil.applyState(card, CardStateName.Backside)`.
+    /// Mirror of `Card.isModal()`: true only for MDFC (modal) cards, whose back
+    /// face may be played from hand. Transform / meld backs are not modal.
+    pub fn is_modal(&self) -> bool {
+        self.other_part.as_ref().is_some_and(|other| other.is_modal)
+    }
+
     pub fn transform(&mut self) {
         if let Some(other) = self.other_part.as_mut() {
             std::mem::swap(&mut self.card_name, &mut other.name);

--- a/manabrew-rs/crates/manabrew-engine/src/game_loop/playability.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/game_loop/playability.rs
@@ -131,7 +131,7 @@ impl GameLoop {
                     if card
                         .other_part
                         .as_ref()
-                        .is_some_and(|other| other.type_line.is_land())
+                        .is_some_and(|other| other.is_modal && other.type_line.is_land())
                     {
                         playable.push(crate::agent::PlayOption {
                             card_id,
@@ -142,11 +142,13 @@ impl GameLoop {
                 }
             } else {
                 // MDFC: emit both the back-face LAND and the front-face SPELL
-                // (Java `getPossibleActions`).
+                // (Java `getPossibleActions`). Only *modal* backs are playable;
+                // a transform back land (e.g. Search for Azcanta // Azcanta) is
+                // not — mirror `Card.hasPlayableLandFace` (gated on isModal).
                 if card
                     .other_part
                     .as_ref()
-                    .is_some_and(|other| other.type_line.is_land())
+                    .is_some_and(|other| other.is_modal && other.type_line.is_land())
                 {
                     let cant_play_land =
                         crate::staticability::static_ability_cant_be_cast::cant_play_land_ability(

--- a/manabrew-rs/crates/manabrew-protocol/src/deck_dto.rs
+++ b/manabrew-rs/crates/manabrew-protocol/src/deck_dto.rs
@@ -55,6 +55,31 @@ pub struct CardRulesSummary {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub is_double_faced: Option<bool>,
+    /// The back face of a double-faced card (transform / modal_dfc), captured at
+    /// deck import from Scryfall so rendering never needs a live lookup. The
+    /// front-face fields above remain the card's identity; this is purely
+    /// additive. `None` for single-faced cards and older decks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub back_face: Option<CardFaceSummary>,
+}
+
+/// One face of a double-faced card, in the same shape the UI renders a front
+/// face from. Carried for the *back* face on `CardRulesSummary` (the front face
+/// is the flattened fields on the card itself).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export, export_to = "deck/index.ts")]
+pub struct CardFaceSummary {
+    pub name: String,
+    #[serde(default)]
+    pub mana_cost: String,
+    #[serde(default)]
+    pub type_line: String,
+    #[serde(default)]
+    pub oracle_text: String,
+    #[serde(default)]
+    pub uris: CardImageUris,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, TS)]

--- a/manabrew-rs/crates/self-hosted-node/src/engine_backend/java_backend.rs
+++ b/manabrew-rs/crates/self-hosted-node/src/engine_backend/java_backend.rs
@@ -232,10 +232,17 @@ pub fn run_self_play(
 type SharedBridge = Arc<Mutex<SubprocessBridge>>;
 
 #[cfg(feature = "java-forge")]
+struct PoolSlot {
+    bridge: SharedBridge,
+    active: usize,
+}
+
+#[cfg(feature = "java-forge")]
 pub struct JavaEnginePool {
     config: JavaRuntimeConfig,
-    max_size: usize,
-    free: Mutex<Vec<SharedBridge>>,
+    max_sessions: usize,
+    sessions_per_process: usize,
+    slots: Mutex<Vec<PoolSlot>>,
     in_use: Mutex<HashMap<String, SharedBridge>>,
 }
 
@@ -247,18 +254,31 @@ pub struct JavaEngineHandle {
 
 #[cfg(feature = "java-forge")]
 impl JavaEnginePool {
-    pub fn start(config: &JavaRuntimeConfig, max_size: usize) -> Result<Arc<Self>, String> {
-        let max_size = max_size.max(1);
-        let mut free = Vec::with_capacity(max_size);
-        for slot in 0..max_size {
-            info!(slot, max_size, "pre-warming java subprocess");
+    pub fn start(
+        config: &JavaRuntimeConfig,
+        max_sessions: usize,
+        sessions_per_process: usize,
+    ) -> Result<Arc<Self>, String> {
+        let max_sessions = max_sessions.max(1);
+        let sessions_per_process = sessions_per_process.max(1);
+        let processes = max_sessions.div_ceil(sessions_per_process);
+        let mut slots = Vec::with_capacity(processes);
+        for slot in 0..processes {
+            info!(
+                slot,
+                processes, sessions_per_process, "pre-warming java subprocess"
+            );
             let bridge = SubprocessBridge::spawn(config)?;
-            free.push(Arc::new(Mutex::new(bridge)));
+            slots.push(PoolSlot {
+                bridge: Arc::new(Mutex::new(bridge)),
+                active: 0,
+            });
         }
         Ok(Arc::new(Self {
             config: config.clone(),
-            max_size,
-            free: Mutex::new(free),
+            max_sessions,
+            sessions_per_process,
+            slots: Mutex::new(slots),
             in_use: Mutex::new(HashMap::new()),
         }))
     }
@@ -273,9 +293,9 @@ impl JavaEnginePool {
 #[cfg(feature = "java-forge")]
 impl Drop for JavaEnginePool {
     fn drop(&mut self) {
-        let free = self.free.get_mut().map(std::mem::take).unwrap_or_default();
-        for bridge in free {
-            if let Ok(mutex) = Arc::try_unwrap(bridge) {
+        let slots = self.slots.get_mut().map(std::mem::take).unwrap_or_default();
+        for slot in slots {
+            if let Ok(mutex) = Arc::try_unwrap(slot.bridge) {
                 if let Ok(inner) = mutex.into_inner() {
                     inner.shutdown();
                 }
@@ -289,14 +309,22 @@ impl JavaEnginePool {
     fn acquire(&self) -> Result<SharedBridge, String> {
         let deadline = Instant::now() + Duration::from_secs(60);
         loop {
-            let popped = {
-                let mut free = self
-                    .free
+            let claimed = {
+                let mut slots = self
+                    .slots
                     .lock()
-                    .map_err(|_| "java engine free queue poisoned".to_string())?;
-                free.pop()
+                    .map_err(|_| "java engine slots poisoned".to_string())?;
+                let mut claimed = None;
+                for slot in slots.iter_mut() {
+                    if slot.active < self.sessions_per_process {
+                        slot.active += 1;
+                        claimed = Some(Arc::clone(&slot.bridge));
+                        break;
+                    }
+                }
+                claimed
             };
-            if let Some(bridge) = popped {
+            if let Some(bridge) = claimed {
                 let alive = bridge
                     .lock()
                     .ok()
@@ -306,18 +334,13 @@ impl JavaEnginePool {
                     return Ok(bridge);
                 }
                 warn!("discarding dead java subprocess from pool");
-                drop(bridge);
-                if let Ok(replacement) = SubprocessBridge::spawn(&self.config) {
-                    if let Ok(mut free) = self.free.lock() {
-                        free.push(Arc::new(Mutex::new(replacement)));
-                    }
-                }
+                self.replace_slot(&bridge);
                 continue;
             }
             if Instant::now() >= deadline {
                 return Err(format!(
-                    "java engine pool exhausted (max_size={}); no free subprocess after 60s",
-                    self.max_size
+                    "java engine pool exhausted (max_sessions={}); no free session slot after 60s",
+                    self.max_sessions
                 ));
             }
             std::thread::sleep(Duration::from_millis(50));
@@ -325,6 +348,22 @@ impl JavaEnginePool {
     }
 
     fn release(&self, bridge: SharedBridge) {
+        let now_idle = {
+            let mut slots = match self.slots.lock() {
+                Ok(slots) => slots,
+                Err(_) => return,
+            };
+            match slots.iter_mut().find(|s| Arc::ptr_eq(&s.bridge, &bridge)) {
+                Some(slot) => {
+                    slot.active = slot.active.saturating_sub(1);
+                    slot.active == 0
+                }
+                None => return,
+            }
+        };
+        if !now_idle {
+            return;
+        }
         let healthy = {
             let mut guard = match bridge.lock() {
                 Ok(guard) => guard,
@@ -332,21 +371,29 @@ impl JavaEnginePool {
             };
             guard.is_alive() && guard.reset().is_ok()
         };
-        if healthy {
-            if let Ok(mut free) = self.free.lock() {
-                free.push(bridge);
-                return;
-            }
+        if !healthy {
+            warn!("java subprocess unhealthy at idle; respawning");
+            self.replace_slot(&bridge);
         }
-        drop(bridge);
+    }
+
+    fn replace_slot(&self, dead: &SharedBridge) {
+        let Ok(mut slots) = self.slots.lock() else {
+            return;
+        };
+        let Some(index) = slots.iter().position(|s| Arc::ptr_eq(&s.bridge, dead)) else {
+            return;
+        };
         match SubprocessBridge::spawn(&self.config) {
             Ok(replacement) => {
-                if let Ok(mut free) = self.free.lock() {
-                    free.push(Arc::new(Mutex::new(replacement)));
-                }
+                slots[index] = PoolSlot {
+                    bridge: Arc::new(Mutex::new(replacement)),
+                    active: 0,
+                };
             }
             Err(error) => {
-                warn!(%error, "failed to respawn java subprocess after release");
+                warn!(%error, "failed to respawn java subprocess; retiring pool slot");
+                slots.remove(index);
             }
         }
     }
@@ -497,15 +544,22 @@ pub fn init_engine() -> Result<(), String> {
         return Ok(());
     }
     let config = JavaRuntimeConfig::from_env();
-    // SELF_HOSTED_NODE_MAX_GAMES doubles as the subprocess pool size: each room
-    // checks out one java subprocess for its lifetime, so the pool ceiling is
-    // also the concurrent-room ceiling for this node.
-    let max_size = env::var("SELF_HOSTED_NODE_MAX_GAMES")
+    // SELF_HOSTED_NODE_MAX_GAMES is the concurrent-session ceiling for this node.
+    // SELF_HOSTED_NODE_GAMES_PER_JVM multiplexes that many sessions into each
+    // subprocess (the engine is concurrency-safe since the endstep patches), so
+    // the pool spawns ceil(max_games / games_per_jvm) processes. Default 1 keeps
+    // the historical one-subprocess-per-game shape.
+    let max_sessions = env::var("SELF_HOSTED_NODE_MAX_GAMES")
         .ok()
         .and_then(|value| value.parse::<usize>().ok())
         .filter(|n| *n >= 1)
         .unwrap_or(1);
-    let pool = JavaEnginePool::start(&config, max_size)?;
+    let sessions_per_process = env::var("SELF_HOSTED_NODE_GAMES_PER_JVM")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|n| *n >= 1)
+        .unwrap_or(1);
+    let pool = JavaEnginePool::start(&config, max_sessions, sessions_per_process)?;
     JAVA_ENGINE
         .set(pool)
         .map_err(|_| "java engine already initialized".to_string())
@@ -564,6 +618,11 @@ mod graal_ffi {
             thread: *mut *mut graal_isolatethread_t,
         ) -> c_int;
         pub fn graal_tear_down_isolate(thread: *mut graal_isolatethread_t) -> c_int;
+        pub fn graal_attach_thread(
+            isolate: *mut graal_isolate_t,
+            thread: *mut *mut graal_isolatethread_t,
+        ) -> c_int;
+        pub fn graal_detach_thread(thread: *mut graal_isolatethread_t) -> c_int;
         pub fn forge_initialize(
             thread: *mut graal_isolatethread_t,
             assets_dir: *const c_char,
@@ -613,13 +672,24 @@ struct ForgeReply {
     error: Option<String>,
 }
 
-// One GraalVM isolate hosts the in-process Forge engine. It is created on, and
-// confined to, the hosted-engine thread (isolate threads are not portable), so
-// the handle is Rc/!Send by design.
+// A GraalVM isolate hosts the in-process Forge engine. The `thread` handle is
+// bound to the hosted-engine thread that created or attached it (isolate
+// threads are not portable), so the handle is Rc/!Send by design. In shared
+// mode one isolate serves all rooms: the first creator initializes Forge, later
+// rooms attach their own thread to it and sessions coexist in the adapter.
 #[cfg(feature = "graal-forge")]
 struct GraalBridge {
     thread: *mut graal_ffi::graal_isolatethread_t,
+    attached: bool,
 }
+
+#[cfg(feature = "graal-forge")]
+struct SharedIsolate(*mut graal_ffi::graal_isolate_t);
+#[cfg(feature = "graal-forge")]
+unsafe impl Send for SharedIsolate {}
+
+#[cfg(feature = "graal-forge")]
+static SHARED_GRAAL_ISOLATE: std::sync::Mutex<Option<SharedIsolate>> = std::sync::Mutex::new(None);
 
 #[cfg(feature = "graal-forge")]
 impl GraalBridge {
@@ -632,7 +702,45 @@ impl GraalBridge {
         if rc != 0 {
             return Err(format!("graal_create_isolate failed with code {rc}"));
         }
-        Ok(Self { thread })
+        Ok(Self {
+            thread,
+            attached: false,
+        })
+    }
+
+    fn create_in_shared_isolate(assets_dir: &Path) -> Result<Self, String> {
+        let mut guard = SHARED_GRAAL_ISOLATE
+            .lock()
+            .map_err(|_| "shared graal isolate poisoned".to_string())?;
+        if let Some(shared) = guard.as_ref() {
+            let mut thread: *mut graal_ffi::graal_isolatethread_t = std::ptr::null_mut();
+            let rc = unsafe { graal_ffi::graal_attach_thread(shared.0, &mut thread) };
+            if rc != 0 {
+                return Err(format!("graal_attach_thread failed with code {rc}"));
+            }
+            return Ok(Self {
+                thread,
+                attached: true,
+            });
+        }
+        let mut isolate: *mut graal_ffi::graal_isolate_t = std::ptr::null_mut();
+        let mut thread: *mut graal_ffi::graal_isolatethread_t = std::ptr::null_mut();
+        let rc = unsafe {
+            graal_ffi::graal_create_isolate(std::ptr::null_mut(), &mut isolate, &mut thread)
+        };
+        if rc != 0 {
+            return Err(format!("graal_create_isolate failed with code {rc}"));
+        }
+        let mut bridge = Self {
+            thread,
+            attached: false,
+        };
+        let assets = cstring(&assets_dir.to_string_lossy())?;
+        bridge.decode(unsafe { graal_ffi::forge_initialize(bridge.thread, assets.as_ptr()) })?;
+        bridge.attached = true;
+        *guard = Some(SharedIsolate(isolate));
+        info!("shared graal isolate initialized");
+        Ok(bridge)
     }
 
     fn decode(&self, raw: *mut std::os::raw::c_char) -> Result<String, String> {
@@ -658,7 +766,11 @@ impl GraalBridge {
 #[cfg(feature = "graal-forge")]
 impl Drop for GraalBridge {
     fn drop(&mut self) {
-        unsafe { graal_ffi::graal_tear_down_isolate(self.thread) };
+        if self.attached {
+            unsafe { graal_ffi::graal_detach_thread(self.thread) };
+        } else {
+            unsafe { graal_ffi::graal_tear_down_isolate(self.thread) };
+        }
     }
 }
 
@@ -671,9 +783,21 @@ struct GraalEngineHandle {
 #[cfg(feature = "graal-forge")]
 impl GraalEngineHandle {
     fn create(assets_dir: &Path) -> Result<Self, String> {
-        let bridge = GraalBridge::create()?;
-        let assets = cstring(&assets_dir.to_string_lossy())?;
-        bridge.decode(unsafe { graal_ffi::forge_initialize(bridge.thread, assets.as_ptr()) })?;
+        // SELF_HOSTED_NODE_SHARED_ISOLATE=1 hosts every room's game in one
+        // isolate (safe since the endstep concurrency patches), so the card db
+        // loads once. Default keeps the historical isolate-per-game shape.
+        let shared = env::var("SELF_HOSTED_NODE_SHARED_ISOLATE")
+            .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        let bridge = if shared {
+            GraalBridge::create_in_shared_isolate(assets_dir)?
+        } else {
+            let bridge = GraalBridge::create()?;
+            let assets = cstring(&assets_dir.to_string_lossy())?;
+            bridge
+                .decode(unsafe { graal_ffi::forge_initialize(bridge.thread, assets.as_ptr()) })?;
+            bridge
+        };
         Ok(Self {
             bridge: std::rc::Rc::new(bridge),
         })
@@ -754,7 +878,12 @@ pub fn run_concurrent_self_play(
     concurrency: usize,
 ) -> Result<(), String> {
     let config = JavaRuntimeConfig::from_env();
-    let pool = JavaEnginePool::start(&config, concurrency.max(1))?;
+    let games_per_process = env::var("SELF_HOSTED_NODE_GAMES_PER_JVM")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|n| *n >= 1)
+        .unwrap_or(1);
+    let pool = JavaEnginePool::start(&config, concurrency.max(1), games_per_process)?;
     info!(
         concurrency,
         "java-engine started; launching concurrent games"

--- a/manabrew-rs/crates/self-hosted-node/tests/hosted_smoke.rs
+++ b/manabrew-rs/crates/self-hosted-node/tests/hosted_smoke.rs
@@ -242,20 +242,10 @@ async fn play_game(
                             .all(|p| p.connected && p.ready && p.selected_deck_name.is_some())
                     {
                         sent_start = true;
-                        let start = StateEnvelope::RoomRelay {
-                            protocol: "self-hosted-node".to_string(),
-                            version: 1,
-                            message_id: uuid::Uuid::new_v4().to_string(),
-                            from_player: Some(username.clone()),
-                            target_player: None,
-                            room_id: Some(room_id.to_string()),
-                            payload: json!({ "type": "startGame", "format": "Standard" }),
-                        };
                         send(
                             &mut write,
-                            &ClientMessage::BroadcastState {
-                                state: serde_json::to_value(&start).map_err(|e| e.to_string())?,
-                                target_player: None,
+                            &ClientMessage::StartGame {
+                                format: Some(GameFormat::Standard),
                             },
                         )
                         .await?;
@@ -295,7 +285,7 @@ fn basic_deck(name: &str, land: &str, creature: &str) -> Value {
 }
 
 fn card(id: String, name: &str) -> Value {
-    json!({ "id": id, "name": name, "setCode": "", "cardNumber": "0" })
+    json!({ "identity": { "id": id, "name": name, "setCode": "", "cardNumber": "0" } })
 }
 
 async fn connect(relay: &str) -> Result<(WsWrite, WsRead), String> {

--- a/public/preset_decks/ramses_commander.json
+++ b/public/preset_decks/ramses_commander.json
@@ -362,7 +362,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg?1669839436",
         "border_crop": "https://cards.scryfall.io/border_crop/front/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg?1669839436"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Murkwater Pathway",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "{T}: Add {B}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg?1783929316",
+          "normal": "https://cards.scryfall.io/normal/back/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg?1783929316",
+          "large": "https://cards.scryfall.io/large/back/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg?1783929316",
+          "png": "https://cards.scryfall.io/png/back/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.png?1783929316",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg?1783929316",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg?1783929316"
+        }
+      }
     },
     {
       "name": "Coastal Piracy",

--- a/public/preset_decks/real_mono_white_weenie.json
+++ b/public/preset_decks/real_mono_white_weenie.json
@@ -149,7 +149,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/4/3/438e3302-daf9-436b-8b08-24b3f33295f6.jpg?1736467543",
         "border_crop": "https://cards.scryfall.io/border_crop/front/4/3/438e3302-daf9-436b-8b08-24b3f33295f6.jpg?1736467543"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Luminous Phantom",
+        "manaCost": "",
+        "typeLine": "Creature — Spirit Cleric",
+        "oracleText": "Flying\nWhenever another creature you control leaves the battlefield, you gain 1 life.\nIf Luminous Phantom would be put into a graveyard from anywhere, exile it instead.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/4/3/438e3302-daf9-436b-8b08-24b3f33295f6.jpg?1783908183",
+          "normal": "https://cards.scryfall.io/normal/back/4/3/438e3302-daf9-436b-8b08-24b3f33295f6.jpg?1783908183",
+          "large": "https://cards.scryfall.io/large/back/4/3/438e3302-daf9-436b-8b08-24b3f33295f6.jpg?1783908183",
+          "png": "https://cards.scryfall.io/png/back/4/3/438e3302-daf9-436b-8b08-24b3f33295f6.png?1783908183",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/4/3/438e3302-daf9-436b-8b08-24b3f33295f6.jpg?1783908183",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/4/3/438e3302-daf9-436b-8b08-24b3f33295f6.jpg?1783908183"
+        }
+      }
     },
     {
       "name": "Kor Skyfisher",

--- a/public/preset_decks/real_mono_white_weenie_2.json
+++ b/public/preset_decks/real_mono_white_weenie_2.json
@@ -173,7 +173,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/4/3/438e3302-daf9-436b-8b08-24b3f33295f6.jpg?1736467543",
         "border_crop": "https://cards.scryfall.io/border_crop/front/4/3/438e3302-daf9-436b-8b08-24b3f33295f6.jpg?1736467543"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Luminous Phantom",
+        "manaCost": "",
+        "typeLine": "Creature — Spirit Cleric",
+        "oracleText": "Flying\nWhenever another creature you control leaves the battlefield, you gain 1 life.\nIf Luminous Phantom would be put into a graveyard from anywhere, exile it instead.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/4/3/438e3302-daf9-436b-8b08-24b3f33295f6.jpg?1783908183",
+          "normal": "https://cards.scryfall.io/normal/back/4/3/438e3302-daf9-436b-8b08-24b3f33295f6.jpg?1783908183",
+          "large": "https://cards.scryfall.io/large/back/4/3/438e3302-daf9-436b-8b08-24b3f33295f6.jpg?1783908183",
+          "png": "https://cards.scryfall.io/png/back/4/3/438e3302-daf9-436b-8b08-24b3f33295f6.png?1783908183",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/4/3/438e3302-daf9-436b-8b08-24b3f33295f6.jpg?1783908183",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/4/3/438e3302-daf9-436b-8b08-24b3f33295f6.jpg?1783908183"
+        }
+      }
     },
     {
       "name": "Kor Skyfisher",

--- a/public/preset_decks/starter_deck_animar.json
+++ b/public/preset_decks/starter_deck_animar.json
@@ -1310,7 +1310,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg?1604250788",
         "border_crop": "https://cards.scryfall.io/border_crop/front/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg?1604250788"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Sea Gate, Reborn",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "As this land enters, you may pay 3 life. If you don't, it enters tapped.\n{T}: Add {U}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg?1783929396",
+          "normal": "https://cards.scryfall.io/normal/back/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg?1783929396",
+          "large": "https://cards.scryfall.io/large/back/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg?1783929396",
+          "png": "https://cards.scryfall.io/png/back/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.png?1783929396",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg?1783929396",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg?1783929396"
+        }
+      }
     },
     {
       "name": "Shatterskull Smashing // Shatterskull, the Hammer Pass",
@@ -1334,7 +1348,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1604197844",
         "border_crop": "https://cards.scryfall.io/border_crop/front/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1604197844"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Shatterskull, the Hammer Pass",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "As this land enters, you may pay 3 life. If you don't, it enters tapped.\n{T}: Add {R}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1783929355",
+          "normal": "https://cards.scryfall.io/normal/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1783929355",
+          "large": "https://cards.scryfall.io/large/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1783929355",
+          "png": "https://cards.scryfall.io/png/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.png?1783929355",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1783929355",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1783929355"
+        }
+      }
     },
     {
       "name": "Forsaken Monument",
@@ -1382,7 +1410,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg?1604199791",
         "border_crop": "https://cards.scryfall.io/border_crop/front/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg?1604199791"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Turntimber, Serpentine Wood",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "As this land enters, you may pay 3 life. If you don't, it enters tapped.\n{T}: Add {G}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg?1783929333",
+          "normal": "https://cards.scryfall.io/normal/back/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg?1783929333",
+          "large": "https://cards.scryfall.io/large/back/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg?1783929333",
+          "png": "https://cards.scryfall.io/png/back/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.png?1783929333",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg?1783929333",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg?1783929333"
+        }
+      }
     },
     {
       "name": "Cultivate",
@@ -1831,7 +1873,21 @@
           "name": "Drowner of Truth // Drowned Jungle",
           "component": "combo_piece"
         }
-      ]
+      ],
+      "backFace": {
+        "name": "Drowned Jungle",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "This land enters tapped.\n{T}: Add {G} or {U}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/7/a/7a1d3c1d-1373-4ac4-bb26-9780976efc4f.jpg?1783911227",
+          "normal": "https://cards.scryfall.io/normal/back/7/a/7a1d3c1d-1373-4ac4-bb26-9780976efc4f.jpg?1783911227",
+          "large": "https://cards.scryfall.io/large/back/7/a/7a1d3c1d-1373-4ac4-bb26-9780976efc4f.jpg?1783911227",
+          "png": "https://cards.scryfall.io/png/back/7/a/7a1d3c1d-1373-4ac4-bb26-9780976efc4f.png?1783911227",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/7/a/7a1d3c1d-1373-4ac4-bb26-9780976efc4f.jpg?1783911227",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/7/a/7a1d3c1d-1373-4ac4-bb26-9780976efc4f.jpg?1783911227"
+        }
+      }
     },
     {
       "name": "Path of Annihilation",

--- a/public/preset_decks/starter_deck_boros_energy.json
+++ b/public/preset_decks/starter_deck_boros_energy.json
@@ -258,7 +258,21 @@
           "name": "Cat Warrior",
           "component": "token"
         }
-      ]
+      ],
+      "backFace": {
+        "name": "Ajani, Nacatl Avenger",
+        "manaCost": "",
+        "typeLine": "Legendary Planeswalker — Ajani",
+        "oracleText": "+2: Put a +1/+1 counter on each Cat you control.\n0: Create a 2/1 white Cat Warrior creature token. When you do, if you control a red permanent other than Ajani, he deals damage equal to the number of creatures you control to any target.\n−4: Each opponent chooses an artifact, a creature, an enchantment, and a planeswalker from among the nonland permanents they control, then sacrifices the rest.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/0/d/0d16e8e0-31b2-4389-afd6-783c501f6fa0.jpg?1783911238",
+          "normal": "https://cards.scryfall.io/normal/back/0/d/0d16e8e0-31b2-4389-afd6-783c501f6fa0.jpg?1783911238",
+          "large": "https://cards.scryfall.io/large/back/0/d/0d16e8e0-31b2-4389-afd6-783c501f6fa0.jpg?1783911238",
+          "png": "https://cards.scryfall.io/png/back/0/d/0d16e8e0-31b2-4389-afd6-783c501f6fa0.png?1783911238",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/0/d/0d16e8e0-31b2-4389-afd6-783c501f6fa0.jpg?1783911238",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/0/d/0d16e8e0-31b2-4389-afd6-783c501f6fa0.jpg?1783911238"
+        }
+      }
     },
     {
       "name": "Windswept Heath",
@@ -482,7 +496,21 @@
           "name": "Fable of the Mirror-Breaker // Reflection of Kiki-Jiki",
           "component": "combo_piece"
         }
-      ]
+      ],
+      "backFace": {
+        "name": "Reflection of Kiki-Jiki",
+        "manaCost": "",
+        "typeLine": "Enchantment Creature — Goblin Shaman",
+        "oracleText": "{1}, {T}: Create a token that's a copy of another target nonlegendary creature you control, except it has haste. Sacrifice it at the beginning of the next end step.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg?1783923875",
+          "normal": "https://cards.scryfall.io/normal/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg?1783923875",
+          "large": "https://cards.scryfall.io/large/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg?1783923875",
+          "png": "https://cards.scryfall.io/png/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.png?1783923875",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg?1783923875",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg?1783923875"
+        }
+      }
     },
     {
       "name": "Mountain",
@@ -574,7 +602,21 @@
           "name": "Dragon",
           "component": "token"
         }
-      ]
+      ],
+      "backFace": {
+        "name": "Avatar Roku",
+        "manaCost": "",
+        "typeLine": "Legendary Creature — Avatar",
+        "oracleText": "Firebending 4 (Whenever this creature attacks, add {R}{R}{R}{R}. This mana lasts until end of combat.)\n{8}: Create a 4/4 red Dragon creature token with flying and firebending 4.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/9/5/95f2f5af-d405-4534-8683-5a9001f997b4.jpg?1783904959",
+          "normal": "https://cards.scryfall.io/normal/back/9/5/95f2f5af-d405-4534-8683-5a9001f997b4.jpg?1783904959",
+          "large": "https://cards.scryfall.io/large/back/9/5/95f2f5af-d405-4534-8683-5a9001f997b4.jpg?1783904959",
+          "png": "https://cards.scryfall.io/png/back/9/5/95f2f5af-d405-4534-8683-5a9001f997b4.png?1783904959",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/9/5/95f2f5af-d405-4534-8683-5a9001f997b4.jpg?1783904959",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/9/5/95f2f5af-d405-4534-8683-5a9001f997b4.jpg?1783904959"
+        }
+      }
     },
     {
       "name": "Elegant Parlor",

--- a/public/preset_decks/starter_deck_dihada_reanimate.json
+++ b/public/preset_decks/starter_deck_dihada_reanimate.json
@@ -348,7 +348,21 @@
           "name": "Path of Mettle // Metzali, Tower of Triumph",
           "component": "combo_piece"
         }
-      ]
+      ],
+      "backFace": {
+        "name": "Metzali, Tower of Triumph",
+        "manaCost": "",
+        "typeLine": "Legendary Land",
+        "oracleText": "(Transforms from Path of Mettle.)\n{T}: Add one mana of any color.\n{1}{R}, {T}: Metzali deals 2 damage to each opponent.\n{2}{W}, {T}: Choose a creature at random that attacked this turn. Destroy that creature.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/6/6/66d9d524-3611-48d9-86c9-48e509e8ae70.jpg?1783935278",
+          "normal": "https://cards.scryfall.io/normal/back/6/6/66d9d524-3611-48d9-86c9-48e509e8ae70.jpg?1783935278",
+          "large": "https://cards.scryfall.io/large/back/6/6/66d9d524-3611-48d9-86c9-48e509e8ae70.jpg?1783935278",
+          "png": "https://cards.scryfall.io/png/back/6/6/66d9d524-3611-48d9-86c9-48e509e8ae70.png?1783935278",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/6/6/66d9d524-3611-48d9-86c9-48e509e8ae70.jpg?1783935278",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/6/6/66d9d524-3611-48d9-86c9-48e509e8ae70.jpg?1783935278"
+        }
+      }
     },
     {
       "name": "Clifftop Retreat",

--- a/public/preset_decks/starter_deck_dimir_tempo.json
+++ b/public/preset_decks/starter_deck_dimir_tempo.json
@@ -187,7 +187,21 @@
           "name": "Tamiyo, Seasoned Scholar Emblem",
           "component": "combo_piece"
         }
-      ]
+      ],
+      "backFace": {
+        "name": "Tamiyo, Seasoned Scholar",
+        "manaCost": "",
+        "typeLine": "Legendary Planeswalker — Tamiyo",
+        "oracleText": "+2: Until your next turn, whenever a creature attacks you or a planeswalker you control, it gets -1/-0 until end of turn.\n−3: Return target instant or sorcery card from your graveyard to your hand. If it's a green card, add one mana of any color.\n−7: Draw cards equal to half the number of cards in your library, rounded up. You get an emblem with \"You have no maximum hand size.\"",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/2/a/2a717b98-cdac-416d-bf6c-f6b6638e65d1.jpg?1783911236",
+          "normal": "https://cards.scryfall.io/normal/back/2/a/2a717b98-cdac-416d-bf6c-f6b6638e65d1.jpg?1783911236",
+          "large": "https://cards.scryfall.io/large/back/2/a/2a717b98-cdac-416d-bf6c-f6b6638e65d1.jpg?1783911236",
+          "png": "https://cards.scryfall.io/png/back/2/a/2a717b98-cdac-416d-bf6c-f6b6638e65d1.png?1783911236",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/2/a/2a717b98-cdac-416d-bf6c-f6b6638e65d1.jpg?1783911236",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/2/a/2a717b98-cdac-416d-bf6c-f6b6638e65d1.jpg?1783911236"
+        }
+      }
     },
     {
       "name": "Fatal Push",

--- a/public/preset_decks/starter_deck_esper_pixie.json
+++ b/public/preset_decks/starter_deck_esper_pixie.json
@@ -624,7 +624,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/8/2/82866a0e-485a-4f7e-8c49-f7d9ff3f4ad4.jpg?1764121420",
         "border_crop": "https://cards.scryfall.io/border_crop/front/8/2/82866a0e-485a-4f7e-8c49-f7d9ff3f4ad4.jpg?1764121420"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Aang and La, Ocean's Fury",
+        "manaCost": "",
+        "typeLine": "Legendary Creature — Avatar Spirit Ally",
+        "oracleText": "Reach, trample\nWhenever Aang and La attack, put a +1/+1 counter on each tapped creature you control.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/8/2/82866a0e-485a-4f7e-8c49-f7d9ff3f4ad4.jpg?1783904937",
+          "normal": "https://cards.scryfall.io/normal/back/8/2/82866a0e-485a-4f7e-8c49-f7d9ff3f4ad4.jpg?1783904937",
+          "large": "https://cards.scryfall.io/large/back/8/2/82866a0e-485a-4f7e-8c49-f7d9ff3f4ad4.jpg?1783904937",
+          "png": "https://cards.scryfall.io/png/back/8/2/82866a0e-485a-4f7e-8c49-f7d9ff3f4ad4.png?1783904937",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/8/2/82866a0e-485a-4f7e-8c49-f7d9ff3f4ad4.jpg?1783904937",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/8/2/82866a0e-485a-4f7e-8c49-f7d9ff3f4ad4.jpg?1783904937"
+        }
+      }
     }
   ]
 }

--- a/public/preset_decks/starter_deck_ghired.json
+++ b/public/preset_decks/starter_deck_ghired.json
@@ -538,7 +538,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1604197844",
         "border_crop": "https://cards.scryfall.io/border_crop/front/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1604197844"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Shatterskull, the Hammer Pass",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "As this land enters, you may pay 3 life. If you don't, it enters tapped.\n{T}: Add {R}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1783929355",
+          "normal": "https://cards.scryfall.io/normal/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1783929355",
+          "large": "https://cards.scryfall.io/large/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1783929355",
+          "png": "https://cards.scryfall.io/png/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.png?1783929355",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1783929355",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1783929355"
+        }
+      }
     },
     {
       "name": "Arcane Signet",
@@ -1002,7 +1016,21 @@
           "name": "Fable of the Mirror-Breaker // Reflection of Kiki-Jiki",
           "component": "combo_piece"
         }
-      ]
+      ],
+      "backFace": {
+        "name": "Reflection of Kiki-Jiki",
+        "manaCost": "",
+        "typeLine": "Enchantment Creature — Goblin Shaman",
+        "oracleText": "{1}, {T}: Create a token that's a copy of another target nonlegendary creature you control, except it has haste. Sacrifice it at the beginning of the next end step.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/6/d/6dee0388-a78d-4b3c-a0c5-25655e14115e.jpg?1783923746",
+          "normal": "https://cards.scryfall.io/normal/back/6/d/6dee0388-a78d-4b3c-a0c5-25655e14115e.jpg?1783923746",
+          "large": "https://cards.scryfall.io/large/back/6/d/6dee0388-a78d-4b3c-a0c5-25655e14115e.jpg?1783923746",
+          "png": "https://cards.scryfall.io/png/back/6/d/6dee0388-a78d-4b3c-a0c5-25655e14115e.png?1783923746",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/6/d/6dee0388-a78d-4b3c-a0c5-25655e14115e.jpg?1783923746",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/6/d/6dee0388-a78d-4b3c-a0c5-25655e14115e.jpg?1783923746"
+        }
+      }
     },
     {
       "name": "Eiganjo, Seat of the Empire",
@@ -1318,7 +1346,21 @@
           "name": "Etali, Primal Conqueror // Etali, Primal Sickness",
           "component": "combo_piece"
         }
-      ]
+      ],
+      "backFace": {
+        "name": "Etali, Primal Sickness",
+        "manaCost": "",
+        "typeLine": "Legendary Creature — Phyrexian Elder Dinosaur",
+        "oracleText": "Trample, indestructible\nWhenever Etali deals combat damage to a player, they get that many poison counters. (A player with ten or more poison counters loses the game.)",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/3/e/3e97c609-3932-4428-96d4-1c97e61f0abb.jpg?1783916922",
+          "normal": "https://cards.scryfall.io/normal/back/3/e/3e97c609-3932-4428-96d4-1c97e61f0abb.jpg?1783916922",
+          "large": "https://cards.scryfall.io/large/back/3/e/3e97c609-3932-4428-96d4-1c97e61f0abb.jpg?1783916922",
+          "png": "https://cards.scryfall.io/png/back/3/e/3e97c609-3932-4428-96d4-1c97e61f0abb.png?1783916922",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/3/e/3e97c609-3932-4428-96d4-1c97e61f0abb.jpg?1783916922",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/3/e/3e97c609-3932-4428-96d4-1c97e61f0abb.jpg?1783916922"
+        }
+      }
     },
     {
       "name": "Delighted Halfling",
@@ -1770,7 +1812,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/6/2/62061e7c-cf19-4f03-b8fa-2bdba62d6b0b.jpg?1717013161",
         "border_crop": "https://cards.scryfall.io/border_crop/front/6/2/62061e7c-cf19-4f03-b8fa-2bdba62d6b0b.jpg?1717013161"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Witch-Blessed Meadow",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "As this land enters, you may pay 3 life. If you don't, it enters tapped.\n{T}: Add {W}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/6/2/62061e7c-cf19-4f03-b8fa-2bdba62d6b0b.jpg?1783911236",
+          "normal": "https://cards.scryfall.io/normal/back/6/2/62061e7c-cf19-4f03-b8fa-2bdba62d6b0b.jpg?1783911236",
+          "large": "https://cards.scryfall.io/large/back/6/2/62061e7c-cf19-4f03-b8fa-2bdba62d6b0b.jpg?1783911236",
+          "png": "https://cards.scryfall.io/png/back/6/2/62061e7c-cf19-4f03-b8fa-2bdba62d6b0b.png?1783911236",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/6/2/62061e7c-cf19-4f03-b8fa-2bdba62d6b0b.jpg?1783911236",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/6/2/62061e7c-cf19-4f03-b8fa-2bdba62d6b0b.jpg?1783911236"
+        }
+      }
     },
     {
       "name": "Bridgeworks Battle // Tanglespan Bridgeworks",
@@ -1794,7 +1850,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg?1717013318",
         "border_crop": "https://cards.scryfall.io/border_crop/front/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg?1717013318"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Tanglespan Bridgeworks",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "As this land enters, you may pay 3 life. If you don't, it enters tapped.\n{T}: Add {G}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg?1783911228",
+          "normal": "https://cards.scryfall.io/normal/back/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg?1783911228",
+          "large": "https://cards.scryfall.io/large/back/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg?1783911228",
+          "png": "https://cards.scryfall.io/png/back/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.png?1783911228",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg?1783911228",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg?1783911228"
+        }
+      }
     },
     {
       "name": "Springheart Nantuko",
@@ -2581,7 +2651,21 @@
           "name": "Brigid, Clachan's Heart // Brigid, Doun's Mind",
           "component": "combo_piece"
         }
-      ]
+      ],
+      "backFace": {
+        "name": "Brigid, Doun's Mind",
+        "manaCost": "",
+        "typeLine": "Legendary Creature — Kithkin Soldier",
+        "oracleText": "{T}: Add X {G} or X {W}, where X is the number of other creatures you control.\nAt the beginning of your first main phase, you may pay {W}. If you do, transform Brigid.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/c/b/cb7d5bbb-4f68-4e38-8bb0-a95af21b24c8.jpg?1783904517",
+          "normal": "https://cards.scryfall.io/normal/back/c/b/cb7d5bbb-4f68-4e38-8bb0-a95af21b24c8.jpg?1783904517",
+          "large": "https://cards.scryfall.io/large/back/c/b/cb7d5bbb-4f68-4e38-8bb0-a95af21b24c8.jpg?1783904517",
+          "png": "https://cards.scryfall.io/png/back/c/b/cb7d5bbb-4f68-4e38-8bb0-a95af21b24c8.png?1783904517",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/c/b/cb7d5bbb-4f68-4e38-8bb0-a95af21b24c8.jpg?1783904517",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/c/b/cb7d5bbb-4f68-4e38-8bb0-a95af21b24c8.jpg?1783904517"
+        }
+      }
     },
     {
       "name": "Forest",

--- a/public/preset_decks/starter_deck_greasefang.json
+++ b/public/preset_decks/starter_deck_greasefang.json
@@ -439,7 +439,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/d/2/d24c3d51-795d-4c01-a34a-3280fccd2d78.jpg?1669839386",
         "border_crop": "https://cards.scryfall.io/border_crop/front/d/2/d24c3d51-795d-4c01-a34a-3280fccd2d78.jpg?1669839386"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Grimclimb Pathway",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "{T}: Add {B}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/d/2/d24c3d51-795d-4c01-a34a-3280fccd2d78.jpg?1783929313",
+          "normal": "https://cards.scryfall.io/normal/back/d/2/d24c3d51-795d-4c01-a34a-3280fccd2d78.jpg?1783929313",
+          "large": "https://cards.scryfall.io/large/back/d/2/d24c3d51-795d-4c01-a34a-3280fccd2d78.jpg?1783929313",
+          "png": "https://cards.scryfall.io/png/back/d/2/d24c3d51-795d-4c01-a34a-3280fccd2d78.png?1783929313",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/d/2/d24c3d51-795d-4c01-a34a-3280fccd2d78.jpg?1783929313",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/d/2/d24c3d51-795d-4c01-a34a-3280fccd2d78.jpg?1783929313"
+        }
+      }
     },
     {
       "name": "Shadowy Backstreet",

--- a/public/preset_decks/starter_deck_izzet_creativity.json
+++ b/public/preset_decks/starter_deck_izzet_creativity.json
@@ -77,7 +77,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/a/6/a69541db-3f4e-412f-aa8e-dec1e74f74dc.jpg?1604198070",
         "border_crop": "https://cards.scryfall.io/border_crop/front/a/6/a69541db-3f4e-412f-aa8e-dec1e74f74dc.jpg?1604198070"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Spikefield Cave",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "This land enters tapped.\n{T}: Add {R}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/a/6/a69541db-3f4e-412f-aa8e-dec1e74f74dc.jpg?1783929354",
+          "normal": "https://cards.scryfall.io/normal/back/a/6/a69541db-3f4e-412f-aa8e-dec1e74f74dc.jpg?1783929354",
+          "large": "https://cards.scryfall.io/large/back/a/6/a69541db-3f4e-412f-aa8e-dec1e74f74dc.jpg?1783929354",
+          "png": "https://cards.scryfall.io/png/back/a/6/a69541db-3f4e-412f-aa8e-dec1e74f74dc.png?1783929354",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/a/6/a69541db-3f4e-412f-aa8e-dec1e74f74dc.jpg?1783929354",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/a/6/a69541db-3f4e-412f-aa8e-dec1e74f74dc.jpg?1783929354"
+        }
+      }
     },
     {
       "name": "Sokenzan, Crucible of Defiance",
@@ -268,7 +282,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/2/6/2668ac91-6cda-4f81-a08d-4fc5f9cb35b2.jpg?1669839416",
         "border_crop": "https://cards.scryfall.io/border_crop/front/2/6/2668ac91-6cda-4f81-a08d-4fc5f9cb35b2.jpg?1669839416"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Lavaglide Pathway",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "{T}: Add {R}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/2/6/2668ac91-6cda-4f81-a08d-4fc5f9cb35b2.jpg?1783929311",
+          "normal": "https://cards.scryfall.io/normal/back/2/6/2668ac91-6cda-4f81-a08d-4fc5f9cb35b2.jpg?1783929311",
+          "large": "https://cards.scryfall.io/large/back/2/6/2668ac91-6cda-4f81-a08d-4fc5f9cb35b2.jpg?1783929311",
+          "png": "https://cards.scryfall.io/png/back/2/6/2668ac91-6cda-4f81-a08d-4fc5f9cb35b2.png?1783929311",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/2/6/2668ac91-6cda-4f81-a08d-4fc5f9cb35b2.jpg?1783929311",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/2/6/2668ac91-6cda-4f81-a08d-4fc5f9cb35b2.jpg?1783929311"
+        }
+      }
     },
     {
       "name": "Fable of the Mirror-Breaker // Reflection of Kiki-Jiki",
@@ -309,7 +337,21 @@
           "name": "Fable of the Mirror-Breaker // Reflection of Kiki-Jiki",
           "component": "combo_piece"
         }
-      ]
+      ],
+      "backFace": {
+        "name": "Reflection of Kiki-Jiki",
+        "manaCost": "",
+        "typeLine": "Enchantment Creature — Goblin Shaman",
+        "oracleText": "{1}, {T}: Create a token that's a copy of another target nonlegendary creature you control, except it has haste. Sacrifice it at the beginning of the next end step.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg?1783923875",
+          "normal": "https://cards.scryfall.io/normal/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg?1783923875",
+          "large": "https://cards.scryfall.io/large/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg?1783923875",
+          "png": "https://cards.scryfall.io/png/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.png?1783923875",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg?1783923875",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg?1783923875"
+        }
+      }
     },
     {
       "name": "Big Score",
@@ -484,7 +526,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg?1604198379",
         "border_crop": "https://cards.scryfall.io/border_crop/front/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg?1604198379"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Valakut Stoneforge",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "This land enters tapped.\n{T}: Add {R}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg?1783929350",
+          "normal": "https://cards.scryfall.io/normal/back/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg?1783929350",
+          "large": "https://cards.scryfall.io/large/back/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg?1783929350",
+          "png": "https://cards.scryfall.io/png/back/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.png?1783929350",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg?1783929350",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg?1783929350"
+        }
+      }
     },
     {
       "name": "Dig Through Time",

--- a/public/preset_decks/starter_deck_kasla.json
+++ b/public/preset_decks/starter_deck_kasla.json
@@ -947,7 +947,21 @@
           "name": "Angel Warrior",
           "component": "token"
         }
-      ]
+      ],
+      "backFace": {
+        "name": "Emeria, Shattered Skyclave",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "As this land enters, you may pay 3 life. If you don't, it enters tapped.\n{T}: Add {W}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/c/4/c470539a-9cc7-4175-8f7c-c982b6072b6d.jpg?1783929425",
+          "normal": "https://cards.scryfall.io/normal/back/c/4/c470539a-9cc7-4175-8f7c-c982b6072b6d.jpg?1783929425",
+          "large": "https://cards.scryfall.io/large/back/c/4/c470539a-9cc7-4175-8f7c-c982b6072b6d.jpg?1783929425",
+          "png": "https://cards.scryfall.io/png/back/c/4/c470539a-9cc7-4175-8f7c-c982b6072b6d.png?1783929425",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/c/4/c470539a-9cc7-4175-8f7c-c982b6072b6d.jpg?1783929425",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/c/4/c470539a-9cc7-4175-8f7c-c982b6072b6d.jpg?1783929425"
+        }
+      }
     },
     {
       "name": "Shatterskull Smashing // Shatterskull, the Hammer Pass",
@@ -971,7 +985,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1604197844",
         "border_crop": "https://cards.scryfall.io/border_crop/front/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1604197844"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Shatterskull, the Hammer Pass",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "As this land enters, you may pay 3 life. If you don't, it enters tapped.\n{T}: Add {R}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1783929355",
+          "normal": "https://cards.scryfall.io/normal/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1783929355",
+          "large": "https://cards.scryfall.io/large/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1783929355",
+          "png": "https://cards.scryfall.io/png/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.png?1783929355",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1783929355",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/b/c/bc7239ea-f8aa-4a6f-87bd-c35359635673.jpg?1783929355"
+        }
+      }
     },
     {
       "name": "Arcane Signet",
@@ -2394,7 +2422,21 @@
           "name": "Kraken",
           "component": "token"
         }
-      ]
+      ],
+      "backFace": {
+        "name": "Caetus, Sea Tyrant of Segovia",
+        "manaCost": "",
+        "typeLine": "Legendary Creature — Serpent",
+        "oracleText": "Noncreature spells you cast have convoke. (Your creatures can help cast those spells. Each creature you tap while casting a noncreature spell pays for {1} or one mana of that creature's color.)\nAt the beginning of your end step, untap up to four target creatures.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/9/d/9df3e743-7bb8-482a-afd1-4d51119d416c.jpg?1783917037",
+          "normal": "https://cards.scryfall.io/normal/back/9/d/9df3e743-7bb8-482a-afd1-4d51119d416c.jpg?1783917037",
+          "large": "https://cards.scryfall.io/large/back/9/d/9df3e743-7bb8-482a-afd1-4d51119d416c.jpg?1783917037",
+          "png": "https://cards.scryfall.io/png/back/9/d/9df3e743-7bb8-482a-afd1-4d51119d416c.png?1783917037",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/9/d/9df3e743-7bb8-482a-afd1-4d51119d416c.jpg?1783917037",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/9/d/9df3e743-7bb8-482a-afd1-4d51119d416c.jpg?1783917037"
+        }
+      }
     },
     {
       "name": "City on Fire",

--- a/public/preset_decks/starter_deck_lands.json
+++ b/public/preset_decks/starter_deck_lands.json
@@ -360,7 +360,21 @@
           "name": "Outland Liberator // Frenzied Trapbreaker",
           "component": "combo_piece"
         }
-      ]
+      ],
+      "backFace": {
+        "name": "Frenzied Trapbreaker",
+        "manaCost": "",
+        "typeLine": "Creature — Werewolf",
+        "oracleText": "{1}, Sacrifice this creature: Destroy target artifact or enchantment.\nWhenever this creature attacks, destroy target artifact or enchantment defending player controls.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/f/8/f86b7c7e-825a-4634-8a85-3b56f112188c.jpg?1783925525",
+          "normal": "https://cards.scryfall.io/normal/back/f/8/f86b7c7e-825a-4634-8a85-3b56f112188c.jpg?1783925525",
+          "large": "https://cards.scryfall.io/large/back/f/8/f86b7c7e-825a-4634-8a85-3b56f112188c.jpg?1783925525",
+          "png": "https://cards.scryfall.io/png/back/f/8/f86b7c7e-825a-4634-8a85-3b56f112188c.png?1783925525",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/f/8/f86b7c7e-825a-4634-8a85-3b56f112188c.jpg?1783925525",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/f/8/f86b7c7e-825a-4634-8a85-3b56f112188c.jpg?1783925525"
+        }
+      }
     },
     {
       "name": "Boseiju, Who Endures",

--- a/public/preset_decks/starter_deck_living_end.json
+++ b/public/preset_decks/starter_deck_living_end.json
@@ -327,7 +327,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/a/8/a8e9ea5a-5e10-4b77-baef-0352ff035483.jpg?1717013335",
         "border_crop": "https://cards.scryfall.io/border_crop/front/a/8/a8e9ea5a-5e10-4b77-baef-0352ff035483.jpg?1717013335"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Garden of Freyalise",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "As this land enters, you may pay 3 life. If you don't, it enters tapped.\n{T}: Add {G}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/a/8/a8e9ea5a-5e10-4b77-baef-0352ff035483.jpg?1783911228",
+          "normal": "https://cards.scryfall.io/normal/back/a/8/a8e9ea5a-5e10-4b77-baef-0352ff035483.jpg?1783911228",
+          "large": "https://cards.scryfall.io/large/back/a/8/a8e9ea5a-5e10-4b77-baef-0352ff035483.jpg?1783911228",
+          "png": "https://cards.scryfall.io/png/back/a/8/a8e9ea5a-5e10-4b77-baef-0352ff035483.png?1783911228",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/a/8/a8e9ea5a-5e10-4b77-baef-0352ff035483.jpg?1783911228",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/a/8/a8e9ea5a-5e10-4b77-baef-0352ff035483.jpg?1783911228"
+        }
+      }
     },
     {
       "name": "Sink into Stupor // Soporific Springs",
@@ -351,7 +365,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1717013194",
         "border_crop": "https://cards.scryfall.io/border_crop/front/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1717013194"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Soporific Springs",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "As this land enters, you may pay 3 life. If you don't, it enters tapped.\n{T}: Add {U}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1783911236",
+          "normal": "https://cards.scryfall.io/normal/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1783911236",
+          "large": "https://cards.scryfall.io/large/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1783911236",
+          "png": "https://cards.scryfall.io/png/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.png?1783911236",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1783911236",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1783911236"
+        }
+      }
     },
     {
       "name": "Forest",

--- a/public/preset_decks/starter_deck_mono_red_prison.json
+++ b/public/preset_decks/starter_deck_mono_red_prison.json
@@ -158,7 +158,21 @@
           "name": "Fable of the Mirror-Breaker // Reflection of Kiki-Jiki",
           "component": "combo_piece"
         }
-      ]
+      ],
+      "backFace": {
+        "name": "Reflection of Kiki-Jiki",
+        "manaCost": "",
+        "typeLine": "Enchantment Creature — Goblin Shaman",
+        "oracleText": "{1}, {T}: Create a token that's a copy of another target nonlegendary creature you control, except it has haste. Sacrifice it at the beginning of the next end step.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg?1783923875",
+          "normal": "https://cards.scryfall.io/normal/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg?1783923875",
+          "large": "https://cards.scryfall.io/large/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg?1783923875",
+          "png": "https://cards.scryfall.io/png/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.png?1783923875",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg?1783923875",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/2/4/24c0d87b-0049-4beb-b9cb-6f813b7aa7dc.jpg?1783923875"
+        }
+      }
     },
     {
       "name": "The One Ring",
@@ -241,7 +255,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/5/0/50686ac7-346c-43d1-bdaa-28d46a12ad93.jpg?1717013301",
         "border_crop": "https://cards.scryfall.io/border_crop/front/5/0/50686ac7-346c-43d1-bdaa-28d46a12ad93.jpg?1717013301"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Volcanic Fissure",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "As this land enters, you may pay 3 life. If you don't, it enters tapped.\n{T}: Add {R}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/5/0/50686ac7-346c-43d1-bdaa-28d46a12ad93.jpg?1783911228",
+          "normal": "https://cards.scryfall.io/normal/back/5/0/50686ac7-346c-43d1-bdaa-28d46a12ad93.jpg?1783911228",
+          "large": "https://cards.scryfall.io/large/back/5/0/50686ac7-346c-43d1-bdaa-28d46a12ad93.jpg?1783911228",
+          "png": "https://cards.scryfall.io/png/back/5/0/50686ac7-346c-43d1-bdaa-28d46a12ad93.png?1783911228",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/5/0/50686ac7-346c-43d1-bdaa-28d46a12ad93.jpg?1783911228",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/5/0/50686ac7-346c-43d1-bdaa-28d46a12ad93.jpg?1783911228"
+        }
+      }
     },
     {
       "name": "Pyrogoyf",

--- a/public/preset_decks/starter_deck_nicol_bolas_god_pharaoh.json
+++ b/public/preset_decks/starter_deck_nicol_bolas_god_pharaoh.json
@@ -391,7 +391,21 @@
           "name": "Core Set 2019 Checklist",
           "component": "combo_piece"
         }
-      ]
+      ],
+      "backFace": {
+        "name": "Nicol Bolas, the Arisen",
+        "manaCost": "",
+        "typeLine": "Legendary Planeswalker — Bolas",
+        "oracleText": "+2: Draw two cards.\n−3: Nicol Bolas deals 10 damage to target creature or planeswalker.\n−4: Put target creature or planeswalker card from a graveyard onto the battlefield under your control.\n−12: Exile all but the bottom card of target player's library.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/7/b/7b215968-93a6-4278-ac61-4e3e8c3c3943.jpg?1783934524",
+          "normal": "https://cards.scryfall.io/normal/back/7/b/7b215968-93a6-4278-ac61-4e3e8c3c3943.jpg?1783934524",
+          "large": "https://cards.scryfall.io/large/back/7/b/7b215968-93a6-4278-ac61-4e3e8c3c3943.jpg?1783934524",
+          "png": "https://cards.scryfall.io/png/back/7/b/7b215968-93a6-4278-ac61-4e3e8c3c3943.png?1783934524",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/7/b/7b215968-93a6-4278-ac61-4e3e8c3c3943.jpg?1783934524",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/7/b/7b215968-93a6-4278-ac61-4e3e8c3c3943.jpg?1783934524"
+        }
+      }
     },
     {
       "name": "Hostage Taker",
@@ -465,7 +479,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/7/8/78792607-0872-4de4-a9d8-92f1d58f4a71.jpg?1681763406",
         "border_crop": "https://cards.scryfall.io/border_crop/front/7/8/78792607-0872-4de4-a9d8-92f1d58f4a71.jpg?1681763406"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Lavaglide Pathway",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "{T}: Add {R}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/7/8/78792607-0872-4de4-a9d8-92f1d58f4a71.jpg?1783929299",
+          "normal": "https://cards.scryfall.io/normal/back/7/8/78792607-0872-4de4-a9d8-92f1d58f4a71.jpg?1783929299",
+          "large": "https://cards.scryfall.io/large/back/7/8/78792607-0872-4de4-a9d8-92f1d58f4a71.jpg?1783929299",
+          "png": "https://cards.scryfall.io/png/back/7/8/78792607-0872-4de4-a9d8-92f1d58f4a71.png?1783929299",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/7/8/78792607-0872-4de4-a9d8-92f1d58f4a71.jpg?1783929299",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/7/8/78792607-0872-4de4-a9d8-92f1d58f4a71.jpg?1783929299"
+        }
+      }
     },
     {
       "name": "Thieving Skydiver",
@@ -515,7 +543,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1669839373",
         "border_crop": "https://cards.scryfall.io/border_crop/front/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1669839373"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Searstep Pathway",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "{T}: Add {R}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1783928185",
+          "normal": "https://cards.scryfall.io/normal/back/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1783928185",
+          "large": "https://cards.scryfall.io/large/back/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1783928185",
+          "png": "https://cards.scryfall.io/png/back/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.png?1783928185",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1783928185",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1783928185"
+        }
+      }
     },
     {
       "name": "Valki, God of Lies // Tibalt, Cosmic Impostor",
@@ -550,7 +592,21 @@
           "name": "Valki, God of Lies // Tibalt, Cosmic Impostor",
           "component": "combo_piece"
         }
-      ]
+      ],
+      "backFace": {
+        "name": "Tibalt, Cosmic Impostor",
+        "manaCost": "{5}{B}{R}",
+        "typeLine": "Legendary Planeswalker — Tibalt",
+        "oracleText": "As Tibalt enters, you get an emblem with \"You may play cards exiled with Tibalt, Cosmic Impostor, and you may spend mana as though it were mana of any color to cast those spells.\"\n+2: Exile the top card of each player's library.\n−3: Exile target artifact or creature.\n−8: Exile all graveyards. Add {R}{R}{R}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/e/a/ea7e4c65-b4c4-4795-9475-3cba71c50ea5.jpg?1783928244",
+          "normal": "https://cards.scryfall.io/normal/back/e/a/ea7e4c65-b4c4-4795-9475-3cba71c50ea5.jpg?1783928244",
+          "large": "https://cards.scryfall.io/large/back/e/a/ea7e4c65-b4c4-4795-9475-3cba71c50ea5.jpg?1783928244",
+          "png": "https://cards.scryfall.io/png/back/e/a/ea7e4c65-b4c4-4795-9475-3cba71c50ea5.png?1783928244",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/e/a/ea7e4c65-b4c4-4795-9475-3cba71c50ea5.jpg?1783928244",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/e/a/ea7e4c65-b4c4-4795-9475-3cba71c50ea5.jpg?1783928244"
+        }
+      }
     },
     {
       "name": "Damnation",
@@ -890,7 +946,21 @@
           "name": "Day // Night",
           "component": "combo_piece"
         }
-      ]
+      ],
+      "backFace": {
+        "name": "Rahilda, Feral Outlaw",
+        "manaCost": "",
+        "typeLine": "Legendary Creature — Werewolf",
+        "oracleText": "Double strike\nWhen Rahilda, Feral Outlaw deals combat damage to a player, exile a nonland card from their library at random. During any turn you attacked with a Wolf or Werewolf, you may cast that card and you may spend mana as though it were mana of any color to cast that spell.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/2/f/2f986406-bfe3-4e59-bcb6-839ef5f1fbc4.jpg?1783924549",
+          "normal": "https://cards.scryfall.io/normal/back/2/f/2f986406-bfe3-4e59-bcb6-839ef5f1fbc4.jpg?1783924549",
+          "large": "https://cards.scryfall.io/large/back/2/f/2f986406-bfe3-4e59-bcb6-839ef5f1fbc4.jpg?1783924549",
+          "png": "https://cards.scryfall.io/png/back/2/f/2f986406-bfe3-4e59-bcb6-839ef5f1fbc4.png?1783924549",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/2/f/2f986406-bfe3-4e59-bcb6-839ef5f1fbc4.jpg?1783924549",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/2/f/2f986406-bfe3-4e59-bcb6-839ef5f1fbc4.jpg?1783924549"
+        }
+      }
     },
     {
       "name": "Otawara, Soaring City",
@@ -1243,7 +1313,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/b/f/bf2249e6-af74-4b88-8eb7-144ce8fa7f6b.jpg?1682203978",
         "border_crop": "https://cards.scryfall.io/border_crop/front/b/f/bf2249e6-af74-4b88-8eb7-144ce8fa7f6b.jpg?1682203978"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "The True Scriptures",
+        "manaCost": "",
+        "typeLine": "Enchantment — Saga",
+        "oracleText": "(As this Saga enters and after your draw step, add a lore counter.)\nI — For each opponent, destroy up to one target creature or planeswalker that player controls.\nII — Each opponent discards three cards, then mills three cards.\nIII — Put all creature cards from all graveyards onto the battlefield under your control. Exile this Saga, then return it to the battlefield (front face up).",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/b/f/bf2249e6-af74-4b88-8eb7-144ce8fa7f6b.jpg?1783917007",
+          "normal": "https://cards.scryfall.io/normal/back/b/f/bf2249e6-af74-4b88-8eb7-144ce8fa7f6b.jpg?1783917007",
+          "large": "https://cards.scryfall.io/large/back/b/f/bf2249e6-af74-4b88-8eb7-144ce8fa7f6b.jpg?1783917007",
+          "png": "https://cards.scryfall.io/png/back/b/f/bf2249e6-af74-4b88-8eb7-144ce8fa7f6b.png?1783917007",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/b/f/bf2249e6-af74-4b88-8eb7-144ce8fa7f6b.jpg?1783917007",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/b/f/bf2249e6-af74-4b88-8eb7-144ce8fa7f6b.jpg?1783917007"
+        }
+      }
     },
     {
       "name": "Clearwater Pathway // Murkwater Pathway",
@@ -1260,7 +1344,21 @@
       "text": "{T}: Add {U}.",
       "imageUrl": "https://cards.scryfall.io/normal/front/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg?1669839436",
       "layout": "modal_dfc",
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Murkwater Pathway",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "{T}: Add {B}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg?1783929316",
+          "normal": "https://cards.scryfall.io/normal/back/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg?1783929316",
+          "large": "https://cards.scryfall.io/large/back/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg?1783929316",
+          "png": "https://cards.scryfall.io/png/back/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.png?1783929316",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg?1783929316",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg?1783929316"
+        }
+      }
     },
     {
       "name": "Spiteful Banditry",
@@ -2008,7 +2106,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg?1717013242",
         "border_crop": "https://cards.scryfall.io/border_crop/front/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg?1717013242"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Fell Mire",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "As this land enters, you may pay 3 life. If you don't, it enters tapped.\n{T}: Add {B}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg?1783911234",
+          "normal": "https://cards.scryfall.io/normal/back/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg?1783911234",
+          "large": "https://cards.scryfall.io/large/back/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg?1783911234",
+          "png": "https://cards.scryfall.io/png/back/a/3/a3cb782d-c459-468d-9779-9b5669abc337.png?1783911234",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg?1783911234",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg?1783911234"
+        }
+      }
     },
     {
       "name": "Crabomination",

--- a/public/preset_decks/starter_deck_ognis.json
+++ b/public/preset_decks/starter_deck_ognis.json
@@ -622,7 +622,21 @@
           "name": "Ixalan Checklist",
           "component": "combo_piece"
         }
-      ]
+      ],
+      "backFace": {
+        "name": "Treasure Cove",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "(Transforms from Treasure Map.)\n{T}: Add {C}.\n{T}, Sacrifice a Treasure: Draw a card.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/c/0/c0f9c733-0818-4a03-8f0c-a163d09e0fff.jpg?1783935704",
+          "normal": "https://cards.scryfall.io/normal/back/c/0/c0f9c733-0818-4a03-8f0c-a163d09e0fff.jpg?1783935704",
+          "large": "https://cards.scryfall.io/large/back/c/0/c0f9c733-0818-4a03-8f0c-a163d09e0fff.jpg?1783935704",
+          "png": "https://cards.scryfall.io/png/back/c/0/c0f9c733-0818-4a03-8f0c-a163d09e0fff.png?1783935704",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/c/0/c0f9c733-0818-4a03-8f0c-a163d09e0fff.jpg?1783935704",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/c/0/c0f9c733-0818-4a03-8f0c-a163d09e0fff.jpg?1783935704"
+        }
+      }
     },
     {
       "name": "Grand Warlord Radha",
@@ -1077,7 +1091,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1669839373",
         "border_crop": "https://cards.scryfall.io/border_crop/front/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1669839373"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Searstep Pathway",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "{T}: Add {R}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1783928185",
+          "normal": "https://cards.scryfall.io/normal/back/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1783928185",
+          "large": "https://cards.scryfall.io/large/back/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1783928185",
+          "png": "https://cards.scryfall.io/png/back/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.png?1783928185",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1783928185",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1783928185"
+        }
+      }
     },
     {
       "name": "Darkbore Pathway // Slitherbore Pathway",
@@ -1101,7 +1129,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1669839402",
         "border_crop": "https://cards.scryfall.io/border_crop/front/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1669839402"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Slitherbore Pathway",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "{T}: Add {G}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1783928184",
+          "normal": "https://cards.scryfall.io/normal/back/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1783928184",
+          "large": "https://cards.scryfall.io/large/back/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1783928184",
+          "png": "https://cards.scryfall.io/png/back/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.png?1783928184",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1783928184",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1783928184"
+        }
+      }
     },
     {
       "name": "Goldspan Dragon",
@@ -1687,7 +1729,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/5/f/5fdf5fc4-69c8-4a59-9095-c2feefb64371.jpg?1643593558",
         "border_crop": "https://cards.scryfall.io/border_crop/front/5/f/5fdf5fc4-69c8-4a59-9095-c2feefb64371.jpg?1643593558"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Ulvenwald Behemoth",
+        "manaCost": "",
+        "typeLine": "Creature — Beast Horror",
+        "oracleText": "Trample, haste\nOther creatures you control get +1/+1 and have trample and haste.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/5/f/5fdf5fc4-69c8-4a59-9095-c2feefb64371.jpg?1783924806",
+          "normal": "https://cards.scryfall.io/normal/back/5/f/5fdf5fc4-69c8-4a59-9095-c2feefb64371.jpg?1783924806",
+          "large": "https://cards.scryfall.io/large/back/5/f/5fdf5fc4-69c8-4a59-9095-c2feefb64371.jpg?1783924806",
+          "png": "https://cards.scryfall.io/png/back/5/f/5fdf5fc4-69c8-4a59-9095-c2feefb64371.png?1783924806",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/5/f/5fdf5fc4-69c8-4a59-9095-c2feefb64371.jpg?1783924806",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/5/f/5fdf5fc4-69c8-4a59-9095-c2feefb64371.jpg?1783924806"
+        }
+      }
     },
     {
       "name": "Rakdos Charm",

--- a/public/preset_decks/starter_deck_red_deck_wins.json
+++ b/public/preset_decks/starter_deck_red_deck_wins.json
@@ -119,7 +119,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/2/8/28d92cad-45b0-479d-97fc-c175f3a3f259.jpg?1693966032",
         "border_crop": "https://cards.scryfall.io/border_crop/front/2/8/28d92cad-45b0-479d-97fc-c175f3a3f259.jpg?1693966032"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Etching of Kumano",
+        "manaCost": "",
+        "typeLine": "Enchantment Creature — Human Shaman",
+        "oracleText": "Haste\nIf a creature dealt damage this turn by a source you controlled would die, exile it instead.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/2/8/28d92cad-45b0-479d-97fc-c175f3a3f259.jpg?1783923870",
+          "normal": "https://cards.scryfall.io/normal/back/2/8/28d92cad-45b0-479d-97fc-c175f3a3f259.jpg?1783923870",
+          "large": "https://cards.scryfall.io/large/back/2/8/28d92cad-45b0-479d-97fc-c175f3a3f259.jpg?1783923870",
+          "png": "https://cards.scryfall.io/png/back/2/8/28d92cad-45b0-479d-97fc-c175f3a3f259.png?1783923870",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/2/8/28d92cad-45b0-479d-97fc-c175f3a3f259.jpg?1783923870",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/2/8/28d92cad-45b0-479d-97fc-c175f3a3f259.jpg?1783923870"
+        }
+      }
     },
     {
       "name": "Monastery Swiftspear",

--- a/public/preset_decks/starter_deck_ruby_storm.json
+++ b/public/preset_decks/starter_deck_ruby_storm.json
@@ -151,7 +151,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/4/3/438d8a26-ddc9-4829-8aff-22d6af6575cf.jpg?1748260617",
         "border_crop": "https://cards.scryfall.io/border_crop/front/4/3/438d8a26-ddc9-4829-8aff-22d6af6575cf.jpg?1748260617"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Ral, Leyline Prodigy",
+        "manaCost": "",
+        "typeLine": "Legendary Planeswalker — Ral",
+        "oracleText": "Ral enters with an additional loyalty counter on him for each instant and sorcery spell you've cast this turn.\n+1: Until your next turn, instant and sorcery spells you cast cost {1} less to cast.\n−2: Ral deals 2 damage divided as you choose among one or two targets. Draw a card if you control a blue permanent other than Ral.\n−8: Exile the top eight cards of your library. You may cast instant and sorcery spells from among them this turn without paying their mana costs.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/4/3/438d8a26-ddc9-4829-8aff-22d6af6575cf.jpg?1783911228",
+          "normal": "https://cards.scryfall.io/normal/back/4/3/438d8a26-ddc9-4829-8aff-22d6af6575cf.jpg?1783911228",
+          "large": "https://cards.scryfall.io/large/back/4/3/438d8a26-ddc9-4829-8aff-22d6af6575cf.jpg?1783911228",
+          "png": "https://cards.scryfall.io/png/back/4/3/438d8a26-ddc9-4829-8aff-22d6af6575cf.png?1783911228",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/4/3/438d8a26-ddc9-4829-8aff-22d6af6575cf.jpg?1783911228",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/4/3/438d8a26-ddc9-4829-8aff-22d6af6575cf.jpg?1783911228"
+        }
+      }
     },
     {
       "name": "Manamorphose",
@@ -424,7 +438,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg?1604198379",
         "border_crop": "https://cards.scryfall.io/border_crop/front/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg?1604198379"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Valakut Stoneforge",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "This land enters tapped.\n{T}: Add {R}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg?1783929350",
+          "normal": "https://cards.scryfall.io/normal/back/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg?1783929350",
+          "large": "https://cards.scryfall.io/large/back/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg?1783929350",
+          "png": "https://cards.scryfall.io/png/back/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.png?1783929350",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg?1783929350",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/2/2/228e551e-023a-4c9a-8f32-58dae6ffdf7f.jpg?1783929350"
+        }
+      }
     },
     {
       "name": "Grapeshot",

--- a/public/preset_decks/starter_deck_tyvar_glimpse.json
+++ b/public/preset_decks/starter_deck_tyvar_glimpse.json
@@ -813,7 +813,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg?1604199791",
         "border_crop": "https://cards.scryfall.io/border_crop/front/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg?1604199791"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Turntimber, Serpentine Wood",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "As this land enters, you may pay 3 life. If you don't, it enters tapped.\n{T}: Add {G}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg?1783929333",
+          "normal": "https://cards.scryfall.io/normal/back/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg?1783929333",
+          "large": "https://cards.scryfall.io/large/back/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg?1783929333",
+          "png": "https://cards.scryfall.io/png/back/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.png?1783929333",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg?1783929333",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/6/1/61bd69ea-1e9e-46b0-b1a1-ed7fdbe3deb6.jpg?1783929333"
+        }
+      }
     },
     {
       "name": "Fyndhorn Elves",
@@ -863,7 +877,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1669839402",
         "border_crop": "https://cards.scryfall.io/border_crop/front/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1669839402"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Slitherbore Pathway",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "{T}: Add {G}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1783928184",
+          "normal": "https://cards.scryfall.io/normal/back/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1783928184",
+          "large": "https://cards.scryfall.io/large/back/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1783928184",
+          "png": "https://cards.scryfall.io/png/back/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.png?1783928184",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1783928184",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1783928184"
+        }
+      }
     },
     {
       "name": "Lathril, Blade of the Elves",

--- a/public/preset_decks/starter_deck_urza_chief_artificer.json
+++ b/public/preset_decks/starter_deck_urza_chief_artificer.json
@@ -634,7 +634,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/f/2/f25d56f9-aa54-4657-9ac9-e93fbba3e715.jpg?1604193214",
         "border_crop": "https://cards.scryfall.io/border_crop/front/f/2/f25d56f9-aa54-4657-9ac9-e93fbba3e715.jpg?1604193214"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Sejiri Glacier",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "This land enters tapped.\n{T}: Add {W}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/f/2/f25d56f9-aa54-4657-9ac9-e93fbba3e715.jpg?1783929413",
+          "normal": "https://cards.scryfall.io/normal/back/f/2/f25d56f9-aa54-4657-9ac9-e93fbba3e715.jpg?1783929413",
+          "large": "https://cards.scryfall.io/large/back/f/2/f25d56f9-aa54-4657-9ac9-e93fbba3e715.jpg?1783929413",
+          "png": "https://cards.scryfall.io/png/back/f/2/f25d56f9-aa54-4657-9ac9-e93fbba3e715.png?1783929413",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/f/2/f25d56f9-aa54-4657-9ac9-e93fbba3e715.jpg?1783929413",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/f/2/f25d56f9-aa54-4657-9ac9-e93fbba3e715.jpg?1783929413"
+        }
+      }
     },
     {
       "name": "Kabira Takedown // Kabira Plateau",
@@ -658,7 +672,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/3/6/366e9845-019d-47cc-adb8-8fbbaad35b6d.jpg?1604195985",
         "border_crop": "https://cards.scryfall.io/border_crop/front/3/6/366e9845-019d-47cc-adb8-8fbbaad35b6d.jpg?1604195985"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Kabira Plateau",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "This land enters tapped.\n{T}: Add {W}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/3/6/366e9845-019d-47cc-adb8-8fbbaad35b6d.jpg?1783929423",
+          "normal": "https://cards.scryfall.io/normal/back/3/6/366e9845-019d-47cc-adb8-8fbbaad35b6d.jpg?1783929423",
+          "large": "https://cards.scryfall.io/large/back/3/6/366e9845-019d-47cc-adb8-8fbbaad35b6d.jpg?1783929423",
+          "png": "https://cards.scryfall.io/png/back/3/6/366e9845-019d-47cc-adb8-8fbbaad35b6d.png?1783929423",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/3/6/366e9845-019d-47cc-adb8-8fbbaad35b6d.jpg?1783929423",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/3/6/366e9845-019d-47cc-adb8-8fbbaad35b6d.jpg?1783929423"
+        }
+      }
     },
     {
       "name": "Sea Gate Restoration // Sea Gate, Reborn",
@@ -682,7 +710,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg?1604250788",
         "border_crop": "https://cards.scryfall.io/border_crop/front/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg?1604250788"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Sea Gate, Reborn",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "As this land enters, you may pay 3 life. If you don't, it enters tapped.\n{T}: Add {U}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg?1783929396",
+          "normal": "https://cards.scryfall.io/normal/back/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg?1783929396",
+          "large": "https://cards.scryfall.io/large/back/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg?1783929396",
+          "png": "https://cards.scryfall.io/png/back/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.png?1783929396",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg?1783929396",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/1/9/193071fe-180b-4d35-ba78-9c16675c29fc.jpg?1783929396"
+        }
+      }
     },
     {
       "name": "Malakir Rebirth // Malakir Mire",
@@ -706,7 +748,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/6/0/609d3ecf-f88d-4268-a8d3-4bf2bcf5df60.jpg?1604195984",
         "border_crop": "https://cards.scryfall.io/border_crop/front/6/0/609d3ecf-f88d-4268-a8d3-4bf2bcf5df60.jpg?1604195984"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Malakir Mire",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "This land enters tapped.\n{T}: Add {B}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/6/0/609d3ecf-f88d-4268-a8d3-4bf2bcf5df60.jpg?1783929378",
+          "normal": "https://cards.scryfall.io/normal/back/6/0/609d3ecf-f88d-4268-a8d3-4bf2bcf5df60.jpg?1783929378",
+          "large": "https://cards.scryfall.io/large/back/6/0/609d3ecf-f88d-4268-a8d3-4bf2bcf5df60.jpg?1783929378",
+          "png": "https://cards.scryfall.io/png/back/6/0/609d3ecf-f88d-4268-a8d3-4bf2bcf5df60.png?1783929378",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/6/0/609d3ecf-f88d-4268-a8d3-4bf2bcf5df60.jpg?1783929378",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/6/0/609d3ecf-f88d-4268-a8d3-4bf2bcf5df60.jpg?1783929378"
+        }
+      }
     },
     {
       "name": "Agadeem's Awakening // Agadeem, the Undercrypt",
@@ -730,7 +786,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/6/7/67f4c93b-080c-4196-b095-6a120a221988.jpg?1604195226",
         "border_crop": "https://cards.scryfall.io/border_crop/front/6/7/67f4c93b-080c-4196-b095-6a120a221988.jpg?1604195226"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Agadeem, the Undercrypt",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "As this land enters, you may pay 3 life. If you don't, it enters tapped.\n{T}: Add {B}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/6/7/67f4c93b-080c-4196-b095-6a120a221988.jpg?1783929388",
+          "normal": "https://cards.scryfall.io/normal/back/6/7/67f4c93b-080c-4196-b095-6a120a221988.jpg?1783929388",
+          "large": "https://cards.scryfall.io/large/back/6/7/67f4c93b-080c-4196-b095-6a120a221988.jpg?1783929388",
+          "png": "https://cards.scryfall.io/png/back/6/7/67f4c93b-080c-4196-b095-6a120a221988.png?1783929388",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/6/7/67f4c93b-080c-4196-b095-6a120a221988.jpg?1783929388",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/6/7/67f4c93b-080c-4196-b095-6a120a221988.jpg?1783929388"
+        }
+      }
     },
     {
       "name": "Inventors' Fair",
@@ -2318,7 +2388,21 @@
           "name": "Gnome Soldier",
           "component": "token"
         }
-      ]
+      ],
+      "backFace": {
+        "name": "Barracks of the Thousand",
+        "manaCost": "",
+        "typeLine": "Legendary Artifact Land",
+        "oracleText": "(Transforms from Thousand Moons Smithy.)\n{T}: Add {W}.\nWhenever you cast an artifact or creature spell using mana produced by Barracks of the Thousand, create a white Gnome Soldier artifact creature token with \"This token's power and toughness are each equal to the number of artifacts and/or creatures you control.\"",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/8/9/89a0f7fe-6bff-4c0a-b419-1f4f457c194c.jpg?1783913691",
+          "normal": "https://cards.scryfall.io/normal/back/8/9/89a0f7fe-6bff-4c0a-b419-1f4f457c194c.jpg?1783913691",
+          "large": "https://cards.scryfall.io/large/back/8/9/89a0f7fe-6bff-4c0a-b419-1f4f457c194c.jpg?1783913691",
+          "png": "https://cards.scryfall.io/png/back/8/9/89a0f7fe-6bff-4c0a-b419-1f4f457c194c.png?1783913691",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/8/9/89a0f7fe-6bff-4c0a-b419-1f4f457c194c.jpg?1783913691",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/8/9/89a0f7fe-6bff-4c0a-b419-1f4f457c194c.jpg?1783913691"
+        }
+      }
     },
     {
       "name": "Illustrious Wanderglyph",
@@ -2459,7 +2543,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1717013194",
         "border_crop": "https://cards.scryfall.io/border_crop/front/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1717013194"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Soporific Springs",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "As this land enters, you may pay 3 life. If you don't, it enters tapped.\n{T}: Add {U}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1783911236",
+          "normal": "https://cards.scryfall.io/normal/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1783911236",
+          "large": "https://cards.scryfall.io/large/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1783911236",
+          "png": "https://cards.scryfall.io/png/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.png?1783911236",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1783911236",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1783911236"
+        }
+      }
     },
     {
       "name": "Dawn's Truce",

--- a/public/preset_decks/starter_deck_workshop.json
+++ b/public/preset_decks/starter_deck_workshop.json
@@ -182,7 +182,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1717013194",
         "border_crop": "https://cards.scryfall.io/border_crop/front/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1717013194"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Soporific Springs",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "As this land enters, you may pay 3 life. If you don't, it enters tapped.\n{T}: Add {U}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1783911236",
+          "normal": "https://cards.scryfall.io/normal/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1783911236",
+          "large": "https://cards.scryfall.io/large/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1783911236",
+          "png": "https://cards.scryfall.io/png/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.png?1783911236",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1783911236",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/5/3/5358b87a-1a29-426d-b165-40c97da2c14d.jpg?1783911236"
+        }
+      }
     },
     {
       "name": "Paradoxical Outcome",

--- a/public/preset_decks/starter_deck_yarok.json
+++ b/public/preset_decks/starter_deck_yarok.json
@@ -1404,7 +1404,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg?1717013242",
         "border_crop": "https://cards.scryfall.io/border_crop/front/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg?1717013242"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Fell Mire",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "As this land enters, you may pay 3 life. If you don't, it enters tapped.\n{T}: Add {B}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg?1783911234",
+          "normal": "https://cards.scryfall.io/normal/back/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg?1783911234",
+          "large": "https://cards.scryfall.io/large/back/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg?1783911234",
+          "png": "https://cards.scryfall.io/png/back/a/3/a3cb782d-c459-468d-9779-9b5669abc337.png?1783911234",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg?1783911234",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/a/3/a3cb782d-c459-468d-9779-9b5669abc337.jpg?1783911234"
+        }
+      }
     },
     {
       "name": "Bridgeworks Battle // Tanglespan Bridgeworks",
@@ -1428,7 +1442,21 @@
         "art_crop": "https://cards.scryfall.io/art_crop/front/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg?1717013318",
         "border_crop": "https://cards.scryfall.io/border_crop/front/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg?1717013318"
       },
-      "allParts": []
+      "allParts": [],
+      "backFace": {
+        "name": "Tanglespan Bridgeworks",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "As this land enters, you may pay 3 life. If you don't, it enters tapped.\n{T}: Add {G}.",
+        "uris": {
+          "small": "https://cards.scryfall.io/small/back/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg?1783911228",
+          "normal": "https://cards.scryfall.io/normal/back/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg?1783911228",
+          "large": "https://cards.scryfall.io/large/back/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg?1783911228",
+          "png": "https://cards.scryfall.io/png/back/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.png?1783911228",
+          "art_crop": "https://cards.scryfall.io/art_crop/back/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg?1783911228",
+          "border_crop": "https://cards.scryfall.io/border_crop/back/e/b/ebef3db0-2b58-4581-a79c-fbca9a059e63.jpg?1783911228"
+        }
+      }
     },
     {
       "name": "Springheart Nantuko",

--- a/scripts/enrich-preset-decks.mjs
+++ b/scripts/enrich-preset-decks.mjs
@@ -39,8 +39,15 @@ function hasMetadata(entry) {
   return META_FIELDS.some((f) => f in entry);
 }
 
+// A double-faced card (transform / modal_dfc) that predates the baked back face
+// needs one more fetch to add it. Non-DFC cards never do.
+function needsBackFace(entry) {
+  const dfc = entry.layout === "transform" || entry.layout === "modal_dfc";
+  return dfc && !("backFace" in entry);
+}
+
 function isFullyEnriched(entry) {
-  return hasMetadata(entry) && "allParts" in entry;
+  return hasMetadata(entry) && "allParts" in entry && !needsBackFace(entry);
 }
 
 function parseTypeLine(typeLine) {
@@ -72,11 +79,35 @@ function frontFace(sc) {
   return sc.card_faces?.[0] ?? sc;
 }
 
+// The back face (transform / modal_dfc), in `CardFaceSummary` shape, so the deck
+// carries it and rendering never needs a live Scryfall lookup. `undefined` for
+// single-faced cards and faces without their own image.
+function backFaceFromScryfall(sc) {
+  const back = sc.card_faces?.[1];
+  const img = back?.image_uris;
+  if (!back || !img) return undefined;
+  return {
+    name: back.name,
+    manaCost: back.mana_cost ?? "",
+    typeLine: back.type_line ?? "",
+    oracleText: back.oracle_text ?? "",
+    uris: {
+      small: img.small ?? "",
+      normal: img.normal ?? "",
+      large: img.large ?? "",
+      png: img.png ?? "",
+      art_crop: img.art_crop ?? "",
+      border_crop: img.border_crop ?? "",
+    },
+  };
+}
+
 function metadataFromScryfall(sc) {
   const front = frontFace(sc);
   const tl = front.type_line ?? sc.type_line ?? "";
   const { supertypes, types, subtypes } = parseTypeLine(tl);
   return {
+    backFace: backFaceFromScryfall(sc),
     manaCost: front.mana_cost ?? sc.mana_cost ?? "",
     colors: sc.colors ?? front.colors ?? [],
     colorIdentity: sc.color_identity ?? [],
@@ -98,7 +129,12 @@ function metadataFromScryfall(sc) {
 async function fetchBatch(identifiers) {
   const res = await fetch(`${SCRYFALL_API}/cards/collection`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    // Scryfall rejects the HTTP library's default User-Agent (400 generic_user_agent).
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      "User-Agent": "manabrew-preset-enricher/1.0",
+    },
     body: JSON.stringify({ identifiers }),
   });
   if (!res.ok) throw new Error(`Scryfall ${res.status}`);
@@ -209,7 +245,9 @@ async function main() {
       // preserve the existing shape and only patch in `allParts` so we don't
       // churn unrelated fields or drop the full `uris` object.
       if (hasMetadata(card)) {
-        return { ...card, allParts: meta.allParts ?? [] };
+        const patched = { ...card, allParts: meta.allParts ?? [] };
+        if (meta.backFace) patched.backFace = meta.backFace;
+        return patched;
       }
       const ordered = { name: card.name };
       if (card.count !== undefined) ordered.count = card.count;

--- a/src/lib/presetDecks.ts
+++ b/src/lib/presetDecks.ts
@@ -1,4 +1,10 @@
-import type { CardPartComponent, Deck, DeckCard, DeckFormat } from "@/protocol/deck";
+import type {
+  CardFaceSummary,
+  CardPartComponent,
+  Deck,
+  DeckCard,
+  DeckFormat,
+} from "@/protocol/deck";
 import type { ScryfallImageUris } from "@/types/scryfall";
 import { frontFaceName } from "@/lib/scryfall.utils";
 
@@ -19,6 +25,7 @@ interface PresetDeckCardDefinition {
   layout?: string;
   power?: string;
   toughness?: string;
+  backFace?: CardFaceSummary;
   allParts?: Array<{ name: string; component: CardPartComponent }>;
 }
 
@@ -62,6 +69,7 @@ export function expandPresetDeckDefinition(preset: PresetDeckDefinition): Deck {
         text: entry.text ?? "",
         uris: entry.uris,
         layout: entry.layout,
+        backFace: entry.backFace,
         allParts: entry.allParts,
       };
 

--- a/src/lib/scryfall.utils.ts
+++ b/src/lib/scryfall.utils.ts
@@ -1,4 +1,4 @@
-import type { DeckCard } from "@/protocol/deck";
+import type { CardFaceSummary, DeckCard } from "@/protocol/deck";
 import type { ScryfallCard } from "@/types/scryfall";
 import { getScryfallManaCost } from "@/api/scryfall";
 import { chooseImageUrisForCard } from "@/stores/useScryfallStore";
@@ -53,6 +53,30 @@ function detectIsDoubleFaced(sc: ScryfallCard): boolean {
   return !!(sc.card_faces && sc.card_faces.length >= 2 && sc.card_faces[1]?.image_uris);
 }
 
+/** Capture the back face (name/text/mana/type + images) so the deck carries it
+ *  and rendering never needs a live Scryfall lookup. Only for real two-image
+ *  faces (same gate as `detectIsDoubleFaced`), so split/adventure/flip/room —
+ *  which share one image — return undefined. */
+function buildBackFaceSummary(sc: ScryfallCard): CardFaceSummary | undefined {
+  const back = sc.card_faces?.[1];
+  const img = back?.image_uris;
+  if (!back || !img) return undefined;
+  return {
+    name: back.name,
+    manaCost: back.mana_cost ?? "",
+    typeLine: back.type_line ?? "",
+    oracleText: back.oracle_text ?? "",
+    uris: {
+      small: img.small,
+      normal: img.normal,
+      large: img.large,
+      png: img.png,
+      art_crop: img.art_crop,
+      border_crop: img.border_crop,
+    },
+  };
+}
+
 export function scryfallToDeckCard(sc: ScryfallCard): DeckCard {
   const id = sc.id;
   const { supertypes, types, subtypes } = parseTypeLine(getFrontTypeLine(sc));
@@ -77,6 +101,7 @@ export function scryfallToDeckCard(sc: ScryfallCard): DeckCard {
     text: getFrontOracleText(sc),
     uris,
     isDoubleFaced: detectIsDoubleFaced(sc) || undefined,
+    backFace: buildBackFaceSummary(sc),
     layout: sc.layout || undefined,
     allParts: sc.all_parts?.map((p) => ({ name: p.name, component: p.component })) ?? [],
   };

--- a/src/stores/useScryfallStore.ts
+++ b/src/stores/useScryfallStore.ts
@@ -345,7 +345,10 @@ export const useScryfallStore = create<ScryfallState>()(
       getCardTexture: async (deckCard, variant = "full", faceIndex = 0) => {
         const pick = (u: ScryfallImageUris | undefined) =>
           variant === "art" ? u?.art_crop : u?.border_crop;
-        let url = faceIndex === 0 ? pick(deckCard.uris) : undefined;
+        // The deck now carries the back face (`backFace.uris`), so DFC rendering
+        // reads it directly instead of a live Scryfall lookup. Falls through to
+        // the fetch below for older decks that predate the stored back face.
+        let url = faceIndex === 0 ? pick(deckCard.uris) : pick(deckCard.backFace?.uris);
         if (!url) {
           const entry = await get().getCard({
             name: deckCard.identity.name,

--- a/website/src/generated/protocol-types.json
+++ b/website/src/generated/protocol-types.json
@@ -60,6 +60,7 @@
     "ZoneKind"
   ],
   "deck": [
+    "CardFaceSummary",
     "CardImageUris",
     "CardPart",
     "CardPartComponent",
@@ -109,6 +110,11 @@
       "ts": "interface CardDto {\n  id: string;\n  identity: CardIdentity;\n  color: string;\n  manaCost: string;\n  cmc: number;\n  types: Array<string>;\n  subtypes: Array<string>;\n  supertypes: Array<string>;\n  power: string | null;\n  toughness: string | null;\n  basePower?: number;\n  baseToughness?: number;\n  text: string;\n  controllerId: string;\n  ownerId: string;\n  tapped: boolean;\n  isCrewed: boolean;\n  isAttacking: boolean;\n  attackingPlayerId?: string;\n  attackTargetId?: string;\n  keywords: Array<string>;\n  counters: Record<string, number>;\n  damage: number;\n  summoningSick: boolean;\n  isCopy: boolean;\n  isDoubleFaced: boolean;\n  isTransformed: boolean;\n  isFaceDown: boolean;\n  isBestowed: boolean;\n  phasedOut: boolean;\n  exerted: boolean;\n  isRingBearer: boolean;\n  attachedTo?: string;\n  attachmentIds: Array<string>;\n  mergedCardIds: Array<string>;\n  flashbackCost?: string;\n  kickerCost?: string;\n  effectiveManaCost?: string;\n  madnessCost?: string;\n  isMadnessExiled: boolean;\n  isPlotted: boolean;\n  isWarpExiled: boolean;\n  foil: boolean;\n  wouldDieInCombat: boolean;\n}",
       "rust": "#[serde(rename_all = \"camelCase\", default)]\npub struct CardDto {\n    pub id: String,\n    pub identity: CardIdentity,\n    pub color: String,\n    pub mana_cost: String,\n    pub cmc: i32,\n    pub types: Vec<String>,\n    pub subtypes: Vec<String>,\n    pub supertypes: Vec<String>,\n    pub power: Option<String>,\n    pub toughness: Option<String>,\n    #[serde(skip_serializing_if = \"Option::is_none\")]\n    pub base_power: Option<i32>,\n    #[serde(skip_serializing_if = \"Option::is_none\")]\n    pub base_toughness: Option<i32>,\n    pub text: String,\n    pub controller_id: String,\n    pub owner_id: String,\n    pub tapped: bool,\n    #[serde(default, skip_serializing_if = \"std::ops::Not::not\")]\n    pub is_crewed: bool,\n    #[serde(default, skip_serializing_if = \"std::ops::Not::not\")]\n    pub is_attacking: bool,\n    #[serde(default, skip_serializing_if = \"Option::is_none\")]\n    pub attacking_player_id: Option<String>,\n    #[serde(default, skip_serializing_if = \"Option::is_none\")]\n    pub attack_target_id: Option<String>,\n    pub keywords: Vec<String>,\n    // Keyed by the engine's canonical `CounterType` display form (\"P1P1\",\n    // \"Loyalty\", one-off counter names uppercase); both producers must match it.\n    pub counters: BTreeMap<String, u32>,\n    pub damage: i32,\n    pub summoning_sick: bool,\n    #[serde(default, skip_serializing_if = \"std::ops::Not::not\")]\n    pub is_copy: bool,\n    pub is_double_faced: bool,\n    pub is_transformed: bool,\n    pub is_face_down: bool,\n    pub is_bestowed: bool,\n    pub phased_out: bool,\n    pub exerted: bool,\n    #[serde(default, skip_serializing_if = \"std::ops::Not::not\")]\n    pub is_ring_bearer: bool,\n    #[serde(skip_serializing_if = \"Option::is_none\")]\n    pub attached_to: Option<String>,\n    #[serde(default, skip_serializing_if = \"Vec::is_empty\")]\n    pub attachment_ids: Vec<String>,\n    // Mutate pile: the card ids merged under this top card.\n    #[serde(default, skip_serializing_if = \"Vec::is_empty\")]\n    pub merged_card_ids: Vec<String>,\n    #[serde(skip_serializing_if = \"Option::is_none\")]\n    pub flashback_cost: Option<String>,\n    #[serde(skip_serializing_if = \"Option::is_none\")]\n    pub kicker_cost: Option<String>,\n    #[serde(skip_serializing_if = \"Option::is_none\")]\n    pub effective_mana_cost: Option<String>,\n    #[serde(skip_serializing_if = \"Option::is_none\")]\n    pub madness_cost: Option<String>,\n    #[serde(default, skip_serializing_if = \"std::ops::Not::not\")]\n    pub is_madness_exiled: bool,\n    #[serde(default, skip_serializing_if = \"std::ops::Not::not\")]\n    pub is_plotted: bool,\n    #[serde(default, skip_serializing_if = \"std::ops::Not::not\")]\n    pub is_warp_exiled: bool,\n    #[serde(default, skip_serializing_if = \"std::ops::Not::not\")]\n    pub foil: bool,\n    #[serde(default, skip_serializing_if = \"std::ops::Not::not\")]\n    pub would_die_in_combat: bool,\n}",
       "refs": ["CardIdentity"]
+    },
+    "CardFaceSummary": {
+      "ts": "interface CardFaceSummary {\n  name: string;\n  manaCost: string;\n  typeLine: string;\n  oracleText: string;\n  uris: CardImageUris;\n}",
+      "rust": "/// One face of a double-faced card, in the same shape the UI renders a front\n/// face from. Carried for the *back* face on `CardRulesSummary` (the front face\n/// is the flattened fields on the card itself).\n#[serde(rename_all = \"camelCase\")]\npub struct CardFaceSummary {\n    pub name: String,\n    #[serde(default)]\n    pub mana_cost: String,\n    #[serde(default)]\n    pub type_line: String,\n    #[serde(default)]\n    pub oracle_text: String,\n    #[serde(default)]\n    pub uris: CardImageUris,\n}",
+      "refs": ["CardImageUris"]
     },
     "CardIdentity": {
       "ts": "interface CardIdentity {\n  name: string;\n  setCode: string;\n  cardNumber: string;\n  isToken: boolean;\n}",
@@ -206,9 +212,14 @@
       "refs": ["DeckCard", "DeckFormat", "DeckLabel", "PlaymatSettings"]
     },
     "DeckCard": {
-      "ts": "interface DeckCard {\n  identity: DeckCardIdentity;\n  uris: CardImageUris;\n  allParts?: Array<CardPart>;\n  color: string;\n  colorIdentity: Array<string>;\n  manaCost: string;\n  cmc: number;\n  types: Array<string>;\n  subtypes: Array<string>;\n  supertypes: Array<string>;\n  keywords?: Array<string>;\n  power?: string;\n  toughness?: string;\n  text: string;\n  layout?: string;\n  isDoubleFaced?: boolean;\n}",
+      "ts": "interface DeckCard {\n  identity: DeckCardIdentity;\n  uris: CardImageUris;\n  allParts?: Array<CardPart>;\n  color: string;\n  colorIdentity: Array<string>;\n  manaCost: string;\n  cmc: number;\n  types: Array<string>;\n  subtypes: Array<string>;\n  supertypes: Array<string>;\n  keywords?: Array<string>;\n  power?: string;\n  toughness?: string;\n  text: string;\n  layout?: string;\n  isDoubleFaced?: boolean;\n  /**\n   * The back face of a double-faced card (transform / modal_dfc), captured at\n   * deck import from Scryfall so rendering never needs a live lookup. The\n   * front-face fields above remain the card's identity; this is purely\n   * additive. `None` for single-faced cards and older decks.\n   */\n  backFace?: CardFaceSummary;\n}",
       "rust": "#[serde(rename_all = \"camelCase\")]\npub struct DeckCard {\n    pub identity: DeckCardIdentity,\n    #[serde(flatten)]\n    pub rules: CardRulesSummary,\n    #[serde(default)]\n    pub uris: CardImageUris,\n    #[serde(default, skip_serializing_if = \"Option::is_none\")]\n    pub all_parts: Option<Vec<CardPart>>,\n}",
-      "refs": ["CardImageUris", "CardPart", "DeckCardIdentity"]
+      "refs": [
+        "CardFaceSummary",
+        "CardImageUris",
+        "CardPart",
+        "DeckCardIdentity"
+      ]
     },
     "DeckCardIdentity": {
       "ts": "interface DeckCardIdentity {\n  id: string;\n  name: string;\n  setCode: string;\n  cardNumber: string;\n  foil?: boolean;\n}",


### PR DESCRIPTION
## Summary

- Carries double-faced back faces in the deck representation so both faces reach the engine at game start (#465 pt.1, #468).
- Gates playing a double-faced back-land on the card being modal (#469).
- Adds the endstep concurrency patches that let one Forge JVM host several games (#493).

## Why

Double-faced cards lost their back face in the deck representation, so the engine started games without it. The back-land fix is the matching rules gate: a back face that is a land is only playable when the card is modal.

The endstep patches are the engine-side prerequisite for running more than one game per Forge JVM. Evaluation on `scratch/endstep-patch-test` came back green at 40 games in 3.5GB.

The compose change that raises the staging node to 4 games per JVM is deliberately not in this PR. It belongs with the slot topology and only makes sense once both have landed.

## Test plan

- `yarn typecheck` clean.
- `cargo test -p manabrew-engine --lib`: 333 passed, 0 failed. This is the same gate `build-checks.yml` runs.
- `cargo check -p self-hosted-node` clean, verified against an initialized `forge` submodule since that crate `include_str!`s from it.
- `cargo check -p manabrew-engine -p manabrew_game_runtime` clean.
- The `forge` submodule bump (`6ab8389` to `1b900c6`) is carried unchanged from the original commit.
