### PR TITLE
ci(staging): gate the staging slot on the deploy-preview label

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,8 +1,16 @@
 name: Staging deploy
 
-# Deploys the `staging` branch to staging.manabrew.app — a staging slot on the
-# PRODUCTION box (/opt/manabrew-staging, compose.staging.yml on the prod docker
-# network, fronted by prod Caddy's staging.manabrew.app / relay-staging vhosts):
+# Label-gated: a PR labelled `deploy-preview` takes the staging slot, the way
+# per-PR previews worked before #470 turned this into a branch auto-deploy.
+# Pushes to `staging` no longer deploy on their own — run this workflow from the
+# Actions tab (workflow_dispatch) to put the `staging` branch back on the slot.
+# There is ONE slot, so labelling a second PR replaces whatever is on it; the
+# slot is never torn down, it just holds the last thing deployed. Only the
+# `staging` branch gets a hosted-AI node (see deploy-staging.sh).
+#
+# Deploys to staging.manabrew.app — a staging slot on the PRODUCTION box
+# (/opt/manabrew-staging, compose.staging.yml on the prod docker network,
+# fronted by prod Caddy's staging.manabrew.app / relay-staging vhosts):
 #   1. build + push the self-hosting images tagged `staging` to ghcr
 #      (docker-images.yml does the same on v* tags for the release `latest`
 #      images),
@@ -21,13 +29,13 @@ name: Staging deploy
 # The optional standalone VM is not CI-driven: run deploy-local.sh on the VM
 # itself (compose.selfhost.yml — self-contained, builds from the checkout).
 on:
-  push:
-    branches: [staging]
+  pull_request:
+    types: [labeled, synchronize, reopened]
   workflow_dispatch:
 
 concurrency:
-  group: staging-deploy
-  cancel-in-progress: false
+  group: staging-deploy-${{ github.event.pull_request.number || 'manual' }}
+  cancel-in-progress: true
 
 jobs:
   # ── Build & push the :staging images ───────────────────────────────
@@ -36,9 +44,17 @@ jobs:
   # The web image bakes the hub endpoint (from the STAGING_HUB_API_URL repo
   # variable) and the same-origin symbol proxy; the relay is configured at
   # runtime (compose RELAY_HOST), like prod.
+  # Fork PRs are skipped: they get neither a package-write token nor the SSH
+  # secrets for the prod box.
   build-images:
     name: Build & push ${{ matrix.image }} (staging tag)
-    if: github.repository == 'witchesofthehill/manabrew'
+    if: |
+      github.repository == 'witchesofthehill/manabrew'
+      && (github.event_name == 'workflow_dispatch'
+          || (github.event.pull_request.head.repo.full_name == github.repository
+              && ((github.event.action == 'labeled' && github.event.label.name == 'deploy-preview')
+                  || (contains(fromJSON('["synchronize","reopened"]'), github.event.action)
+                      && contains(github.event.pull_request.labels.*.name, 'deploy-preview')))))
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
@@ -60,8 +76,11 @@ jobs:
           - image: manabrew-hub
             dockerfile: manabrew-rs/crates/manabrew-hub/Dockerfile
     steps:
+      # Build the PR head, not the pull_request merge commit — deploy-staging.sh
+      # checks the head branch out on the box, so the two must agree.
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
           submodules: recursive
 
       - name: Set up Docker Buildx
@@ -112,6 +131,11 @@ jobs:
           HOST: ${{ secrets.DEPLOY_HOST }}
           USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_STAGING_PATH || '/opt/manabrew-staging' }}
+          # The PR's head branch, so the box checks out what the images were
+          # built from. Empty on workflow_dispatch → deploy-staging.sh falls
+          # back to its `staging` default, which is also the only branch that
+          # gets a hosted-AI node.
+          DEPLOY_BRANCH: ${{ github.event.pull_request.head.ref }}
           # Synced into the slot's .env below. MANABREW_SERVER_KEY is included
           # because the slot's .env is standalone — it must NOT symlink prod's
           # secrets file. The STAGING_OAUTH_GITHUB_* names avoid GitHub
@@ -153,7 +177,7 @@ jobs:
               -o ServerAliveInterval=30 \
               -o ServerAliveCountMax=120 \
               "$USER@$HOST" \
-            "cd '$DEPLOY_PATH' && ./deploy-staging.sh 2>&1" 2>&1 | tee deploy.log
+            "cd '$DEPLOY_PATH' && DEPLOY_BRANCH='$DEPLOY_BRANCH' ./deploy-staging.sh 2>&1" 2>&1 | tee deploy.log
           exit ${PIPESTATUS[0]}
 
       - name: Fetch raw deploy log on failure

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -82,6 +82,8 @@ services:
       start_period: 5s
 
   self-hosted-node-staging:
+    profiles:
+      - hosted-ai
     image: ghcr.io/witchesofthehill/manabrew-node:${MANABREW_IMAGE_TAG:-staging}
     environment:
       SELF_HOSTED_NODE_RELAY_URL: "ws://manabrew-server-staging:9443"

--- a/deploy-staging.sh
+++ b/deploy-staging.sh
@@ -7,6 +7,9 @@
 # profiles) lives here — staging just tracks a branch and swaps in fresh
 # images. Driven by staging-deploy.yml over SSH.
 #
+# DEPLOY_BRANCH selects what lands in the slot: `staging` (the default, and the
+# only branch that gets a hosted-AI node) or a labelled PR's head branch.
+#
 # stdout = clean summary (captured by the workflow and posted to Discord).
 # Raw output goes to /tmp/deploy-staging-raw.log.
 set -euo pipefail
@@ -19,6 +22,20 @@ COMPOSE_FILE="${COMPOSE_FILE:-compose.staging.yml}"
 export MANABREW_IMAGE_TAG="${MANABREW_IMAGE_TAG:-staging}"
 RAW_LOG="/tmp/deploy-staging-raw.log"
 : > "$RAW_LOG"
+
+# ── Hosted AI: staging branch only ───────────────────────────────────
+# The self-hosted node is a Forge JVM — ~500 MiB resident and CPU-bound during
+# games, on a box that also runs production. The `staging` branch gets one; PR
+# previews (any other branch) do not, so a labelled PR costs web + relay + hub
+# only. The node sits behind the `hosted-ai` compose profile, and
+# `up --remove-orphans` below drops its container when the profile is off — so
+# switching the slot from staging to a preview reclaims it.
+PROFILE_FLAG=""
+HOSTED_AI_NOTE="off (preview — node not started)"
+if [ "$BRANCH" = "staging" ]; then
+    PROFILE_FLAG="--profile hosted-ai"
+    HOSTED_AI_NOTE="on (staging branch)"
+fi
 
 on_failure() {
     echo "💥 **Staging deploy FAILED** at $(date '+%H:%M:%S')"
@@ -77,7 +94,8 @@ fi
 # The deploy job needs build-images, so these normally exist already; the retry
 # is a safety net if ghcr is briefly behind.
 export DOCKER_BUILDKIT=1
-SERVICES="manabrew-staging manabrew-server-staging manabrew-hub-staging self-hosted-node-staging"
+SERVICES="manabrew-staging manabrew-server-staging manabrew-hub-staging"
+[ -n "$PROFILE_FLAG" ] && SERVICES="$SERVICES self-hosted-node-staging"
 WEB_SERVICE="manabrew-staging"
 echo "Pulling :${MANABREW_IMAGE_TAG} images ($SERVICES)…" >> "$RAW_LOG"
 PULLED=false
@@ -106,7 +124,8 @@ for svc in $SERVICES; do
     [ -n "$cid" ] && ROLLBACK_IMG[$svc]=$(docker inspect --format '{{.Image}}' "$cid" 2>/dev/null || true)
 done
 
-if docker compose -f "$COMPOSE_FILE" up -d --remove-orphans --wait --wait-timeout 180 >> "$RAW_LOG" 2>&1; then
+# shellcheck disable=SC2086
+if docker compose -f "$COMPOSE_FILE" $PROFILE_FLAG up -d --remove-orphans --wait --wait-timeout 180 >> "$RAW_LOG" 2>&1; then
     echo "✅ rollout healthy" >> "$RAW_LOG"
 else
     echo "⚠️ rollout unhealthy — rolling back to the previous images" | tee -a "$RAW_LOG"
@@ -128,6 +147,15 @@ docker compose -f "$COMPOSE_FILE" exec -T "$WEB_SERVICE" \
     caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile >> "$RAW_LOG" 2>&1 \
     || echo "caddy reload skipped/failed (see raw log)" >> "$RAW_LOG"
 
+# ── Reclaim superseded images ────────────────────────────────────────
+# Every deploy pulls a fresh `:staging` tag, which leaves the previous one
+# dangling (untagged, unreferenced). Nothing reclaimed them before, and this box
+# shares its docker volume with production. `image prune` (no -a) only touches
+# dangling images, so nothing tagged or in use by a running container can be
+# caught, and the rollback re-tag above has already happened by this point.
+RECLAIMED=$(docker image prune -f 2>> "$RAW_LOG" | tail -1)
+echo "🧹 ${RECLAIMED:-nothing to reclaim}" >> "$RAW_LOG"
+
 # No pipe here: `| head -c` SIGPIPEs git log on large merge ranges, and with
 # pipefail + the ERR trap that flagged an already-healthy rollout as failed.
 CHANGELOG=$(git log --pretty=format:'- %s (%h, %an)' "${PREV}..${CURR}" 2>/dev/null || true)
@@ -137,7 +165,9 @@ CHANGELOG=${CHANGELOG:0:1500}
 cat <<EOF
 🧪 **Staging deploy complete** (\`${PREV}\` → \`${CURR}\`)
 
-🔁 **Rolled out:** ${SERVICES} (tag \`${MANABREW_IMAGE_TAG}\`)
+🔁 **Rolled out:** ${SERVICES} (tag \`${MANABREW_IMAGE_TAG}\`, branch \`${BRANCH}\`)
+🤖 **Hosted AI:** ${HOSTED_AI_NOTE}
+🧹 **Reclaimed:** ${RECLAIMED:-nothing}
 📄 **Log:** \`${RAW_LOG}\`
 
 📝 **Changelog:**


### PR DESCRIPTION
> Stacked on #513. Base is `khaliostr/staging-slot-ops`, so the diff shown here is only this change. Retarget to `main` once #513 lands.

## Summary

- A PR labelled `deploy-preview` takes the staging slot. Pushes to `staging` no longer deploy on their own; `workflow_dispatch` puts the staging branch back on the slot.
- The hosted-AI node moves behind the `hosted-ai` compose profile, and only the `staging` branch enables it.
- Dangling images are reclaimed after each rollout.

## Why

This is the staging half of #511, rebuilt on the slot topology.

#511 as opened restores the pre-#470 label-gating but keeps #470's standalone-VM plumbing: Twingate, `STAGING_DEPLOY_HOST`, and the bare `manabrew manabrew-server manabrew-hub` service names. That combination does not match what is deployed. The prod Caddy proxies `staging.manabrew.app` to `manabrew-staging:80`, which only the slot compose creates, so label-gated previews pointed at the VM would recreate the same inconsistency #513 exists to fix, just from the other direction.

Worth noting the original preview model this restores was already slot-based: the pre-#470 `preview-deploy.yml` used `secrets.DEPLOY_HOST`, the prod box, with no Twingate at all. So this is closer to the thing #511 says it is restoring than #511 itself is.

The node gating matters because the slot shares a box with production. The self-hosted node is a Forge JVM, roughly 500 MiB resident and CPU-bound during games. Only `staging` gets one; a labelled PR costs web + relay + hub. `up --remove-orphans` drops the node container when the profile is off, so switching the slot from staging to a preview reclaims it rather than leaving it running.

`image prune` (no `-a`) only touches dangling images, so nothing tagged or in use by a running container can be caught, and it runs after the rollback re-tag.

## Test plan

- `bash -n deploy-staging.sh` clean.
- `staging-deploy.yml` parses as valid YAML; triggers resolve to `pull_request` + `workflow_dispatch`.
- `docker compose -f compose.staging.yml config --services` returns web, relay and hub. With `--profile hosted-ai` it also returns `self-hosted-node-staging`. Verified both.
- Simulated the `DEPLOY_BRANCH` to `PROFILE_FLAG` to `SERVICES` logic for `staging` and for a PR branch, and confirmed the node is included only for `staging`.
- Confirmed `DEPLOY_BRANCH` is passed across the SSH hop on the command line. The job-level `env:` alone does not reach the box, which is easy to miss.
- Confirmed the SIGPIPE fix from #513 (`${CHANGELOG:0:1500}` rather than `| head -c`) survives, since a regression there marks a healthy rollout as failed.
- The deploy job keeps a single global `staging-box-deploy` concurrency group. There is one physical slot, so deploys must serialize even though the build job is now per-PR.
