### PR TITLE
feat(ironsmith): update ironsmith-wasm to 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "clsx": "^2.1.1",
     "gsap": "^3.15.0",
     "immer": "^11.1.4",
-    "ironsmith-wasm": "^0.1.1",
+    "ironsmith-wasm": "^0.1.2",
     "lucide-react": "^0.574.0",
     "next-themes": "^0.4.6",
     "pixi-filters": "^6.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2833,10 +2833,10 @@ ini@6.0.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-6.0.0.tgz#efc7642b276f6a37d22fdf56ef50889d7146bf30"
   integrity sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==
 
-ironsmith-wasm@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/ironsmith-wasm/-/ironsmith-wasm-0.1.1.tgz#3d95ddfb621773f731e4d002b70256b88c7f8691"
-  integrity sha512-ae80wTcF1c0gqNnj6fUgIBMjZHWQok485uJ5tPMugmZo4O6XERqOGaa5QecgOSLxPaGn5qg8UBgrRDsv4zMZUQ==
+ironsmith-wasm@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ironsmith-wasm/-/ironsmith-wasm-0.1.2.tgz#4f95d9aeccd01cb738d1e335bcbf07bd8270a823"
+  integrity sha512-vE91LJZGCIpixTHJtk0StxhGDr+VaYbDcYTicHNPQm+VonYBXwF83iCz90kFouS76QnuMn/I0QmjqwllXEsA8A==
 
 is-arrayish@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
## Summary

- update `ironsmith-wasm` from `^0.1.1` to `^0.1.2`
- refresh `yarn.lock` to resolve the newly published package

## Why

ManaBrew installs dependencies with `--frozen-lockfile`, so deployments continue using `ironsmith-wasm@0.1.1` even though `0.1.2` is available. Version `0.1.2` updates Ironsmith's ManaBrew bridge to the current protocol and emits the structured prompt messages expected by the UI.

This fixes crashes when casting spells or activating abilities that open selection prompts, where the old package emitted string options and the current UI expected `{ label, weight, canRepeat }` objects.

## Validation

- `yarn install --frozen-lockfile --ignore-scripts --ignore-engines`
- confirmed `node_modules/ironsmith-wasm/package.json` reports `0.1.2`
- Prettier check for `package.json`
