### PR TITLE
ci: warm tauri caches from main, stop tag cache saves, mold linker

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -13,9 +13,15 @@ concurrency:
   cancel-in-progress: true
 
 # Cargo caches use rust-cache shared-keys (engine / relay / web-wasm /
-# tauri-ios / tauri-android). PR-saved caches are only visible to the same
+# tauri-ios / tauri-android; cache-warm.yml additionally owns tauri-macos /
+# tauri-windows for publish.yml). PR-saved caches are only visible to the same
 # branch, so cache-warm.yml re-saves them from main on every merge — keep the
 # shared-keys and build commands here in sync with that workflow.
+#
+# The Linux cargo jobs link with mold (rui314/setup-mold installs it as the
+# default ld). No RUSTFLAGS change means cargo fingerprints are untouched, so
+# caches stay interchangeable with GNU-ld-linked ones. Mirrored in
+# cache-warm.yml; not applicable to macOS/Windows runners or wasm targets.
 
 jobs:
   changes:
@@ -136,6 +142,9 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
+      - name: Set up mold linker
+        uses: rui314/setup-mold@v1
+
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -196,6 +205,9 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Set up mold linker
+        uses: rui314/setup-mold@v1
+
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -227,6 +239,9 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Set up mold linker
+        uses: rui314/setup-mold@v1
+
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -249,6 +264,9 @@ jobs:
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up mold linker
+        uses: rui314/setup-mold@v1
 
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2
@@ -280,6 +298,9 @@ jobs:
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up mold linker
+        uses: rui314/setup-mold@v1
 
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -18,10 +18,8 @@ concurrency:
 # branch, so cache-warm.yml re-saves them from main on every merge — keep the
 # shared-keys and build commands here in sync with that workflow.
 #
-# The Linux cargo jobs link with mold (rui314/setup-mold installs it as the
-# default ld). No RUSTFLAGS change means cargo fingerprints are untouched, so
-# caches stay interchangeable with GNU-ld-linked ones. Mirrored in
-# cache-warm.yml; not applicable to macOS/Windows runners or wasm targets.
+# Linux cargo jobs link with mold, installed as the default ld: no RUSTFLAGS
+# change, so caches stay valid. Mirrored in cache-warm.yml.
 
 jobs:
   changes:

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -4,8 +4,12 @@ name: Cache warm
 # PR run are scoped to that PR's branch — invisible to every other PR. Nothing
 # else compiles on main, so without this workflow the first push of every PR
 # starts from a cold cache. Each job here mirrors the build commands and
-# rust-cache shared-key of a build-checks job and saves main-scoped caches,
-# which every PR run (and every tag build) can restore.
+# rust-cache shared-key of a build-checks job (or, for the tauri-macos /
+# tauri-windows keys, of a publish.yml installer job: the desktop builds have
+# no PR trigger at all) and saves main-scoped caches, which every PR run (and
+# every tag build) can restore. publish.yml itself never saves (save-if:
+# false): a cache saved on a tag ref is unreadable by every later tag, so it
+# would only evict the warm caches saved here.
 #
 # Steady-state cost is low: every job is gated on whether its inputs actually
 # changed in the pushed commit (a UI-only merge warms nothing), rust-cache
@@ -129,6 +133,12 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # Installed as the default ld (no RUSTFLAGS change), so artifacts stay
+      # fingerprint-compatible with caches linked by GNU ld. Keep the Linux
+      # cargo jobs in build-checks.yml in sync.
+      - name: Set up mold linker
+        uses: rui314/setup-mold@v1
+
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -159,6 +169,9 @@ jobs:
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up mold linker
+        uses: rui314/setup-mold@v1
 
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2
@@ -199,6 +212,9 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
+      - name: Set up mold linker
+        uses: rui314/setup-mold@v1
+
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -232,3 +248,240 @@ jobs:
 
       - name: Warm xtask (gen:types)
         run: yarn gen:types
+
+  # publish.yml's installer builds restore the four tauri-* keys below but
+  # nothing used to save them anywhere a tag build can read (PR saves are
+  # PR-scoped, tag saves die with their tag), so every release compiled the
+  # full desktop and mobile workspaces from scratch. The desktop warms mirror
+  # publish.yml's macos-dmg / windows-exe jobs up to the tauri crate build,
+  # with dist stubbed instead of running the vite bundle: real assets only
+  # refingerprint the manabrew crate itself, the dependency graph stays warm.
+  # The mobile warms mirror build-checks' ios-build / android-build. Release
+  # bump commits are skipped like everywhere else; the version-bumped
+  # workspace members rebuild on top of the previous merge's warm deps via
+  # rust-cache prefix restore.
+  tauri-macos:
+    name: Warm macOS tauri
+    runs-on: macos-latest
+    timeout-minutes: 90
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' && !startsWith(github.event.head_commit.message, 'chore(release):')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: yarn
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Set up GraalVM (JDK 21)
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: "21"
+          distribution: "graalvm-community"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache: "maven"
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: tauri-macos
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.13.1
+
+      - run: yarn
+
+      - name: Build WASM + bundle cards
+        run: yarn build:wasm
+
+      - name: Build Forge harness jar (Maven, GraalVM JDK 21)
+        run: yarn build:harness
+
+      - name: Build native Forge library (GraalVM native-image)
+        run: ./forge-harness/build-native.sh
+
+      - name: Stub frontend dist for tauri context macro
+        run: |
+          mkdir -p dist
+          printf '<!doctype html><title>ci</title>' > dist/index.html
+
+      - name: Build tauri crate with forge-room feature
+        run: cargo build --release -p manabrew --features forge-room
+
+  tauri-windows:
+    name: Warm Windows tauri
+    runs-on: windows-latest
+    timeout-minutes: 90
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' && !startsWith(github.event.head_commit.message, 'chore(release):')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: yarn
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Set up GraalVM (JDK 21)
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: "21"
+          distribution: "graalvm-community"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache: "maven"
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: tauri-windows
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.13.1
+
+      - run: yarn
+
+      - name: Build WASM + bundle cards
+        run: yarn build:wasm
+
+      - name: Build Forge harness jar (Maven, GraalVM JDK 21)
+        run: yarn build:harness
+
+      - name: Build native Forge library (GraalVM native-image)
+        run: ./forge-harness/build-native.ps1
+        shell: pwsh
+
+      - name: Stub frontend dist for tauri context macro
+        shell: bash
+        run: |
+          mkdir -p dist
+          printf '<!doctype html><title>ci</title>' > dist/index.html
+
+      - name: Build tauri crate with forge-room feature
+        run: cargo build --release -p manabrew --features forge-room
+
+  tauri-ios:
+    name: Warm iOS tauri
+    # Pinned to macos-15 like publish.yml's ios-ipa (tauri-apps/tauri#15066).
+    runs-on: macos-15
+    timeout-minutes: 90
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' && !startsWith(github.event.head_commit.message, 'chore(release):')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: yarn
+
+      - name: Install Yarn
+        run: npm install --global yarn
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios,wasm32-unknown-unknown
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: tauri-ios
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.13.1
+
+      - run: yarn
+
+      - name: Build WASM + bundle cards
+        run: yarn build:wasm
+
+      - name: Build cardset archive
+        run: |
+          cargo run -p forge-cardset-archive --features build --release \
+            --bin build-cardset-archive
+
+      - name: Tauri build (iOS, unsigned)
+        run: yarn tauri ios build --no-sign
+
+  tauri-android:
+    name: Warm Android tauri
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' && !startsWith(github.event.head_commit.message, 'chore(release):')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: yarn
+
+      - name: Install Yarn
+        run: npm install --global yarn
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,wasm32-unknown-unknown
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: tauri-android
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.13.1
+
+      - run: yarn
+
+      - name: Build WASM + bundle cards
+        run: yarn build:wasm
+
+      - name: Build cardset archive
+        run: |
+          cargo run -p forge-cardset-archive --features build --release \
+            --bin build-cardset-archive
+
+      - name: Tauri build (Android APK, arm64)
+        run: node scripts/mobile-dev.mjs android build --apk --target aarch64

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -4,12 +4,9 @@ name: Cache warm
 # PR run are scoped to that PR's branch — invisible to every other PR. Nothing
 # else compiles on main, so without this workflow the first push of every PR
 # starts from a cold cache. Each job here mirrors the build commands and
-# rust-cache shared-key of a build-checks job (or, for the tauri-macos /
-# tauri-windows keys, of a publish.yml installer job: the desktop builds have
-# no PR trigger at all) and saves main-scoped caches, which every PR run (and
-# every tag build) can restore. publish.yml itself never saves (save-if:
-# false): a cache saved on a tag ref is unreadable by every later tag, so it
-# would only evict the warm caches saved here.
+# rust-cache shared-key of a build-checks job (or a publish.yml job for the
+# desktop tauri keys) and saves main-scoped caches, which every PR run (and
+# every tag build) can restore. publish.yml itself is restore-only.
 #
 # Steady-state cost is low: every job is gated on whether its inputs actually
 # changed in the pushed commit (a UI-only merge warms nothing), rust-cache
@@ -133,9 +130,8 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      # Installed as the default ld (no RUSTFLAGS change), so artifacts stay
-      # fingerprint-compatible with caches linked by GNU ld. Keep the Linux
-      # cargo jobs in build-checks.yml in sync.
+      # Default-ld swap: no RUSTFLAGS change, caches stay compatible. Keep
+      # in sync with build-checks.yml.
       - name: Set up mold linker
         uses: rui314/setup-mold@v1
 
@@ -249,17 +245,8 @@ jobs:
       - name: Warm xtask (gen:types)
         run: yarn gen:types
 
-  # publish.yml's installer builds restore the four tauri-* keys below but
-  # nothing used to save them anywhere a tag build can read (PR saves are
-  # PR-scoped, tag saves die with their tag), so every release compiled the
-  # full desktop and mobile workspaces from scratch. The desktop warms mirror
-  # publish.yml's macos-dmg / windows-exe jobs up to the tauri crate build,
-  # with dist stubbed instead of running the vite bundle: real assets only
-  # refingerprint the manabrew crate itself, the dependency graph stays warm.
-  # The mobile warms mirror build-checks' ios-build / android-build. Release
-  # bump commits are skipped like everywhere else; the version-bumped
-  # workspace members rebuild on top of the previous merge's warm deps via
-  # rust-cache prefix restore.
+  # publish.yml restores these tauri-* keys but can never save them anywhere
+  # readable, so releases built cold. Desktop mirrors publish with dist stubbed.
   tauri-macos:
     name: Warm macOS tauri
     runs-on: macos-latest

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -25,9 +25,11 @@ on:
 permissions:
   contents: read
 
+# Never cancel an in-progress warm: every merge is followed ~90s later by its
+# chore(release) push, which would kill the real warm and then skip all jobs.
 concurrency:
   group: cache-warm
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   # What changed in this push decides which warms are worth running. The

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -101,4 +101,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.image }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+          # Layers saved from a tag build are unreadable by the next tag (GHA
+          # caches are ref-scoped); cache-warm.yml maintains the main-scoped
+          # layers every build restores. Saving here would only evict those,
+          # so tag builds are restore-only. workflow_dispatch runs (from main)
+          # still save: there the cache lands where future builds can see it.
+          cache-to: ${{ github.ref_type != 'tag' && format('type=gha,mode=max,scope={0}', matrix.image) || '' }}

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -101,9 +101,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.image }}
-          # Layers saved from a tag build are unreadable by the next tag (GHA
-          # caches are ref-scoped); cache-warm.yml maintains the main-scoped
-          # layers every build restores. Saving here would only evict those,
-          # so tag builds are restore-only. workflow_dispatch runs (from main)
-          # still save: there the cache lands where future builds can see it.
+          # Tag-scoped layer saves are unreadable by the next tag; cache-warm
+          # owns the main-scoped layers. Dispatch runs (from main) still save.
           cache-to: ${{ github.ref_type != 'tag' && format('type=gha,mode=max,scope={0}', matrix.image) || '' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,6 +79,10 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: tauri-macos
+          # Restore-only, here and in every job below: a cache saved on a tag
+          # ref is unreadable by every other ref, so saving would only evict
+          # the main-scoped caches cache-warm.yml maintains for these keys.
+          save-if: false
 
       - name: Install wasm-pack
         uses: taiki-e/install-action@v2
@@ -180,6 +184,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: tauri-windows
+          save-if: false
 
       - name: Install wasm-pack
         uses: taiki-e/install-action@v2
@@ -281,6 +286,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: tauri-ios
+          save-if: false
 
       - name: Install wasm-pack
         uses: taiki-e/install-action@v2
@@ -351,6 +357,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: tauri-android
+          save-if: false
 
       - name: Install wasm-pack
         uses: taiki-e/install-action@v2
@@ -403,6 +410,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: xtask-deploy
+          save-if: false
 
       # Prebuilt deploy tool: an evergreen binary — it fetches the deployed
       # ref's config from GitHub at run time, so one download deploys (or
@@ -559,6 +567,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: xtask-deploy
+          save-if: false
 
       # Semver compatibility of the client-facing crates vs the previous
       # release, decided in Rust with the same semver crate the release
@@ -607,6 +616,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: xtask-deploy
+          save-if: false
 
       - name: Deploy web (xtask, from the runner)
         id: deploy
@@ -688,6 +698,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: xtask-deploy
+          save-if: false
 
       - name: Deploy production (xtask, from the runner)
         id: deploy

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,9 +79,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: tauri-macos
-          # Restore-only, here and in every job below: a cache saved on a tag
-          # ref is unreadable by every other ref, so saving would only evict
-          # the main-scoped caches cache-warm.yml maintains for these keys.
+          # Restore-only (all jobs below too): tag-scoped saves are unreadable
+          # by later tags and would evict cache-warm.yml's main-scoped caches.
           save-if: false
 
       - name: Install wasm-pack


### PR DESCRIPTION
## Summary

- `cache-warm.yml` gains four jobs that warm the `tauri-macos`, `tauri-windows`, `tauri-ios` and `tauri-android` rust-cache keys from main. Desktop mirrors the publish jobs up to the tauri crate build (dist stubbed, no vite bundle). Mobile mirrors the build-checks jobs.
- `publish.yml` sets `save-if: false` on every rust-cache step (the four tauri keys plus the four `xtask-deploy` uses). `docker-images.yml` stops writing layer caches on tag builds; `workflow_dispatch` runs still save.
- The Linux cargo jobs in `build-checks.yml` and `cache-warm.yml` link with mold via `rui314/setup-mold`. It installs as the default `ld`, so RUSTFLAGS and cargo fingerprints are unchanged and existing caches stay valid.
- `cache-warm.yml` no longer cancels in-progress runs. Every merge is followed about 90s later by its `chore(release)` push, which started a new warm run, cancelled the real one, then skipped all of its own jobs. In practice no warm completed after a substantive merge: the last successful docker-layers warm was July 21, and the v2.1.0 image builds ran with zero layer cache hits, `cargo chef cook` included.

## Why

Every release compiled the full desktop and mobile workspaces from scratch. publish.yml restores the `tauri-*` keys, but nothing saved them anywhere a tag build can read: PR saves are scoped to the PR branch, and a cache saved on a tag ref is unreadable by every later tag. The v2.1.0 run showed the cost: 10 min of Tauri build on macOS, 18.9 min on Windows, all cold.

The tag-scoped saves also hurt on their own. The repo sits at the 10 GB Actions cache limit, and the largest entries right now are all dead weight from `refs/tags/v2.1.0` (roughly 7 GB of rust-cache, node and buildkit blobs). Each release evicted main's warm caches to store caches nothing can restore. Making tag builds restore-only frees that headroom for the new tauri warms.

mold is a smaller win on top: it mainly helps the link-heavy regression job, which builds the relay, the node and a large test binary.

Expected steady state: macOS .dmg around 8 to 10 min, Windows .exe around 15 to 20 min. The first release after this merges is still cold; the warm caches exist once cache-warm has run on a rust-touching merge. Release bump commits stay skipped: the bumped workspace members rebuild on top of the previous merge's deps via rust-cache prefix restore.

## Test plan

- `actionlint` and `prettier --check` pass on all four workflows.
- After merge: check the cache-warm run on this merge saves `tauri-*` caches (Actions cache list shows them on `refs/heads/main`).
- Next release after that: the macOS and Windows job logs should show dependency crates restored, not compiled, and the Tauri build step well under its current 10 and 19 min.
- Cache usage (`gh api repos/witchesofthehill/manabrew/actions/cache/usage`) should stop accumulating tag-ref entries after the next release.
