### PR TITLE
fix(web): fail the image build when the nodesource fetch fails

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -10,12 +10,18 @@
 # --- Base: Rust + Node toolchain shared by the planner and builder stages ---
 FROM rust:1.88-slim AS base
 
-# Install Node.js 20 and build tools
+# Install Node.js 20 and build tools. The NodeSource script is downloaded to a
+# file, not piped: a piped curl failure exits 0 (no pipefail in /bin/sh), apt
+# then falls back to Debian's node 18 — which has no corepack — and the broken
+# layer caches. The version/corepack check makes that failure mode impossible.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         curl ca-certificates build-essential pkg-config libssl-dev && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    curl -fsSL -o /tmp/nodesource-setup.sh https://deb.nodesource.com/setup_20.x && \
+    bash /tmp/nodesource-setup.sh && \
+    rm /tmp/nodesource-setup.sh && \
     apt-get install -y --no-install-recommends nodejs && \
+    node --version | grep -q '^v20\.' && command -v corepack && \
     rm -rf /var/lib/apt/lists/*
 
 # Install wasm32 target and wasm-pack (pinned; newer versions track latest rustc)


### PR DESCRIPTION
## Summary

- Download the NodeSource setup script to a file instead of piping it into bash in the web image base stage.
- Assert in the same layer that node is v20 and corepack exists.

## Why

The v3.0.0 Docker images run failed on `Build & push manabrew-web` with `corepack: not found` (exit 127) and passed on rerun ([attempt 1 logs](https://github.com/witchesofthehill/manabrew/actions/runs/30303214021/attempts/1)). The piped `curl -fsSL ... | bash -` fetch failed transiently. `/bin/sh` has no pipefail, so the pipeline exited 0 and the chain continued. `apt-get install nodejs` then fell back to Debian bookworm's nodejs 18.20.4, which ships no corepack, and the failure only surfaced two minutes later in the builder stage.

As a separate `&&` step, a failed fetch now fails the layer immediately with curl's error in the log. The guard means no fallback Node can ever produce a cacheable "good" layer.

## Test plan

- RUN chain syntax checked with `sh -n` under dash.
- Version guard accepts `v20.x` and rejects `v18.x`.
- PR checks do not build `Dockerfile.web`; the real exercise is the next tag's Docker images workflow.
