### PR TITLE
build(ironsmith): sync yarn.lock with the ironsmith-wasm range bump

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2833,10 +2833,10 @@ ini@6.0.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-6.0.0.tgz#efc7642b276f6a37d22fdf56ef50889d7146bf30"
   integrity sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==
 
-ironsmith-wasm@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/ironsmith-wasm/-/ironsmith-wasm-0.1.0.tgz#6334f5866ff74ab85e8ba196864f82c15b0f909e"
-  integrity sha512-WbxMUa5BtNTjHtZfM/3ArbKowMyiEm54zeJAgyNtQR6S70LAfh62TQeIb6q9ygvl+rLA2gM6+Lzm1p/UluTrug==
+ironsmith-wasm@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ironsmith-wasm/-/ironsmith-wasm-0.1.1.tgz#3d95ddfb621773f731e4d002b70256b88c7f8691"
+  integrity sha512-ae80wTcF1c0gqNnj6fUgIBMjZHWQok485uJ5tPMugmZo4O6XERqOGaa5QecgOSLxPaGn5qg8UBgrRDsv4zMZUQ==
 
 is-arrayish@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
## Summary

- Regenerates `yarn.lock` for the `ironsmith-wasm` range bump from #528 (`0.1.0` pinned to `^0.1.1`).

## Why

#528 changed the range in `package.json` without updating the lockfile. `yarn install --frozen-lockfile` now fails on main, which breaks the "Generated protocol types are up to date" check on every PR merge ref.

## Test plan

- `yarn install --frozen-lockfile` passes locally on this branch.
