### PR TITLE
ci: pin the release image tag so deploys stop shipping N-1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,12 +9,17 @@ name: Publish
 #   3. deploy the Wasm/web stack to production (deploy.sh over SSH). When the
 #      release is relay-compatible (deploy-gate: no semver-incompatible bump
 #      of manabrew-protocol / manabrew-server / manabrew-hub), deploy-web
-#      ships it EARLY — in parallel with the installer builds — with the
-#      served /manifest.json held back at the previous release so installed
-#      apps aren't told to update before the installers exist (the final
-#      deploy job releases it). Incompatible releases keep the old ordering:
+#      ships the WEB container EARLY — in parallel with the installer builds
+#      — with the served /manifest.json held back at the previous release so
+#      installed apps aren't told to update before the installers exist. The
+#      relay and hub are deferred to the final deploy job, which also
+#      releases the manifest. Incompatible releases keep the old ordering:
 #      deploy only after the Release has all its assets, so no installed
 #      client is stranded against a relay it can't talk to.
+#
+#      Both deploy jobs pass MANABREW_IMAGE_TAG=<tag>, which is what makes
+#      deploy.sh's ghcr pull-retry actually wait for this release's images
+#      rather than instantly resolving `latest` to the previous one.
 # There is no main-push deploy: main commits only run release.yml.
 #
 # GitHub-hosted runners are free for public repositories (unlimited minutes
@@ -548,13 +553,22 @@ jobs:
       early: ${{ steps.gate.outputs.early }}
 
   # ── Early web deploy ───────────────────────────────────────────────
-  # Ships the web/relay/hub stack as soon as the tag lands instead of after
-  # the ~60–90 min installer builds. deploy.sh's ghcr pull-retry loop waits
-  # out docker-images.yml, so web players get the release roughly when the
-  # images finish building. HOLD_MANIFEST keeps the served /manifest.json
-  # (what installed apps poll to nag about updates) at the previous release
-  # until the final deploy job releases it — /tauri.json redirects to the
-  # *latest* GitHub Release's assets, which don't exist yet at this point.
+  # Ships the WEB container as soon as the tag lands instead of after the
+  # ~60–90 min installer builds. deploy.sh's ghcr pull-retry loop waits out
+  # docker-images.yml — which only works because MANABREW_IMAGE_TAG pins the
+  # pull to this release's tag; without it the pull resolves `latest`, which
+  # mid-release is still the PREVIOUS release's images, and every release
+  # shipped N-1 (issue #510).
+  #
+  # --web-only: manabrew-server and manabrew-hub stay put until the final
+  # deploy. They are what an already-installed desktop/mobile app talks to,
+  # and moving them here would put those clients in front of a new relay with
+  # no installer published yet to update to.
+  #
+  # HOLD_MANIFEST keeps the served /manifest.json (what installed apps poll to
+  # nag about updates) at the previous release until the final deploy job
+  # releases it — /tauri.json redirects to the *latest* GitHub Release's
+  # assets, which don't exist yet at this point.
   deploy-web:
     name: Deploy web (early)
     needs: [deploy-gate]
@@ -578,6 +592,7 @@ jobs:
           HOST: ${{ secrets.DEPLOY_HOST }}
           USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh
@@ -594,7 +609,7 @@ jobs:
               -o ServerAliveInterval=30 \
               -o ServerAliveCountMax=120 \
               "$USER@$HOST" \
-            "cd '$DEPLOY_PATH' && HOLD_MANIFEST=1 ./deploy.sh 2>&1" 2>&1 | tee deploy.log
+            "cd '$DEPLOY_PATH' && MANABREW_IMAGE_TAG='$TAG' HOLD_MANIFEST=1 ./deploy.sh --web-only 2>&1" 2>&1 | tee deploy.log
           exit ${PIPESTATUS[0]}
 
       - name: Fetch raw deploy log on failure
@@ -632,14 +647,19 @@ jobs:
           exit 1
 
   # ── Deploy production (finalize) ───────────────────────────────────
-  # Runs once the Release has all its installer artifacts. On the early
-  # path this is a near-no-op that releases the held /manifest.json; on the
-  # gated (semver-incompatible) path it is the full deploy, running LAST so
-  # the tauri.json redirect never points at assets that don't exist yet.
-  # FORCE_DEPLOY re-runs a deploy whose early attempt failed after pulling
-  # (deploy.sh would otherwise early-exit on "no new commits"). Job-level
-  # concurrency serializes deploys across runs (two tags in flight must not
-  # deploy concurrently).
+  # Runs once the Release has all its installer artifacts. On the early path
+  # it rolls out the relay + hub the --web-only run deferred and releases the
+  # held /manifest.json; on the gated (semver-incompatible) path it is the
+  # full deploy, running LAST so the tauri.json redirect never points at
+  # assets that don't exist yet.
+  #
+  # FORCE_DEPLOY is unconditional: the early run already fast-forwarded the
+  # host's HEAD, so deploy.sh would early-exit on "no new commits" and never
+  # roll the relay/hub out. With it set, the run skips that exit and lets the
+  # image-diff checks decide what actually needs recreating — a no-op when
+  # the early path already shipped everything.
+  # Job-level concurrency serializes deploys across runs (two tags in flight
+  # must not deploy concurrently).
   deploy:
     name: Deploy production
     needs: [release, deploy-gate, deploy-web]
@@ -664,7 +684,7 @@ jobs:
           USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
           TAG: ${{ github.ref_name }}
-          FORCE_DEPLOY: ${{ needs.deploy-web.result == 'failure' && '1' || '' }}
+          FORCE_DEPLOY: "1"
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh
@@ -681,7 +701,7 @@ jobs:
               -o ServerAliveInterval=30 \
               -o ServerAliveCountMax=120 \
               "$USER@$HOST" \
-            "cd '$DEPLOY_PATH' && FORCE_DEPLOY='$FORCE_DEPLOY' ./deploy.sh 2>&1 && ./deploy.sh --release-manifest '$TAG' 2>&1" 2>&1 | tee deploy.log
+            "cd '$DEPLOY_PATH' && MANABREW_IMAGE_TAG='$TAG' FORCE_DEPLOY='$FORCE_DEPLOY' ./deploy.sh 2>&1 && ./deploy.sh --release-manifest '$TAG' 2>&1" 2>&1 | tee deploy.log
           exit ${PIPESTATUS[0]}
 
       - name: Fetch raw deploy log on failure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ chore: bump prettier
 perf(carddb): avoid re-parsing SVars on card load
 ```
 
-The PR body itself must follow `.github/pull_request_template.md`: `Summary`, `Why`, `Test plan` in that order (plus `Demo` for UI changes). Installers are not built per-PR — every merge to main releases via `cargo xtask release`, and the resulting `v*` tag runs the full publish pipeline (`publish.yml`: build installers → populate the Release → deploy production). Relay-compatible releases deploy the web stack early (in parallel with the installer builds) with the served `/manifest.json` held back until the installers publish; a semver-incompatible bump of `manabrew-protocol`/`manabrew-server`/`manabrew-hub` falls back to deploying only after the Release has all its assets.
+The PR body itself must follow `.github/pull_request_template.md`: `Summary`, `Why`, `Test plan` in that order (plus `Demo` for UI changes). Installers are not built per-PR — every merge to main releases via `cargo xtask release`, and the resulting `v*` tag runs the full publish pipeline (`publish.yml`: build installers → populate the Release → deploy production). Relay-compatible releases deploy the web container early (in parallel with the installer builds) with the served `/manifest.json` held back until the installers publish; the relay and hub roll out in the final deploy, once installed clients have an installer to update to. A semver-incompatible bump of `manabrew-protocol`/`manabrew-server`/`manabrew-hub` falls back to deploying everything only after the Release has all its assets.
 
 ## Workflow rules
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,10 +7,11 @@
 #
 # Invocations (all from publish.yml over SSH, or manually on the host):
 #   ./deploy.sh                          full rollout of whatever main has
-#   HOLD_MANIFEST=1 ./deploy.sh          early rollout (deploy-web job): same,
-#                                        but keeps serving the previous
-#                                        release's /manifest.json until the
-#                                        installers are published
+#   HOLD_MANIFEST=1 ./deploy.sh --web-only
+#                                        early rollout (deploy-web job): web
+#                                        container only, keeping the previous
+#                                        release's /manifest.json served until
+#                                        the installers are published
 #   ./deploy.sh --release-manifest vX.Y.Z
 #                                        flip the served /manifest.json to
 #                                        that tag's (final deploy job, after
@@ -19,7 +20,14 @@
 #                                        compose service(s); no change
 #                                        classification, no early-exit
 #   FORCE_DEPLOY=1 ./deploy.sh           skip the "no new commits" early exit
-#                                        (recovery after a failed early run)
+#                                        (the final deploy job always sets it:
+#                                        the early run already advanced HEAD,
+#                                        but relay/hub still need rolling out)
+#
+# MANABREW_IMAGE_TAG pins which ghcr images this rollout pulls. publish.yml
+# passes the release tag, so the pull-retry loop below blocks until THIS
+# release's images are pushed instead of silently re-deploying `latest` —
+# which, mid-release, is still the previous release's build.
 #
 # stdout = clean summary (captured by the workflow and posted to Discord).
 # Raw output goes to /tmp/deploy-raw.log.
@@ -39,6 +47,12 @@ COMPOSE_FILE="${COMPOSE_FILE:-compose.production.yml}"
 RAW_LOG="/tmp/deploy-raw.log"
 
 HOLD_MARKER="ops/.manifest-hold"
+
+# Captured before the .env files are sourced (they are read with `set -a`, so a
+# stale MANABREW_IMAGE_TAG on the host would otherwise clobber what CI passed)
+# and re-exported after, since compose.production.yml resolves the image refs
+# through it.
+GHCR_TAG="${MANABREW_IMAGE_TAG:-latest}"
 
 # ── Manifest release mode ────────────────────────────────────────────
 # (Appends to RAW_LOG without truncating: this runs right after a full
@@ -76,6 +90,18 @@ if [ "${1:-}" = "--only" ]; then
     ONLY_SERVICES="$*"
 fi
 
+# ── Web-only mode ────────────────────────────────────────────────────
+# `deploy.sh --web-only` rolls out the manabrew (web) container and leaves
+# manabrew-server / manabrew-hub on their current images. publish.yml's early
+# deploy job uses it: browsers reload onto the new client immediately, while
+# the relay and hub — the surfaces an already-installed desktop/mobile app
+# talks to — only move in the final deploy, once that release's installers
+# exist for those clients to update to.
+WEB_ONLY=false
+if [ "${1:-}" = "--web-only" ]; then
+    WEB_ONLY=true
+fi
+
 : > "$RAW_LOG"   # truncate
 
 # ── Load .env files ──────────────────────────────────────────────────
@@ -95,6 +121,7 @@ if [ -f "$SERVER_ENV" ]; then
     source "$SERVER_ENV"
     set +a
 fi
+export MANABREW_IMAGE_TAG="$GHCR_TAG"
 
 # Check if parity dashboard profile is active
 SKIP_DASHBOARD=true
@@ -311,11 +338,19 @@ fi
 # pulled here instead of built locally (the web image is a ~1h WASM+Vite build
 # that no longer fits the prod host's disk). Pull with retry: the image workflow
 # runs in parallel with this deploy, so the new images may not be pushed yet.
+#
+# The retry only does its job when MANABREW_IMAGE_TAG names THIS release: a
+# `latest` pull always succeeds instantly against the previous release's images,
+# so the loop never engages and the rollout ships N-1 (issue #510). 60 attempts
+# ≈ 30 min, comfortably over the ~18 min the image builds take.
 RELAY_UNCHANGED=false
-echo "Pulling ghcr images (manabrew manabrew-server manabrew-hub)..." >> "$RAW_LOG"
+PULL_SERVICES="manabrew manabrew-server manabrew-hub"
+$WEB_ONLY && PULL_SERVICES="manabrew"
+echo "Pulling ghcr images at tag ${GHCR_TAG} (${PULL_SERVICES})..." >> "$RAW_LOG"
 PULLED=false
-for attempt in $(seq 1 40); do
-    if docker compose -f "$COMPOSE_FILE" pull --quiet manabrew manabrew-server manabrew-hub >> "$RAW_LOG" 2>&1; then
+for attempt in $(seq 1 60); do
+    # shellcheck disable=SC2086
+    if docker compose -f "$COMPOSE_FILE" pull --quiet $PULL_SERVICES >> "$RAW_LOG" 2>&1; then
         PULLED=true; break
     fi
     echo "  pull attempt $attempt failed (CI images not pushed yet?); retrying in 30s" >> "$RAW_LOG"
@@ -334,28 +369,32 @@ image_changed() {  # $1 service, $2 image ref
     pulled=$(docker image inspect --format '{{.Id}}' "$2" 2>/dev/null || echo "x")
     [ "$running" != "$pulled" ]
 }
-GHCR_TAG="${MANABREW_IMAGE_TAG:-latest}"
 image_changed manabrew "ghcr.io/witchesofthehill/manabrew-web:${GHCR_TAG}" \
     && SERVICES_TO_RESTART="$SERVICES_TO_RESTART manabrew"
-image_changed manabrew-hub "ghcr.io/witchesofthehill/manabrew-hub:${GHCR_TAG}" \
-    && SERVICES_TO_RESTART="$SERVICES_TO_RESTART manabrew-hub"
 
-# Relay: extra-conservative — restart only when the actual binary differs (an
-# image-digest change from an unrelated base bump must not kill live games).
-RELAY_IMAGE="ghcr.io/witchesofthehill/manabrew-server:${GHCR_TAG}"
-RELAY_CID=$(docker compose -f "$COMPOSE_FILE" ps -q manabrew-server 2>/dev/null || true)
-if [ -n "$RELAY_CID" ]; then
-    RELAY_OLD_IMAGE=$(docker inspect --format '{{.Image}}' "$RELAY_CID")
-    OLD_SHA=$(docker run --rm --entrypoint sha256sum "$RELAY_OLD_IMAGE" /usr/local/bin/manabrew-server 2>> "$RAW_LOG" | cut -d' ' -f1 || true)
-    NEW_SHA=$(docker run --rm --entrypoint sha256sum "$RELAY_IMAGE" /usr/local/bin/manabrew-server 2>> "$RAW_LOG" | cut -d' ' -f1 || true)
-    if [ -n "$OLD_SHA" ] && [ "$OLD_SHA" = "$NEW_SHA" ]; then
-        RELAY_UNCHANGED=true
-        echo "manabrew-server binary unchanged (${NEW_SHA:0:12}) — relay not restarted" >> "$RAW_LOG"
+if $WEB_ONLY; then
+    echo "Web-only rollout — relay + hub deferred to the final deploy" >> "$RAW_LOG"
+else
+    image_changed manabrew-hub "ghcr.io/witchesofthehill/manabrew-hub:${GHCR_TAG}" \
+        && SERVICES_TO_RESTART="$SERVICES_TO_RESTART manabrew-hub"
+
+    # Relay: extra-conservative — restart only when the actual binary differs (an
+    # image-digest change from an unrelated base bump must not kill live games).
+    RELAY_IMAGE="ghcr.io/witchesofthehill/manabrew-server:${GHCR_TAG}"
+    RELAY_CID=$(docker compose -f "$COMPOSE_FILE" ps -q manabrew-server 2>/dev/null || true)
+    if [ -n "$RELAY_CID" ]; then
+        RELAY_OLD_IMAGE=$(docker inspect --format '{{.Image}}' "$RELAY_CID")
+        OLD_SHA=$(docker run --rm --entrypoint sha256sum "$RELAY_OLD_IMAGE" /usr/local/bin/manabrew-server 2>> "$RAW_LOG" | cut -d' ' -f1 || true)
+        NEW_SHA=$(docker run --rm --entrypoint sha256sum "$RELAY_IMAGE" /usr/local/bin/manabrew-server 2>> "$RAW_LOG" | cut -d' ' -f1 || true)
+        if [ -n "$OLD_SHA" ] && [ "$OLD_SHA" = "$NEW_SHA" ]; then
+            RELAY_UNCHANGED=true
+            echo "manabrew-server binary unchanged (${NEW_SHA:0:12}) — relay not restarted" >> "$RAW_LOG"
+        else
+            SERVICES_TO_RESTART="$SERVICES_TO_RESTART manabrew-server"
+        fi
     else
         SERVICES_TO_RESTART="$SERVICES_TO_RESTART manabrew-server"
     fi
-else
-    SERVICES_TO_RESTART="$SERVICES_TO_RESTART manabrew-server"
 fi
 
 # -- observability stack (config-only; images are pulled, never built) --
@@ -448,6 +487,11 @@ if [ -f "$HOLD_MARKER" ]; then
     HOLD_NOTE=$'🔒 **Manifest:** held at previous release until the installers publish\n'
 fi
 
+WEB_ONLY_NOTE=""
+if $WEB_ONLY; then
+    WEB_ONLY_NOTE=$'🌐 **Web-only:** relay + hub deferred to the final deploy\n'
+fi
+
 # Build change flags string (with per-stack emoji)
 CHANGES=""
 $JAVA_CHANGED      && CHANGES="${CHANGES} ☕ Java"
@@ -465,9 +509,10 @@ cat <<EOF
 > — ${AUTHOR} (${COMMIT_COUNT} commit(s))
 
 📦 **Changed:** ${CHANGES}
+🏷️ **Image tag:** \`${GHCR_TAG}\`
 🔁 **Services rebuilt:**
 ${SERVICES_FMT}
-${RELAY_NOTE}${HOLD_NOTE}⏱️ **Build time:** ${BUILD_DURATION}s
+${RELAY_NOTE}${HOLD_NOTE}${WEB_ONLY_NOTE}⏱️ **Build time:** ${BUILD_DURATION}s
 📄 **Log:** \`${RAW_LOG}\`
 
 📝 **Changelog:**


### PR DESCRIPTION
## Summary

- Pass `MANABREW_IMAGE_TAG=<tag>` from both deploy jobs, so the ghcr pull resolves this release's images instead of `latest`.
- Raise the pull-retry loop from 40 to 60 attempts (~30 min), now that it actually has to wait for the image builds.
- Early deploy drops to `--web-only`: relay and hub roll out in the final deploy job, once installed clients have an installer to update to.
- Final deploy sets `FORCE_DEPLOY` unconditionally, since the early run already advanced the host's HEAD.

## Why

Fixes #510.

`deploy.sh:317` had a 40x30s pull-retry loop whose comment says it "waits out docker-images.yml". It cannot: `publish.yml` never passed `MANABREW_IMAGE_TAG`, so the pull resolved `ghcr.io/...:latest`, which mid-release is still the previous release's images. The pull always succeeded on the first attempt, the retry never engaged, and `image_changed` happily rolled out N-1.

v1.12.4:

| Time | Event |
| --- | --- |
| 18:49:28 | tag lands, `docker-images.yml` starts building |
| 18:49:49 | early deploy pulls `:latest`, still v1.12.3's images (pushed 18:20) |
| 18:50:13 | restarts web + hub, reports "Wasm deploy complete" in 16s |
| 19:07:31 | the real v1.12.4 images finish and get pushed. Nothing pulls them |
| 19:27 | final deploy: "No new commits. Nothing to deploy." then releases the manifest, green |

This is the first commit of #511, split out so the production fix can land without waiting on the staging-topology discussion. The other two commits of #511 change the staging deploy model and conflict with #513; they are being reworked on top of that branch instead.

## Test plan

- `bash -n deploy.sh` clean.
- `publish.yml` parses as valid YAML.
- No overlap with #513's file set, so the two can land in either order.
- Not exercised end to end. That happens on the next release tag, which is the only place the path runs.
