### PR TITLE
ci(release): publish protocol npm from the release tag, not the trigger commit

### DIFF
--- a/.github/workflows/publish-protocol.yml
+++ b/.github/workflows/publish-protocol.yml
@@ -15,6 +15,16 @@ name: Publish protocol
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        # release.yml passes the freshly created manabrew-protocol-v* tag:
+        # its own trigger commit (github.sha) predates the chore(release)
+        # bump, so checking out the default ref reads the previous version
+        # and skips both registries.
+        description: Git ref holding the version to publish
+        type: string
+        required: false
+        default: ""
   workflow_dispatch:
 
 permissions:
@@ -31,6 +41,9 @@ jobs:
     if: github.repository == 'witchesofthehill/manabrew'
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Empty (workflow_dispatch) falls back to the default ref.
+          ref: ${{ inputs.ref }}
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       protocol_bumped: ${{ steps.detect-protocol.outputs.bumped }}
+      protocol_tag: ${{ steps.detect-protocol.outputs.tag }}
     if: >
       github.repository == 'witchesofthehill/manabrew' &&
       (github.event_name == 'workflow_dispatch' ||
@@ -78,12 +79,17 @@ jobs:
         run: cargo xtask release
 
       # `cargo xtask release` tags each bumped crate at HEAD (`<crate>-vX.Y.Z`);
-      # the protocol tag is the signal that its version moved this run.
+      # the protocol tag is the signal that its version moved this run. The tag
+      # is also handed to publish-protocol as its checkout ref: this workflow
+      # runs at the pre-release merge commit (github.sha), and the version bump
+      # only exists in the chore(release) commit created above.
       - name: Detect protocol bump
         id: detect-protocol
         run: |
-          if git tag --points-at HEAD | grep -q '^manabrew-protocol-v'; then
+          TAG=$(git tag --points-at HEAD | grep '^manabrew-protocol-v' || true)
+          if [ -n "$TAG" ]; then
             echo "bumped=true" >> "$GITHUB_OUTPUT"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           else
             echo "bumped=false" >> "$GITHUB_OUTPUT"
           fi
@@ -103,4 +109,6 @@ jobs:
     needs: release
     if: needs.release.outputs.protocol_bumped == 'true'
     uses: ./.github/workflows/publish-protocol.yml
+    with:
+      ref: ${{ needs.release.outputs.protocol_tag }}
     secrets: inherit


### PR DESCRIPTION
## Summary

- release.yml now captures the freshly created `manabrew-protocol-v*` tag in the detect step and passes it to publish-protocol.yml as the checkout ref.
- publish-protocol.yml accepts an optional `ref` input on `workflow_call`. Empty (manual dispatch) keeps the default checkout.

## Why

release.yml runs at the pre-release merge commit. The version bump only exists in the `chore(release):` commit that `cargo xtask release` creates and pushes. publish-protocol.yml checked out `github.sha`, read the previous crate version, found it already on both registries and skipped while reporting success. crates.io still advanced because the release job's own `cargo xtask publish` runs in the post-bump working tree; npm had no fallback. Result: crate at 2.0.0, npm stuck at 1.1.0 (release run 30076108302 logs show `Publishing ... @ 1.1.0` followed by both skips).

The tag is safe as a ref: release.rs pushes crate tags together with the main push, before the publish-protocol job starts.

## Test plan

- actionlint passes on both files.
- Healed the existing drift with a manual dispatch (run 30080162709): checkout at main read 2.0.0, crates.io skipped, npm published. `npm view @manabrew/protocol` now shows 2.0.0.
- Real verification is the next release that bumps the protocol crate: its publish-protocol job log should read the new version, not the previous one.