### PR TITLE
fix(ui): allow playing cards from opponent zones

### DIFF
--- a/src/components/game/GameBoard.tsx
+++ b/src/components/game/GameBoard.tsx
@@ -1029,10 +1029,28 @@ export function GameBoard({
       const gyTargets = opZoneTargetIds("Graveyard", op.graveyard);
       const exTargets = opZoneTargetIds("Exile", op.exile);
       const cmdTargets = opZoneTargetIds("Command", op.commandZone);
-      const openOpZone = (title: string, cards: CardDto[], targetIds: string[]) =>
-        targetIds.length > 0
-          ? onOpenZone(title, cards, onTargetFromZone, targetIds, hostileTargeting)
-          : onOpenZone(title, cards);
+      const playableIn = (cards: CardDto[]) =>
+        promptType === "chooseAction" ? cards.filter((card) => playableIds.has(card.id)) : [];
+      const openOpZone = (title: string, cards: CardDto[], targetIds: string[]) => {
+        if (targetIds.length > 0) {
+          onOpenZone(title, cards, onTargetFromZone, targetIds, hostileTargeting);
+          return;
+        }
+        const playable = playableIn(cards);
+        if (playable.length > 0) {
+          onOpenZoneAndCast(
+            title,
+            cards,
+            (_cardId) => {},
+            playable.map((card) => card.id),
+          );
+          return;
+        }
+        onOpenZone(title, cards);
+      };
+      const gyPlayable = playableIn(op.graveyard).length > 0;
+      const exPlayable = playableIn(op.exile).length > 0;
+      const cmdPlayable = playableIn(op.commandZone).length > 0;
       const tiles: ZoneTileSpec[] = [
         {
           key: ZONE_TILE_KEY.library,
@@ -1052,7 +1070,7 @@ export function GameBoard({
           topCard: top(op.graveyard),
           onOpen: () =>
             openOpZone(`${stripUsernameTag(op.name)}'s Graveyard`, op.graveyard, gyTargets),
-          highlightColor: gyTargets.length > 0 ? targetColor : undefined,
+          highlightColor: gyTargets.length > 0 ? targetColor : gyPlayable ? active : undefined,
         },
         {
           key: ZONE_TILE_KEY.exile,
@@ -1060,7 +1078,7 @@ export function GameBoard({
           count: op.exile.length,
           topCard: top(op.exile),
           onOpen: () => openOpZone(`${stripUsernameTag(op.name)}'s Exile`, op.exile, exTargets),
-          highlightColor: exTargets.length > 0 ? targetColor : undefined,
+          highlightColor: exTargets.length > 0 ? targetColor : exPlayable ? active : undefined,
         },
       ];
       if ((op.commandZone?.length ?? 0) > 0) {
@@ -1071,7 +1089,7 @@ export function GameBoard({
           topCard: top(op.commandZone),
           onOpen: () =>
             openOpZone(`${stripUsernameTag(op.name)}'s Command Zone`, op.commandZone, cmdTargets),
-          highlightColor: cmdTargets.length > 0 ? targetColor : undefined,
+          highlightColor: cmdTargets.length > 0 ? targetColor : cmdPlayable ? active : undefined,
           commander: playerColors[OPPONENT_SEATS[oppIndex] ?? "opponent1"],
         });
       }
@@ -1099,6 +1117,7 @@ export function GameBoard({
     boardTargets,
     onTargetFromZone,
     onOpenZone,
+    onOpenZoneAndCast,
     openCommandZone,
     openGraveyard,
     openExile,

--- a/src/views/Game.tsx
+++ b/src/views/Game.tsx
@@ -437,12 +437,14 @@ export default function Game({ exitTo }: GameProps = {}) {
     const acts = chooseActionInput?.actions ?? [];
     const castActions = acts.flatMap((a) => (a.type === "cast" && a.cardId === cardId ? [a] : []));
     if (castActions.length > 1) {
-      const myPlayer = gameView?.players.find((p) => p.id === myPlayerSlot);
-      const gc =
-        myPlayer?.hand.find((c) => c.id === cardId) ??
-        myPlayer?.graveyard.find((c) => c.id === cardId) ??
-        myPlayer?.exile.find((c) => c.id === cardId) ??
-        myPlayer?.commandZone.find((c) => c.id === cardId);
+      const gc = gameView?.players
+        .flatMap((player) => [
+          ...player.hand,
+          ...player.graveyard,
+          ...player.exile,
+          ...player.commandZone,
+        ])
+        .find((card) => card.id === cardId);
       if (!gc) throw new Error(`No game card to cast: ${cardId}`);
       const card = asDeckCard(gameDecks[gc.ownerId], gc);
       openPlayModePicker({


### PR DESCRIPTION
## Summary

- make opponent-owned graveyard, exile, and command-zone cards actionable when the active prompt marks them playable
- highlight opponent zone tiles when they contain a playable card
- resolve multi-mode cast metadata across every player's public zones

## Why

Effects such as Ragavan can grant a player permission to cast an opponent-owned card from exile. The engine correctly emits a `cast` action for that card, but the UI only connected playable actions to the local player's zone viewers. Opponent zone tiles could be opened or targeted, but did not surface or dispatch their playable card actions.

## Test plan

- `yarn lint` (ESLint, Prettier, generated protocol types, and TypeScript) passes
- `yarn lint:all` reaches Rust clippy after the frontend checks pass; Rust clippy currently fails on pre-existing `main` warnings/errors unrelated to this UI change, including `large_enum_variant` and unused variables
- verified the pre-commit staged-file ESLint and Prettier hooks pass

## Demo

No static screenshot: the change affects the state-dependent highlight and interaction of opponent zone tiles while a `chooseAction` prompt contains a matching cast action.
