### PR TITLE
fix(ironsmith): Keep minor Ironsmith WASM updates automatic

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "clsx": "^2.1.1",
     "gsap": "^3.15.0",
     "immer": "^11.1.4",
-    "ironsmith-wasm": "0.1.0",
+    "ironsmith-wasm": "^0.1.1",
     "lucide-react": "^0.574.0",
     "next-themes": "^0.4.6",
     "pixi-filters": "^6.1.5",


### PR DESCRIPTION
Small dependency update to use the latest version of Ironsmith's package (0.1.1) + keeping it automatically updated for new minor semver releases.