### PR TITLE
feat(engine): endstep concurrency patches for multi-game forge

### DIFF
--- a/forge-harness/src/main/java/forge/harness/Main.java
+++ b/forge-harness/src/main/java/forge/harness/Main.java
@@ -278,8 +278,10 @@ public final class Main {
 
     /**
      * Interactive server mode: per-game JSON-RPC over stdin/stdout dispatching
-     * to a long-lived {@link ManaBrewEngineAdapter}. One process owns one game
-     * at a time; pool callers send `reset` between games and `quit` to exit.
+     * to a long-lived {@link ManaBrewEngineAdapter}. Sessions are routed by
+     * sessionId and each runs on its own game thread, so one process can host
+     * several concurrent games; pool callers send `reset` only while the
+     * process is idle and `quit` to exit.
      *
      * Request shape:  {"command":"startGame","payload":"<json>"}  (sessionId
      * goes in `sessionId`; payload is the inner JSON string).

--- a/forge-harness/src/main/java/forge/harness/common/ForgeEngineReset.java
+++ b/forge-harness/src/main/java/forge/harness/common/ForgeEngineReset.java
@@ -1,43 +1,66 @@
 package forge.harness.common;
 
 import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Reflection-based reset of private static ID counters in forge-game classes.
  * Used by both harness engines (parity batches and the hosted session pool) to
  * isolate cross-game state without modifying forge-game.
+ *
+ * <p>Every failure is fatal by design: a counter this class claims to reset
+ * but silently cannot (class renamed, field moved, shape changed by an
+ * upstream bump) breaks cross-game id isolation invisibly. Each reset is
+ * verified by reading the counter back; callers treat a throw as an unusable
+ * engine process.
  */
 public final class ForgeEngineReset {
     private ForgeEngineReset() {}
 
+    private static final String[][] COUNTERS = {
+        {"forge.game.spellability.SpellAbility", "maxId"},
+        {"forge.game.spellability.SpellAbilityStackInstance", "maxId"},
+        {"forge.game.trigger.Trigger", "maxId"},
+        {"forge.game.replacement.ReplacementEffect", "maxId"},
+        {"forge.game.staticability.StaticAbility", "maxId"},
+        {"forge.game.Game", "maxId"},
+    };
+
     private static boolean logged = false;
 
-    /** Reset all known static ID counters in forge-game to 0. */
+    /** Reset all known static ID counters in forge-game to 0, verifying each. */
     public static void resetAllIdCounters() {
         if (!logged) {
             System.err.println("[manabrew-engine-reset] Resetting all forge-game ID counters via reflection");
             logged = true;
         }
-        resetStaticInt("forge.game.spellability.SpellAbility", "maxId");
-        resetStaticInt("forge.game.spellability.SpellAbilityStackInstance", "maxId");
-        resetStaticInt("forge.game.trigger.Trigger", "maxId");
-        resetStaticInt("forge.game.cost.IndividualCostPaymentInstance", "maxId");
-        resetStaticInt("forge.game.replacement.ReplacementEffect", "maxId");
-        resetStaticInt("forge.game.staticability.StaticAbility", "maxId");
-        resetStaticInt("forge.game.Game", "maxId");
+        for (final String[] target : COUNTERS) {
+            resetCounter(target[0], target[1]);
+        }
     }
 
-    private static void resetStaticInt(String className, String fieldName) {
+    private static void resetCounter(String className, String fieldName) {
         try {
-            Class<?> clazz = Class.forName(className);
-            Field field = clazz.getDeclaredField(fieldName);
+            Field field = Class.forName(className).getDeclaredField(fieldName);
             field.setAccessible(true);
-            field.setInt(null, 0);
-        } catch (ClassNotFoundException | NoSuchFieldException e) {
-            // Class or field absent in this Forge build — nothing to reset.
-        } catch (Exception e) {
-            System.err.printf("[manabrew-engine-reset] WARNING: Failed to reset %s.%s: %s%n",
-                className, fieldName, e.getMessage());
+            Object value = field.get(null);
+            if (value instanceof AtomicInteger counter) {
+                counter.set(0);
+                if (counter.get() != 0) {
+                    throw new IllegalStateException(className + "." + fieldName + " did not reset to 0");
+                }
+            } else if (field.getType() == int.class) {
+                field.setInt(null, 0);
+                if (field.getInt(null) != 0) {
+                    throw new IllegalStateException(className + "." + fieldName + " did not reset to 0");
+                }
+            } else {
+                throw new IllegalStateException(
+                    className + "." + fieldName + " has unsupported counter shape " + field.getType());
+            }
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(
+                "cannot reset " + className + "." + fieldName + "; engine id isolation would silently break", e);
         }
     }
 }

--- a/forge-harness/src/main/java/forge/harness/common/HarnessCostPlumbing.java
+++ b/forge-harness/src/main/java/forge/harness/common/HarnessCostPlumbing.java
@@ -20,7 +20,6 @@ import forge.game.zone.ZoneType;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 public final class HarnessCostPlumbing {
@@ -716,13 +715,13 @@ public final class HarnessCostPlumbing {
             final GameEntityCounterTable table = new GameEntityCounterTable();
             int remaining = amount;
             for (final Card card : list) {
-                for (final Map.Entry<CounterType, Integer> e : card.getCounters().entrySet()) {
+                for (final com.google.common.collect.Multiset.Entry<CounterType> e : card.getCounters().entrySet()) {
                     if (remaining <= 0) {
                         break;
                     }
-                    final int remove = Math.min(remaining, e.getValue());
+                    final int remove = Math.min(remaining, e.getCount());
                     if (remove > 0) {
-                        table.put(null, card, e.getKey(), remove);
+                        table.put(null, card, e.getElement(), remove);
                         remaining -= remove;
                     }
                 }
@@ -769,9 +768,9 @@ public final class HarnessCostPlumbing {
                         return PaymentDecision.counters(table);
                     }
                 } else {
-                    for (final Map.Entry<CounterType, Integer> e : card.getCounters().entrySet()) {
-                        if (e.getValue() >= amount) {
-                            table.put(null, card, e.getKey(), amount);
+                    for (final com.google.common.collect.Multiset.Entry<CounterType> e : card.getCounters().entrySet()) {
+                        if (e.getCount() >= amount) {
+                            table.put(null, card, e.getElement(), amount);
                             return PaymentDecision.counters(table);
                         }
                     }
@@ -887,6 +886,11 @@ public final class HarnessCostPlumbing {
         @Override
         public PaymentDecision visit(final CostBlight cost) {
             return visit((CostPutCounter) cost);
+        }
+
+        @Override
+        public PaymentDecision visit(final CostPutCounterYou cost) {
+            return PaymentDecision.number(cost.getAbilityAmount(ability));
         }
 
         @Override

--- a/forge-harness/src/main/java/forge/harness/common/HeadlessGuiBase.java
+++ b/forge-harness/src/main/java/forge/harness/common/HeadlessGuiBase.java
@@ -64,7 +64,6 @@ public class HeadlessGuiBase implements IGuiBase {
     @Override public String showFileDialog(String title, String defaultDir) { return null; }
     @Override public File getSaveFile(File defaultFile) { return null; }
     @Override public void download(GuiDownloadService service, Consumer<Boolean> callback) { if (callback != null) callback.accept(false); }
-    @Override public void refreshSkin() {}
     @Override public void showCardList(String title, String message, List<PaperCard> list) {}
     @Override public boolean showBoxedProduct(String title, String message, List<PaperCard> list) { return false; }
     @Override public PaperCard chooseCard(String title, String message, List<PaperCard> list) { return list != null && !list.isEmpty() ? list.get(0) : null; }

--- a/forge-harness/src/main/java/forge/harness/common/SnapshotExtractor.java
+++ b/forge-harness/src/main/java/forge/harness/common/SnapshotExtractor.java
@@ -89,9 +89,9 @@ public final class SnapshotExtractor {
                 .thenComparing(c -> {
                     // Deterministic counter string matching Rust BTreeMap order
                     TreeMap<String, Integer> counters = new TreeMap<>();
-                    for (Map.Entry<CounterType, Integer> entry : c.getCounters().entrySet()) {
-                        if (entry.getValue() > 0) {
-                            counters.put(counterTypeName(entry.getKey()), entry.getValue());
+                    for (com.google.common.collect.Multiset.Entry<CounterType> entry : c.getCounters().entrySet()) {
+                        if (entry.getCount() > 0) {
+                            counters.put(counterTypeName(entry.getElement()), entry.getCount());
                         }
                     }
                     return counters.toString();
@@ -183,9 +183,9 @@ public final class SnapshotExtractor {
 
         // Counters — sorted by counter type name
         Map<String, Integer> counters = new TreeMap<>();
-        for (Map.Entry<CounterType, Integer> entry : c.getCounters().entrySet()) {
-            if (entry.getValue() > 0) {
-                counters.put(counterTypeName(entry.getKey()), entry.getValue());
+        for (com.google.common.collect.Multiset.Entry<CounterType> entry : c.getCounters().entrySet()) {
+            if (entry.getCount() > 0) {
+                counters.put(counterTypeName(entry.getElement()), entry.getCount());
             }
         }
         cs.put("counters", counters);

--- a/forge-harness/src/main/java/forge/harness/host/InteractiveSnapshotExtractor.java
+++ b/forge-harness/src/main/java/forge/harness/host/InteractiveSnapshotExtractor.java
@@ -537,9 +537,9 @@ public final class InteractiveSnapshotExtractor {
 
     private static Map<String, Integer> counterMap(final Card card) {
         final Map<String, Integer> counters = new TreeMap<>();
-        for (final Map.Entry<CounterType, Integer> entry : card.getCounters().entrySet()) {
-            if (entry.getValue() > 0) {
-                counters.put(uiCounterName(entry.getKey()), entry.getValue());
+        for (final com.google.common.collect.Multiset.Entry<CounterType> entry : card.getCounters().entrySet()) {
+            if (entry.getCount() > 0) {
+                counters.put(uiCounterName(entry.getElement()), entry.getCount());
             }
         }
         return counters;

--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewEngineAdapter.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewEngineAdapter.java
@@ -78,7 +78,11 @@ public final class ManaBrewEngineAdapter {
         rules.setAppliedVariants(variants);
         rules.setSimTimeout(120);
 
-        ForgeEngineReset.resetAllIdCounters();
+        // Resetting global counters under a live session would collide its ids;
+        // multiplexed processes only reset between idle periods.
+        if (sessions.isEmpty()) {
+            ForgeEngineReset.resetAllIdCounters();
+        }
         final ManaBrewInteractiveSession session =
                 new ManaBrewInteractiveSession(request.getGameId());
         final List<RegisteredPlayer> registeredPlayers = new ArrayList<>();

--- a/manabrew-rs/crates/self-hosted-node/src/engine_backend/java_backend.rs
+++ b/manabrew-rs/crates/self-hosted-node/src/engine_backend/java_backend.rs
@@ -232,10 +232,17 @@ pub fn run_self_play(
 type SharedBridge = Arc<Mutex<SubprocessBridge>>;
 
 #[cfg(feature = "java-forge")]
+struct PoolSlot {
+    bridge: SharedBridge,
+    active: usize,
+}
+
+#[cfg(feature = "java-forge")]
 pub struct JavaEnginePool {
     config: JavaRuntimeConfig,
-    max_size: usize,
-    free: Mutex<Vec<SharedBridge>>,
+    max_sessions: usize,
+    sessions_per_process: usize,
+    slots: Mutex<Vec<PoolSlot>>,
     in_use: Mutex<HashMap<String, SharedBridge>>,
 }
 
@@ -247,18 +254,31 @@ pub struct JavaEngineHandle {
 
 #[cfg(feature = "java-forge")]
 impl JavaEnginePool {
-    pub fn start(config: &JavaRuntimeConfig, max_size: usize) -> Result<Arc<Self>, String> {
-        let max_size = max_size.max(1);
-        let mut free = Vec::with_capacity(max_size);
-        for slot in 0..max_size {
-            info!(slot, max_size, "pre-warming java subprocess");
+    pub fn start(
+        config: &JavaRuntimeConfig,
+        max_sessions: usize,
+        sessions_per_process: usize,
+    ) -> Result<Arc<Self>, String> {
+        let max_sessions = max_sessions.max(1);
+        let sessions_per_process = sessions_per_process.max(1);
+        let processes = max_sessions.div_ceil(sessions_per_process);
+        let mut slots = Vec::with_capacity(processes);
+        for slot in 0..processes {
+            info!(
+                slot,
+                processes, sessions_per_process, "pre-warming java subprocess"
+            );
             let bridge = SubprocessBridge::spawn(config)?;
-            free.push(Arc::new(Mutex::new(bridge)));
+            slots.push(PoolSlot {
+                bridge: Arc::new(Mutex::new(bridge)),
+                active: 0,
+            });
         }
         Ok(Arc::new(Self {
             config: config.clone(),
-            max_size,
-            free: Mutex::new(free),
+            max_sessions,
+            sessions_per_process,
+            slots: Mutex::new(slots),
             in_use: Mutex::new(HashMap::new()),
         }))
     }
@@ -273,9 +293,9 @@ impl JavaEnginePool {
 #[cfg(feature = "java-forge")]
 impl Drop for JavaEnginePool {
     fn drop(&mut self) {
-        let free = self.free.get_mut().map(std::mem::take).unwrap_or_default();
-        for bridge in free {
-            if let Ok(mutex) = Arc::try_unwrap(bridge) {
+        let slots = self.slots.get_mut().map(std::mem::take).unwrap_or_default();
+        for slot in slots {
+            if let Ok(mutex) = Arc::try_unwrap(slot.bridge) {
                 if let Ok(inner) = mutex.into_inner() {
                     inner.shutdown();
                 }
@@ -289,14 +309,22 @@ impl JavaEnginePool {
     fn acquire(&self) -> Result<SharedBridge, String> {
         let deadline = Instant::now() + Duration::from_secs(60);
         loop {
-            let popped = {
-                let mut free = self
-                    .free
+            let claimed = {
+                let mut slots = self
+                    .slots
                     .lock()
-                    .map_err(|_| "java engine free queue poisoned".to_string())?;
-                free.pop()
+                    .map_err(|_| "java engine slots poisoned".to_string())?;
+                let mut claimed = None;
+                for slot in slots.iter_mut() {
+                    if slot.active < self.sessions_per_process {
+                        slot.active += 1;
+                        claimed = Some(Arc::clone(&slot.bridge));
+                        break;
+                    }
+                }
+                claimed
             };
-            if let Some(bridge) = popped {
+            if let Some(bridge) = claimed {
                 let alive = bridge
                     .lock()
                     .ok()
@@ -306,18 +334,13 @@ impl JavaEnginePool {
                     return Ok(bridge);
                 }
                 warn!("discarding dead java subprocess from pool");
-                drop(bridge);
-                if let Ok(replacement) = SubprocessBridge::spawn(&self.config) {
-                    if let Ok(mut free) = self.free.lock() {
-                        free.push(Arc::new(Mutex::new(replacement)));
-                    }
-                }
+                self.replace_slot(&bridge);
                 continue;
             }
             if Instant::now() >= deadline {
                 return Err(format!(
-                    "java engine pool exhausted (max_size={}); no free subprocess after 60s",
-                    self.max_size
+                    "java engine pool exhausted (max_sessions={}); no free session slot after 60s",
+                    self.max_sessions
                 ));
             }
             std::thread::sleep(Duration::from_millis(50));
@@ -325,6 +348,22 @@ impl JavaEnginePool {
     }
 
     fn release(&self, bridge: SharedBridge) {
+        let now_idle = {
+            let mut slots = match self.slots.lock() {
+                Ok(slots) => slots,
+                Err(_) => return,
+            };
+            match slots.iter_mut().find(|s| Arc::ptr_eq(&s.bridge, &bridge)) {
+                Some(slot) => {
+                    slot.active = slot.active.saturating_sub(1);
+                    slot.active == 0
+                }
+                None => return,
+            }
+        };
+        if !now_idle {
+            return;
+        }
         let healthy = {
             let mut guard = match bridge.lock() {
                 Ok(guard) => guard,
@@ -332,21 +371,29 @@ impl JavaEnginePool {
             };
             guard.is_alive() && guard.reset().is_ok()
         };
-        if healthy {
-            if let Ok(mut free) = self.free.lock() {
-                free.push(bridge);
-                return;
-            }
+        if !healthy {
+            warn!("java subprocess unhealthy at idle; respawning");
+            self.replace_slot(&bridge);
         }
-        drop(bridge);
+    }
+
+    fn replace_slot(&self, dead: &SharedBridge) {
+        let Ok(mut slots) = self.slots.lock() else {
+            return;
+        };
+        let Some(index) = slots.iter().position(|s| Arc::ptr_eq(&s.bridge, dead)) else {
+            return;
+        };
         match SubprocessBridge::spawn(&self.config) {
             Ok(replacement) => {
-                if let Ok(mut free) = self.free.lock() {
-                    free.push(Arc::new(Mutex::new(replacement)));
-                }
+                slots[index] = PoolSlot {
+                    bridge: Arc::new(Mutex::new(replacement)),
+                    active: 0,
+                };
             }
             Err(error) => {
-                warn!(%error, "failed to respawn java subprocess after release");
+                warn!(%error, "failed to respawn java subprocess; retiring pool slot");
+                slots.remove(index);
             }
         }
     }
@@ -497,15 +544,22 @@ pub fn init_engine() -> Result<(), String> {
         return Ok(());
     }
     let config = JavaRuntimeConfig::from_env();
-    // SELF_HOSTED_NODE_MAX_GAMES doubles as the subprocess pool size: each room
-    // checks out one java subprocess for its lifetime, so the pool ceiling is
-    // also the concurrent-room ceiling for this node.
-    let max_size = env::var("SELF_HOSTED_NODE_MAX_GAMES")
+    // SELF_HOSTED_NODE_MAX_GAMES is the concurrent-session ceiling for this node.
+    // SELF_HOSTED_NODE_GAMES_PER_JVM multiplexes that many sessions into each
+    // subprocess (the engine is concurrency-safe since the endstep patches), so
+    // the pool spawns ceil(max_games / games_per_jvm) processes. Default 1 keeps
+    // the historical one-subprocess-per-game shape.
+    let max_sessions = env::var("SELF_HOSTED_NODE_MAX_GAMES")
         .ok()
         .and_then(|value| value.parse::<usize>().ok())
         .filter(|n| *n >= 1)
         .unwrap_or(1);
-    let pool = JavaEnginePool::start(&config, max_size)?;
+    let sessions_per_process = env::var("SELF_HOSTED_NODE_GAMES_PER_JVM")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|n| *n >= 1)
+        .unwrap_or(1);
+    let pool = JavaEnginePool::start(&config, max_sessions, sessions_per_process)?;
     JAVA_ENGINE
         .set(pool)
         .map_err(|_| "java engine already initialized".to_string())
@@ -564,6 +618,11 @@ mod graal_ffi {
             thread: *mut *mut graal_isolatethread_t,
         ) -> c_int;
         pub fn graal_tear_down_isolate(thread: *mut graal_isolatethread_t) -> c_int;
+        pub fn graal_attach_thread(
+            isolate: *mut graal_isolate_t,
+            thread: *mut *mut graal_isolatethread_t,
+        ) -> c_int;
+        pub fn graal_detach_thread(thread: *mut graal_isolatethread_t) -> c_int;
         pub fn forge_initialize(
             thread: *mut graal_isolatethread_t,
             assets_dir: *const c_char,
@@ -613,13 +672,24 @@ struct ForgeReply {
     error: Option<String>,
 }
 
-// One GraalVM isolate hosts the in-process Forge engine. It is created on, and
-// confined to, the hosted-engine thread (isolate threads are not portable), so
-// the handle is Rc/!Send by design.
+// A GraalVM isolate hosts the in-process Forge engine. The `thread` handle is
+// bound to the hosted-engine thread that created or attached it (isolate
+// threads are not portable), so the handle is Rc/!Send by design. In shared
+// mode one isolate serves all rooms: the first creator initializes Forge, later
+// rooms attach their own thread to it and sessions coexist in the adapter.
 #[cfg(feature = "graal-forge")]
 struct GraalBridge {
     thread: *mut graal_ffi::graal_isolatethread_t,
+    attached: bool,
 }
+
+#[cfg(feature = "graal-forge")]
+struct SharedIsolate(*mut graal_ffi::graal_isolate_t);
+#[cfg(feature = "graal-forge")]
+unsafe impl Send for SharedIsolate {}
+
+#[cfg(feature = "graal-forge")]
+static SHARED_GRAAL_ISOLATE: std::sync::Mutex<Option<SharedIsolate>> = std::sync::Mutex::new(None);
 
 #[cfg(feature = "graal-forge")]
 impl GraalBridge {
@@ -632,7 +702,45 @@ impl GraalBridge {
         if rc != 0 {
             return Err(format!("graal_create_isolate failed with code {rc}"));
         }
-        Ok(Self { thread })
+        Ok(Self {
+            thread,
+            attached: false,
+        })
+    }
+
+    fn create_in_shared_isolate(assets_dir: &Path) -> Result<Self, String> {
+        let mut guard = SHARED_GRAAL_ISOLATE
+            .lock()
+            .map_err(|_| "shared graal isolate poisoned".to_string())?;
+        if let Some(shared) = guard.as_ref() {
+            let mut thread: *mut graal_ffi::graal_isolatethread_t = std::ptr::null_mut();
+            let rc = unsafe { graal_ffi::graal_attach_thread(shared.0, &mut thread) };
+            if rc != 0 {
+                return Err(format!("graal_attach_thread failed with code {rc}"));
+            }
+            return Ok(Self {
+                thread,
+                attached: true,
+            });
+        }
+        let mut isolate: *mut graal_ffi::graal_isolate_t = std::ptr::null_mut();
+        let mut thread: *mut graal_ffi::graal_isolatethread_t = std::ptr::null_mut();
+        let rc = unsafe {
+            graal_ffi::graal_create_isolate(std::ptr::null_mut(), &mut isolate, &mut thread)
+        };
+        if rc != 0 {
+            return Err(format!("graal_create_isolate failed with code {rc}"));
+        }
+        let mut bridge = Self {
+            thread,
+            attached: false,
+        };
+        let assets = cstring(&assets_dir.to_string_lossy())?;
+        bridge.decode(unsafe { graal_ffi::forge_initialize(bridge.thread, assets.as_ptr()) })?;
+        bridge.attached = true;
+        *guard = Some(SharedIsolate(isolate));
+        info!("shared graal isolate initialized");
+        Ok(bridge)
     }
 
     fn decode(&self, raw: *mut std::os::raw::c_char) -> Result<String, String> {
@@ -658,7 +766,11 @@ impl GraalBridge {
 #[cfg(feature = "graal-forge")]
 impl Drop for GraalBridge {
     fn drop(&mut self) {
-        unsafe { graal_ffi::graal_tear_down_isolate(self.thread) };
+        if self.attached {
+            unsafe { graal_ffi::graal_detach_thread(self.thread) };
+        } else {
+            unsafe { graal_ffi::graal_tear_down_isolate(self.thread) };
+        }
     }
 }
 
@@ -671,9 +783,21 @@ struct GraalEngineHandle {
 #[cfg(feature = "graal-forge")]
 impl GraalEngineHandle {
     fn create(assets_dir: &Path) -> Result<Self, String> {
-        let bridge = GraalBridge::create()?;
-        let assets = cstring(&assets_dir.to_string_lossy())?;
-        bridge.decode(unsafe { graal_ffi::forge_initialize(bridge.thread, assets.as_ptr()) })?;
+        // SELF_HOSTED_NODE_SHARED_ISOLATE=1 hosts every room's game in one
+        // isolate (safe since the endstep concurrency patches), so the card db
+        // loads once. Default keeps the historical isolate-per-game shape.
+        let shared = env::var("SELF_HOSTED_NODE_SHARED_ISOLATE")
+            .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        let bridge = if shared {
+            GraalBridge::create_in_shared_isolate(assets_dir)?
+        } else {
+            let bridge = GraalBridge::create()?;
+            let assets = cstring(&assets_dir.to_string_lossy())?;
+            bridge
+                .decode(unsafe { graal_ffi::forge_initialize(bridge.thread, assets.as_ptr()) })?;
+            bridge
+        };
         Ok(Self {
             bridge: std::rc::Rc::new(bridge),
         })
@@ -754,7 +878,12 @@ pub fn run_concurrent_self_play(
     concurrency: usize,
 ) -> Result<(), String> {
     let config = JavaRuntimeConfig::from_env();
-    let pool = JavaEnginePool::start(&config, concurrency.max(1))?;
+    let games_per_process = env::var("SELF_HOSTED_NODE_GAMES_PER_JVM")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|n| *n >= 1)
+        .unwrap_or(1);
+    let pool = JavaEnginePool::start(&config, concurrency.max(1), games_per_process)?;
     info!(
         concurrency,
         "java-engine started; launching concurrent games"

--- a/manabrew-rs/crates/self-hosted-node/tests/hosted_smoke.rs
+++ b/manabrew-rs/crates/self-hosted-node/tests/hosted_smoke.rs
@@ -242,20 +242,10 @@ async fn play_game(
                             .all(|p| p.connected && p.ready && p.selected_deck_name.is_some())
                     {
                         sent_start = true;
-                        let start = StateEnvelope::RoomRelay {
-                            protocol: "self-hosted-node".to_string(),
-                            version: 1,
-                            message_id: uuid::Uuid::new_v4().to_string(),
-                            from_player: Some(username.clone()),
-                            target_player: None,
-                            room_id: Some(room_id.to_string()),
-                            payload: json!({ "type": "startGame", "format": "Standard" }),
-                        };
                         send(
                             &mut write,
-                            &ClientMessage::BroadcastState {
-                                state: serde_json::to_value(&start).map_err(|e| e.to_string())?,
-                                target_player: None,
+                            &ClientMessage::StartGame {
+                                format: Some(GameFormat::Standard),
                             },
                         )
                         .await?;
@@ -295,7 +285,7 @@ fn basic_deck(name: &str, land: &str, creature: &str) -> Value {
 }
 
 fn card(id: String, name: &str) -> Value {
-    json!({ "id": id, "name": name, "setCode": "", "cardNumber": "0" })
+    json!({ "identity": { "id": id, "name": name, "setCode": "", "cardNumber": "0" } })
 }
 
 async fn connect(relay: &str) -> Result<(WsWrite, WsRead), String> {


### PR DESCRIPTION
## Summary

- Adds the endstep concurrency patches that let one Forge JVM host several games (#493).
- Bumps the `forge` submodule from `6ab8389` to `1b900c6`, which is the endstep-patched branch.
- Reworks `java_backend.rs` around the reset path and updates the hosted smoke test.

## Why

Running one JVM per game is the current ceiling on the hosted-AI node. These are the engine-side patches that make a shared JVM viable. Evaluation on `scratch/endstep-patch-test` came back green at 40 games in 3.5GB.

Split out of #514 so it can be reviewed on its own. It shares no files with the double-faced work in #520.

The compose change that raises the staging node to 4 games per JVM is deliberately not here. It belongs with the slot topology in #513, which stays at `MAX_GAMES=1` so the slot cannot enable multi-game before this lands. Flipping it is a follow-up once both are in.

## Note for reviewers

This PR does not build against `main`'s forge submodule, by design. The Java harness changes require the bumped revision, so a stale submodule fails with API mismatches (`CostPayShards` in `ICostVisitor`, `Multiset.Entry` vs `Map.Entry` for counters, `refreshSkin()` on `IGuiBase`). If you see those, run `git submodule update --init --recursive` rather than reading them as defects in this diff.

## Test plan

- `yarn build:harness` BUILD SUCCESS against forge `1b900c6`, which is what this PR pins. Verified the same build fails against `6ab8389`, confirming the submodule bump is load-bearing rather than incidental.
- `cargo check -p self-hosted-node` clean.
- `cargo test -p manabrew-engine --lib`: 333 passed, 0 failed.
- `yarn typecheck` clean.
- Not exercised as a live multi-game session on the node. That happens once #513 and this are both in and the slot is flipped to 4 games per JVM.
