### PR TITLE
chore(lint): fix workspace clippy warnings

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
 npx lint-staged
+yarn lint:all

--- a/manabrew-rs/crates/forge-limited/src/card_ranking_comparator.rs
+++ b/manabrew-rs/crates/forge-limited/src/card_ranking_comparator.rs
@@ -12,7 +12,7 @@ impl CardRankingComparator {
         }
     }
 
-    pub fn sort(entries: &mut Vec<(f64, PaperCard)>) {
+    pub fn sort(entries: &mut [(f64, PaperCard)]) {
         entries.sort_by(Self::compare);
     }
 }

--- a/manabrew-rs/crates/forge-limited/src/sealed_card_pool_generator.rs
+++ b/manabrew-rs/crates/forge-limited/src/sealed_card_pool_generator.rs
@@ -100,6 +100,7 @@ impl SealedCardPoolGenerator {
         Some(prod.open(rng))
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn generate_sealed_deck<R: Rng + ?Sized, ColorFn, LandFn>(
         &mut self,
         deck_name: impl Into<String>,

--- a/manabrew-rs/crates/forge-limited/src/winston_draft.rs
+++ b/manabrew-rs/crates/forge-limited/src/winston_draft.rs
@@ -128,20 +128,18 @@ impl WinstonDraft {
     /// Drive the loop: if the AI is on the clock, run AI picks until
     /// either the draft is done or the human is on the clock.
     pub fn tick(&mut self) -> WinstonOutcome {
-        loop {
-            if self.is_complete() {
-                return WinstonOutcome::Complete;
-            }
-            if self.is_human_turn() {
-                self.pending_human_pile = Some(self.current_pile);
-                return WinstonOutcome::AwaitingHuman;
-            }
-            let cards = self.ai_resolve_turn();
-            let seat = self.active_seat;
-            self.seats[seat].picked.extend(cards.iter().cloned());
-            self.advance_seat();
-            return WinstonOutcome::Picked { seat, cards };
+        if self.is_complete() {
+            return WinstonOutcome::Complete;
         }
+        if self.is_human_turn() {
+            self.pending_human_pile = Some(self.current_pile);
+            return WinstonOutcome::AwaitingHuman;
+        }
+        let cards = self.ai_resolve_turn();
+        let seat = self.active_seat;
+        self.seats[seat].picked.extend(cards.iter().cloned());
+        self.advance_seat();
+        WinstonOutcome::Picked { seat, cards }
     }
 
     /// Human accepts the current pile.

--- a/manabrew-rs/crates/manabrew-agent-interface/src/mana_action_id.rs
+++ b/manabrew-rs/crates/manabrew-agent-interface/src/mana_action_id.rs
@@ -88,7 +88,7 @@ fn split_mana_choices(
         .map(String::as_str)
         .filter(|token| *token != "COMBO")
         .collect();
-    let is_any = mana_tokens.iter().any(|token| *token == "ANY");
+    let is_any = mana_tokens.contains(&"ANY");
     let amount = produced_mana_amount.unwrap_or(1).max(1);
 
     if is_any && !is_combo {

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/change_zone_effect/hidden.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/change_zone_effect/hidden.rs
@@ -144,25 +144,22 @@ pub(super) fn resolve_hidden_origin(
             // optional moves originating from a hidden zone (Library).
             if sa.ir.optional {
                 let chooser = controller;
-                let source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.clone());
-                ordered = ordered
-                    .into_iter()
-                    .filter(|&cid| {
-                        let card_name = ctx.game.card(cid).card_name.clone();
-                        let prompt = format!(
-                            "Do you want to move {} from {} to {}?",
-                            card_name, origin_zone, dest_zone,
-                        );
-                        ctx.agents[chooser.index()].confirm_action(
-                            chooser,
-                            None,
-                            &prompt,
-                            &[],
-                            sa.source,
-                            Some(crate::ability::api_type::ApiType::ChangeZone),
-                        )
-                    })
-                    .collect();
+                let _source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.clone());
+                ordered.retain(|&cid| {
+                    let card_name = ctx.game.card(cid).card_name.clone();
+                    let prompt = format!(
+                        "Do you want to move {} from {} to {}?",
+                        card_name, origin_zone, dest_zone,
+                    );
+                    ctx.agents[chooser.index()].confirm_action(
+                        chooser,
+                        None,
+                        &prompt,
+                        &[],
+                        sa.source,
+                        Some(crate::ability::api_type::ApiType::ChangeZone),
+                    )
+                });
             }
             // For Defined card moves, suppress the post-move library shuffle.
             // Java's changeHiddenOriginResolve checks `!defined` before shuffling
@@ -371,7 +368,7 @@ pub(super) fn resolve_hidden_origin(
     };
 
     if optional_confirm {
-        let source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.as_str());
+        let _source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.as_str());
         let origin_label = origin_zone.to_string().to_lowercase();
         let message = if is_defined {
             format!(

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/change_zone_effect/known.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/change_zone_effect/known.rs
@@ -188,7 +188,7 @@ pub(super) fn resolve_known_origin(
     // optional ChangeZone for a peeked land).
     let cards_to_move = if sa.ir.optional && !cards_to_move.is_empty() {
         let chooser = controller;
-        let source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.clone());
+        let _source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.clone());
         cards_to_move
             .into_iter()
             .filter(|&cid| {

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/change_zone_effect/search.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/change_zone_effect/search.rs
@@ -78,7 +78,7 @@ pub(super) fn resolve_single_search(
     }
 
     if !sa.ir.skip_cancel_prompt && !candidates.is_empty() {
-        let source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.as_str());
+        let _source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.as_str());
         ctx.agents[chooser.index()].snapshot_state(ctx.game, ctx.mana_pools);
         let _ = ctx.agents[chooser.index()].confirm_action(
             chooser,

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/choose_direction_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/choose_direction_effect.rs
@@ -11,7 +11,7 @@ use crate::agent::BinaryChoiceKind;
 fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
     let controller = sa.activating_player;
     let Some(source_id) = sa.source else { return };
-    let source_name = ctx.game.card(source_id).card_name.clone();
+    let _source_name = ctx.game.card(source_id).card_name.clone();
     let choose_left = ctx.agents[controller.index()].choose_binary(
         controller,
         "Choose direction",

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/choose_even_odd_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/choose_even_odd_effect.rs
@@ -11,7 +11,7 @@ use crate::ids::PlayerId;
 #[manabrew_engine_macros::spell_effect(ChooseEvenOddEffect)]
 fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
     let Some(source_id) = sa.source else { return };
-    let source_name = ctx.game.card(source_id).card_name.clone();
+    let _source_name = ctx.game.card(source_id).card_name.clone();
 
     let players: Vec<PlayerId> = if let Some(pid) = sa.target_chosen.target_player {
         vec![pid]

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/cost_payment.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/cost_payment.rs
@@ -808,7 +808,7 @@ pub(super) fn resolve_effect_with_unless_cost(
                     .next()
                 })
                 .unwrap_or(sa.activating_player);
-            let card_name = sa.source.map(|cid| ctx.game.card(cid).card_name.clone());
+            let _card_name = sa.source.map(|cid| ctx.game.card(cid).card_name.clone());
             let prompt = sa
                 .ir
                 .spell_description_text

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/counters_put_or_remove_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/counters_put_or_remove_effect.rs
@@ -14,7 +14,7 @@ use crate::parsing::keys;
 fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
     let Some(source_id) = sa.source else { return };
     let controller = sa.activating_player;
-    let source_name = ctx.game.card(source_id).card_name.clone();
+    let _source_name = ctx.game.card(source_id).card_name.clone();
 
     let amount = resolve_numeric_svar(ctx.game, sa, keys::COUNTER_NUM, 1);
     if amount <= 0 {

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/damage_all_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/damage_all_effect.rs
@@ -43,11 +43,11 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
 
     // Pass 1 — collect matching battlefield permanents
     let mut to_damage: Vec<CardId> = Vec::new();
-    if valid_cards_filter.is_some() {
+    if let Some(valid_cards_filter) = valid_cards_filter {
         for &pid in &player_ids {
             let zone_cards = ctx.game.cards_in_zone(ZoneType::Battlefield, pid).to_vec();
             for cid in zone_cards {
-                if damage_all_matches_valid_card(ctx, sa, valid_cards_filter.unwrap(), cid) {
+                if damage_all_matches_valid_card(ctx, sa, valid_cards_filter, cid) {
                     to_damage.push(cid);
                 }
             }

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/dig_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/dig_effect.rs
@@ -103,7 +103,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
     // Otherwise Optional$ True is modeled by allowing 0 selected cards in choose_dig.
     let may_be_skipped = sa.ir.prompt_to_skip_optional_ability;
     if optional && may_be_skipped && !valid.is_empty() {
-        let source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.clone());
+        let _source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.clone());
         let prompt = sa
             .ir
             .optional_ability_prompt

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/dig_multiple_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/dig_multiple_effect.rs
@@ -99,7 +99,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
     // Otherwise Optional$ True is modeled by allowing 0 selected cards in choose_dig.
     let may_be_skipped = sa.ir.prompt_to_skip_optional_ability;
     if optional && may_be_skipped && !valid.is_empty() {
-        let source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.clone());
+        let _source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.clone());
         let prompt = sa
             .ir
             .optional_ability_prompt

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/dig_until_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/dig_until_effect.rs
@@ -87,7 +87,6 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
                     ctx.game.card_mut(source_id).add_imprinted_card(cid);
                 }
             }
-        } else {
         }
     }
     let rest: Vec<_> = revealed

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/draw_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/draw_effect.rs
@@ -50,7 +50,7 @@ fn draw_for_player(
     let upto = sa.ir.upto;
     let optional = sa.ir.optional_present || sa.ir.optional_decider.is_some() || upto;
     if optional {
-        let source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.as_str());
+        let _source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.as_str());
         let accepted = ctx.agents[target.index()].confirm_action(
             target,
             None,

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/explore_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/explore_effect.rs
@@ -105,7 +105,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
             // harness DeterministicController uses a random boolean (pickBool).
             // Use confirm_action here to match that RNG-consuming path.
             let card_name = ctx.game.card(top_card).card_name.clone();
-            let explorer_name = ctx.game.card(explorer_id).card_name.clone();
+            let _explorer_name = ctx.game.card(explorer_id).card_name.clone();
             let msg = format!("Put {} into your graveyard?", card_name);
             let put_in_gy = ctx.agents[controller.index()].confirm_action(
                 controller,

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/flip_coin_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/flip_coin_effect.rs
@@ -42,7 +42,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
         }
     } else {
         // Call mode: player calls heads/tails
-        let card_name = ctx.game.card(source_id).card_name.clone();
+        let _card_name = ctx.game.card(source_id).card_name.clone();
         let called_heads = ctx.agents[controller.index()].choose_binary(
             controller,
             "Call the coin flip",

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/mana_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/mana_effect.rs
@@ -52,7 +52,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
     // `Optional$` — activator confirms before producing (Java ManaEffect
     // optional-prompt branch).
     if sa.ir.optional {
-        let card_name = ctx.game.card(source_id).card_name.clone();
+        let _card_name = ctx.game.card(source_id).card_name.clone();
         if !ctx.agents[player.index()].confirm_action(
             player,
             Some("ProduceMana"),
@@ -236,7 +236,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
         // Emit a summary `specify_mana_combo` callback so the parity trace
         // matches Java's harness logging pattern. The agent's pick here is
         // ignored; the per-unit `choose_color` results above are authoritative.
-        let card_name = ctx.game.card(source_id).card_name.clone();
+        let _card_name = ctx.game.card(source_id).card_name.clone();
         let _summary = ctx.agents[chooser.index()].specify_mana_combo(
             chooser,
             &per_unit,

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/phases_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/phases_effect.rs
@@ -26,28 +26,26 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
     // Defined$ DelayTriggerRememberedLKI / Remembered — phase the cards
     // remembered by the parent delayed trigger (e.g. Teferi's Veil's
     // "creature phases out at end of combat" queues the attacker's LKI).
-    match sa.defined_ref() {
-        Some(
-            DefinedRef::DelayTriggerRememberedLki
-            | DefinedRef::DelayTriggerRemembered
-            | DefinedRef::Remembered,
-        ) => {
-            let ids: Vec<crate::ids::CardId> = sa
-                .trigger_remembered
-                .iter()
-                .filter_map(|v| match v {
-                    AbilityValue::Card(cid) => Some(*cid),
-                    _ => None,
-                })
-                .collect();
-            for cid in ids {
-                if ctx.game.card(cid).zone == ZoneType::Battlefield {
-                    apply_phase(ctx, cid, phase_mode);
-                }
+    if let Some(
+        DefinedRef::DelayTriggerRememberedLki
+        | DefinedRef::DelayTriggerRemembered
+        | DefinedRef::Remembered,
+    ) = sa.defined_ref()
+    {
+        let ids: Vec<crate::ids::CardId> = sa
+            .trigger_remembered
+            .iter()
+            .filter_map(|v| match v {
+                AbilityValue::Card(cid) => Some(*cid),
+                _ => None,
+            })
+            .collect();
+        for cid in ids {
+            if ctx.game.card(cid).zone == ZoneType::Battlefield {
+                apply_phase(ctx, cid, phase_mode);
             }
-            return;
         }
-        _ => {}
+        return;
     }
 
     // Targeted: use the chosen target card.

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/play_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/play_effect.rs
@@ -180,7 +180,7 @@ fn resolve_target_cards(ctx: &EffectContext, sa: &SpellAbility) -> Vec<CardId> {
             return Vec::new();
         };
         let source = ctx.game.card(source_id);
-        let selector = crate::parsing::cached_compiled_selector(&valid);
+        let selector = crate::parsing::cached_compiled_selector(valid);
         let valid_sa = crate::parsing::raw_get(&sa.ability_text, crate::parsing::keys::VALID_SA);
         return ctx
             .game
@@ -193,10 +193,7 @@ fn resolve_target_cards(ctx: &EffectContext, sa: &SpellAbility) -> Vec<CardId> {
                 )
             })
             .filter(|card| {
-                if valid_sa
-                    .as_deref()
-                    .is_some_and(|v| v.eq_ignore_ascii_case("Spell"))
-                {
+                if valid_sa.is_some_and(|v| v.eq_ignore_ascii_case("Spell")) {
                     !card.is_land()
                 } else {
                     true

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/pump_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/pump_effect.rs
@@ -63,7 +63,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
 
     // `Optional$` — activator confirms before any pump applies (Java L283–L292).
     if sa.ir.optional_present {
-        let card_name = sa.source.map(|cid| ctx.game.card(cid).card_name.clone());
+        let _card_name = sa.source.map(|cid| ctx.game.card(cid).card_name.clone());
         let prompt = sa
             .ir
             .option_question

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/rearrange_top_of_library_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/rearrange_top_of_library_effect.rs
@@ -74,7 +74,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
 
     // Handle optional shuffle.
     if may_shuffle {
-        let source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.as_str());
+        let _source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.as_str());
         let wants_shuffle = ctx.agents[sa.activating_player.index()].confirm_action(
             sa.activating_player,
             None,

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/reveal_hand_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/reveal_hand_effect.rs
@@ -23,7 +23,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
         .unwrap_or(sa.activating_player);
 
     if sa.ir.optional {
-        let source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.as_str());
+        let _source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.as_str());
         let accepted = ctx.agents[target.index()].confirm_action(
             target,
             None,

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/roll_dice_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/roll_dice_effect.rs
@@ -592,7 +592,7 @@ pub fn roll_to_visit_attractions(
 
 fn apply_chosen_ignores(
     agents: &mut [Box<dyn crate::agent::PlayerAgent>],
-    card_name: &str,
+    _card_name: &str,
     natural_rolls: &mut Vec<i32>,
     ignore_chosen: &HashMap<PlayerId, i32>,
 ) -> (Vec<i32>, Vec<i32>) {
@@ -625,7 +625,7 @@ fn roll_action(
     ignore: i32,
     ignored_rolls: &mut Vec<i32>,
     dice_pt_exchanges: &mut HashSet<crate::ids::CardId>,
-    source: Option<crate::ids::CardId>,
+    _source: Option<crate::ids::CardId>,
 ) -> Vec<i32> {
     let mut event = ReplacementEvent::RollDice {
         player,
@@ -1226,7 +1226,7 @@ fn apply_keyword_roll_rerolls(
             }
         }
 
-        let reroll_card_name = ctx.game.card(card_id).card_name.clone();
+        let _reroll_card_name = ctx.game.card(card_id).card_name.clone();
         let rerolled = roll_action(
             ctx.game,
             ctx.rng,

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/sacrifice_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/sacrifice_effect.rs
@@ -345,7 +345,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
 
     for sacrificing_player in sacrificing_players {
         if optional {
-            let source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.as_str());
+            let _source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.as_str());
             let accepted = ctx.agents[sacrificing_player.index()].confirm_action(
                 sacrificing_player,
                 None,

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/scry_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/scry_effect.rs
@@ -39,7 +39,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
     };
 
     if sa.ir.optional {
-        let source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.as_str());
+        let _source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.as_str());
         let accepted = ctx.agents[target.index()].confirm_action(
             target,
             None,

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/shuffle_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/shuffle_effect.rs
@@ -20,7 +20,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
     let defined = sa.defined().unwrap_or("You");
     let players = resolve_defined_players(defined, sa.activating_player, ctx.game);
     let optional = sa.ir.optional;
-    let source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.clone());
+    let _source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.clone());
 
     for pid in players {
         if optional {

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/surveil_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/surveil_effect.rs
@@ -22,7 +22,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
         .unwrap_or(sa.activating_player);
 
     if sa.ir.optional {
-        let source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.as_str());
+        let _source_name = sa.source.map(|cid| ctx.game.card(cid).card_name.as_str());
         let accepted = ctx.agents[target.index()].confirm_action(
             target,
             None,

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/tap_or_untap_all_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/tap_or_untap_all_effect.rs
@@ -13,7 +13,7 @@ use crate::ids::{CardId, PlayerId};
 #[manabrew_engine_macros::spell_effect(TapOrUntapAllEffect)]
 fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
     let controller = sa.activating_player;
-    let source_name = sa
+    let _source_name = sa
         .source
         .map(|cid| ctx.game.card(cid).card_name.clone())
         .unwrap_or_else(|| "Ability".to_string());

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/tap_or_untap_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/tap_or_untap_effect.rs
@@ -14,7 +14,7 @@ use crate::ids::CardId;
 #[manabrew_engine_macros::spell_effect(TapOrUntapEffect)]
 fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
     let controller = sa.activating_player;
-    let source_name = sa
+    let _source_name = sa
         .source
         .map(|cid| ctx.game.card(cid).card_name.clone())
         .unwrap_or_else(|| "Ability".to_string());

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/time_travel_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/time_travel_effect.rs
@@ -17,7 +17,7 @@ use crate::parsing::keys;
 fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
     let controller = sa.activating_player;
     let Some(source_id) = sa.source else { return };
-    let source_name = ctx.game.card(source_id).card_name.clone();
+    let _source_name = ctx.game.card(source_id).card_name.clone();
 
     let amount = resolve_numeric_svar(ctx.game, sa, keys::AMOUNT, 1);
     if amount <= 0 {

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/untap_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/untap_effect.rs
@@ -86,9 +86,7 @@ fn choose_untap_type_targets(
     let candidates: Vec<CardId> = if scope_to_controller {
         ctx.game
             .cards_in_zone(ZoneType::Battlefield, controller)
-            .iter()
-            .copied()
-            .collect()
+            .to_vec()
     } else {
         ctx.game.cards_in_all_zones(ZoneType::Battlefield).collect()
     };

--- a/manabrew-rs/crates/manabrew-engine/src/cost/cost_adjustment.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/cost/cost_adjustment.rs
@@ -1115,7 +1115,7 @@ fn apply_convoke_or_improvise_reduction(
     if remaining_cost.cmc() <= 0 {
         return;
     }
-    let card_name = game.card(source).card_name.clone();
+    let _card_name = game.card(source).card_name.clone();
     agents[payer.index()].snapshot_state(game, mana_pools);
     let chosen = if artifacts && !creatures {
         agents[payer.index()].choose_improvise(payer, &untapped, &remaining_cost, Some(source))

--- a/manabrew-rs/crates/manabrew-engine/src/game_loop.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/game_loop.rs
@@ -535,7 +535,7 @@ impl GameLoop {
                 }
 
                 agents[takes_action.index()].snapshot_state(game, &self.mana_pools);
-                let card_name = game.card(source_id).card_name.clone();
+                let _card_name = game.card(source_id).card_name.clone();
                 let prompt = sa
                     .ir
                     .spell_description_text

--- a/manabrew-rs/crates/manabrew-engine/src/game_loop/cast_spell.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/game_loop/cast_spell.rs
@@ -866,7 +866,7 @@ impl GameLoop {
             let combined = mana_cost.add(&kicker_mc);
             let available_mana = mana::calculate_available_mana(self.pool(player), game, player);
             if available_mana.can_pay(&combined) {
-                let name = game.card(card_id).card_name.clone();
+                let _name = game.card(card_id).card_name.clone();
                 agents[player.index()].snapshot_state(game, &self.mana_pools);
                 agents[player.index()].choose_kicker(player, &kicker_cost_str, Some(card_id))
             } else {
@@ -892,7 +892,7 @@ impl GameLoop {
             let combined = mana_cost.add(&buyback_mc);
             let available_mana = mana::calculate_available_mana(self.pool(player), game, player);
             if available_mana.can_pay(&combined) {
-                let name = game.card(card_id).card_name.clone();
+                let _name = game.card(card_id).card_name.clone();
                 agents[player.index()].snapshot_state(game, &self.mana_pools);
                 agents[player.index()].choose_buyback(player, &buyback_cost_str, Some(card_id))
             } else {
@@ -931,7 +931,7 @@ impl GameLoop {
                 }
             }
             if max_kicks > 0 {
-                let name = game.card(card_id).card_name.clone();
+                let _name = game.card(card_id).card_name.clone();
                 agents[player.index()].snapshot_state(game, &self.mana_pools);
                 agents[player.index()].choose_multikicker(
                     player,
@@ -981,7 +981,7 @@ impl GameLoop {
                 }
             }
             if max_reps > 0 {
-                let name = game.card(card_id).card_name.clone();
+                let _name = game.card(card_id).card_name.clone();
                 agents[player.index()].snapshot_state(game, &self.mana_pools);
                 agents[player.index()].choose_replicate(
                     player,
@@ -1117,7 +1117,7 @@ impl GameLoop {
             let combined = mana_cost.add(&entwine_mc);
             let available_mana = mana::calculate_available_mana(self.pool(player), game, player);
             if available_mana.can_pay(&combined) {
-                let name = game.card(card_id).card_name.clone();
+                let _name = game.card(card_id).card_name.clone();
                 agents[player.index()].snapshot_state(game, &self.mana_pools);
                 agents[player.index()].choose_kicker(player, &entwine_cost_str, Some(card_id))
             } else {

--- a/manabrew-rs/crates/manabrew-engine/src/game_loop/cost_payment.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/game_loop/cost_payment.rs
@@ -1106,7 +1106,7 @@ impl GameLoop {
                 CostPart::FlipCoin(amount) => {
                     let resolved_amount = amount.resolve(game, card_id, player);
                     for _ in 0..resolved_amount {
-                        let source_name = game.card(card_id).card_name.clone();
+                        let _source_name = game.card(card_id).card_name.clone();
                         let called_heads = agents[player.index()].choose_binary(
                             player,
                             "Call the coin flip",
@@ -1830,7 +1830,7 @@ impl GameLoop {
                 CostPart::FlipCoin(amount) => {
                     let resolved_amount = amount.resolve(game, card_id, player);
                     for _ in 0..resolved_amount {
-                        let source_name = game.card(card_id).card_name.clone();
+                        let _source_name = game.card(card_id).card_name.clone();
                         let called_heads = agents[player.index()].choose_binary(
                             player,
                             "Call the coin flip",
@@ -2198,7 +2198,7 @@ impl GameLoop {
 
         if !untapped.is_empty() && remaining > 0 {
             // Reuse the convoke agent method — waterbend is convoke+improvise combined
-            let card_name = game.card(card_id).card_name.clone();
+            let _card_name = game.card(card_id).card_name.clone();
             let generic_cost = forge_foundation::ManaCost::generic(remaining);
             agents[player.index()].snapshot_state(game, &self.mana_pools);
             let to_tap = agents[player.index()].choose_convoke(
@@ -3270,7 +3270,7 @@ impl GameLoop {
         type_filter: &str,
         amount: i32,
         min_total_power: Option<i32>,
-        mut sa: Option<&mut SpellAbility>,
+        sa: Option<&mut SpellAbility>,
     ) {
         let mut tapped_cards = Vec::new();
         if let Some(power_threshold) = min_total_power {
@@ -3366,7 +3366,7 @@ impl GameLoop {
                 );
             }
         }
-        if let Some(sa) = sa.as_deref_mut() {
+        if let Some(sa) = sa {
             for cid in tapped_cards {
                 let value = cid.to_string();
                 sa.add_cost_to_hash_list(crate::cost::cost_tap_type::HASH_LKI, &value);

--- a/manabrew-rs/crates/manabrew-engine/src/game_loop/mana_payment.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/game_loop/mana_payment.rs
@@ -580,7 +580,7 @@ impl GameLoop {
                     this.resolve_single_effect(game, agents, &pt.entry.spell_ability, None);
                 }
             },
-            |_game, _mana_pools, player| unsafe { (&mut *self_ptr).undoable_mana_sources(player) },
+            |_game, _mana_pools, player| unsafe { (&*self_ptr).undoable_mana_sources(player) },
             |game, mana_pools, player, card_id| unsafe {
                 (&mut *self_ptr)
                     .begin_mana_undo_action_with_mana_slice(game, mana_pools, player, card_id)

--- a/manabrew-rs/crates/manabrew-engine/src/game_loop/phase_handler.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/game_loop/phase_handler.rs
@@ -368,7 +368,7 @@ impl GameLoop {
                     "You may choose not to untap CARDNAME during your untap step.";
                 let should_untap = if game.card(cid).has_keyword(optional_keyword) {
                     let question = format!("Untap {}?", game.card(cid).card_name);
-                    let source_name = game.card(cid).card_name.clone();
+                    let _source_name = game.card(cid).card_name.clone();
                     agents[active.index()].choose_binary(
                         active,
                         &question,

--- a/manabrew-rs/crates/manabrew-engine/src/spellability/spell_ability_restriction.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/spellability/spell_ability_restriction.rs
@@ -292,9 +292,7 @@ impl SpellAbilityRestriction {
             )
         } else {
             game.cards_in_zone(self.variables.present_zone(), player)
-                .iter()
-                .copied()
-                .collect()
+                .to_vec()
         };
         let count = cards
             .into_iter()

--- a/manabrew-rs/crates/manabrew-engine/src/staticability/layer.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/staticability/layer.rs
@@ -230,8 +230,7 @@ pub fn apply_continuous_effects(game: &mut GameState) {
         player.unlimited_hand_size = false;
     }
     let player_ids: Vec<PlayerId> = game.player_order.clone();
-    for player_idx in 0..player_ids.len() {
-        let pid = player_ids[player_idx];
+    for &pid in &player_ids {
         let battlefield_cards: Vec<CardId> =
             game.cards_in_zone(ZoneType::Battlefield, pid).to_vec();
         for source_id in battlefield_cards {

--- a/manabrew-rs/crates/manabrew-engine/src/svar/mod.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/svar/mod.rs
@@ -505,13 +505,7 @@ fn resolve_discarded_valid_svar(
     }
     for &rem_id in remembered {
         let rem_card = game.card(rem_id);
-        let matches = if filter.contains("nonLand") {
-            !rem_card.is_land()
-        } else if filter == "Card" {
-            true
-        } else {
-            true
-        };
+        let matches = !filter.contains("nonLand") || !rem_card.is_land();
         if matches {
             return times;
         }

--- a/manabrew-rs/crates/manabrew-server/src/lobby.rs
+++ b/manabrew-rs/crates/manabrew-server/src/lobby.rs
@@ -17,6 +17,7 @@ const MIN_RECONNECT_TIMEOUT_S: u32 = 10;
 // Must stay below manabrew_game_runtime 's 120s relay response_timeout
 const MAX_RECONNECT_TIMEOUT_S: u32 = 90;
 
+#[allow(clippy::too_many_arguments)]
 pub fn create_room_sync(
     state: &Arc<ServerState>,
     player_id: &str,

--- a/manabrew-rs/crates/manabrew-server/src/room.rs
+++ b/manabrew-rs/crates/manabrew-server/src/room.rs
@@ -51,6 +51,7 @@ pub struct Room {
 }
 
 impl Room {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         room_id: String,
         room_name: String,

--- a/manabrew-rs/crates/parity-debugger/src/main.rs
+++ b/manabrew-rs/crates/parity-debugger/src/main.rs
@@ -1,3 +1,7 @@
+#![allow(dead_code)]
+#![allow(clippy::large_enum_variant)]
+#![allow(clippy::too_many_arguments)]
+
 use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
 use std::env;
@@ -417,8 +421,8 @@ impl App {
             TraceMode::Java => trace.java.as_ref(),
             _ => trace
                 .pane(self.active_trace_pane)
-                .or_else(|| trace.rust.as_ref())
-                .or_else(|| trace.java.as_ref()),
+                .or(trace.rust.as_ref())
+                .or(trace.java.as_ref()),
         };
         let Some(pane) = pane else {
             return "frame #0 / 0".to_string();
@@ -438,8 +442,8 @@ impl App {
             TraceMode::Java => trace.java.as_ref()?,
             _ => trace
                 .pane(self.active_trace_pane)
-                .or_else(|| trace.rust.as_ref())
-                .or_else(|| trace.java.as_ref())?,
+                .or(trace.rust.as_ref())
+                .or(trace.java.as_ref())?,
         };
         let snapshot = pane.snapshots.get(pane.selected_snapshot)?;
         Some(format!(
@@ -1179,8 +1183,8 @@ impl App {
             TraceMode::Java => trace.java.as_ref(),
             _ => trace
                 .pane(self.active_trace_pane)
-                .or_else(|| trace.rust.as_ref())
-                .or_else(|| trace.java.as_ref()),
+                .or(trace.rust.as_ref())
+                .or(trace.java.as_ref()),
         };
         let Some(pane) = pane else {
             return (0, 0);
@@ -1205,8 +1209,8 @@ impl App {
             TraceMode::Java => trace.java.as_ref(),
             _ => trace
                 .pane(self.active_trace_pane)
-                .or_else(|| trace.rust.as_ref())
-                .or_else(|| trace.java.as_ref()),
+                .or(trace.rust.as_ref())
+                .or(trace.java.as_ref()),
         };
         let Some(pane) = pane else {
             return ("Trace idle".to_string(), "no active pane".to_string());
@@ -4225,7 +4229,7 @@ fn render_timeline_rows(
     let needle = search_query.trim().to_ascii_lowercase();
     let selected_row = selected_phase_row_index(trace, &rows);
     for (idx, (key, snapshot_index)) in rows.iter().enumerate() {
-        let snap = &trace.snapshots[*snapshot_index];
+        let _snap = &trace.snapshots[*snapshot_index];
         let phase_label = short_phase_label(&key.phase);
         let divergence = divergence_for_phase(comparison, key);
         let searchable = format!(

--- a/manabrew-rs/crates/parity-debugger/src/script_view.rs
+++ b/manabrew-rs/crates/parity-debugger/src/script_view.rs
@@ -8,8 +8,8 @@
 use eframe::egui;
 use forge_card_script::{
     ParamEntry, ParsedCardScript, ScriptAbility, ScriptAbilityRecord, ScriptDiagnostic,
-    ScriptDiagnosticKind, ScriptLineKind, ScriptParamRecord, ScriptSVar, ScriptSVarValue,
-    SemanticAmount, SemanticParamValue, SemanticParamValueKind,
+    ScriptLineKind, ScriptParamRecord, ScriptSVar, ScriptSVarValue, SemanticAmount,
+    SemanticParamValue, SemanticParamValueKind,
 };
 
 use crate::ts_view::{tree_sitter_ast_nodes, AstNodeModel};
@@ -263,6 +263,7 @@ fn kind_label(kind: SemanticParamValueKind) -> &'static str {
     match kind {
         SemanticParamValueKind::AbilityRecord => "AbilityRecord",
         SemanticParamValueKind::Symbol => "Symbol",
+        SemanticParamValueKind::ProducedMana => "ProducedMana",
         SemanticParamValueKind::Boolean => "Bool",
         SemanticParamValueKind::Integer => "Int",
         SemanticParamValueKind::Amount => "Amount",
@@ -396,7 +397,7 @@ pub(crate) fn render_ast_param_pill(
                 ui.colored_label(color, egui::RichText::new(key).size(10.0).strong());
                 ui.colored_label(
                     theme::FG_1,
-                    egui::RichText::new(shorten_list(&value, 28)).size(10.0),
+                    egui::RichText::new(shorten_list(value, 28)).size(10.0),
                 );
             });
         });
@@ -448,6 +449,9 @@ pub(crate) fn render_svar(ui: &mut egui::Ui, line_no: usize, svar: &ScriptSVar<'
             }
             ScriptSVarValue::Params(rec) => {
                 render_params(ui, rec.params.entries());
+            }
+            ScriptSVarValue::NumericExpression(_) => {
+                ui.monospace(svar.value);
             }
             ScriptSVarValue::Raw(raw) => {
                 ui.monospace(*raw);

--- a/manabrew-rs/crates/parity-debugger/src/worker.rs
+++ b/manabrew-rs/crates/parity-debugger/src/worker.rs
@@ -97,6 +97,7 @@ pub(crate) fn spawn() -> std::io::Result<TraceWorkerHandle> {
     })
 }
 
+#[allow(unused_assignments)]
 fn worker_loop(command_rx: Receiver<TraceWorkerCommand>, event_tx: Sender<TraceWorkerEvent>) {
     let mut loaded_data: Option<LoadedData> = None;
     let mut java_server: Option<JavaServer> = None;

--- a/manabrew-rs/crates/parity/src/infra/ci_client.rs
+++ b/manabrew-rs/crates/parity/src/infra/ci_client.rs
@@ -24,25 +24,25 @@ pub fn run(args: &[String]) {
     }
 
     let command = &args[1];
-    let server = get_arg(&args, "--server").unwrap_or_else(|| "http://localhost:8080".to_string());
+    let server = get_arg(args, "--server").unwrap_or_else(|| "http://localhost:8080".to_string());
     let (host, port) = parse_host_port(&server);
 
     match command.as_str() {
         "health" => cmd_health(&host, port),
         "submit" => {
-            let file = get_arg(&args, "--file").unwrap_or_else(|| {
+            let file = get_arg(args, "--file").unwrap_or_else(|| {
                 eprintln!("--file is required for submit");
                 std::process::exit(1);
             });
             cmd_submit(&host, port, &file);
         }
         "poll" => {
-            let batch_id = get_arg(&args, "--batch-id").unwrap_or_else(|| {
+            let batch_id = get_arg(args, "--batch-id").unwrap_or_else(|| {
                 eprintln!("--batch-id is required for poll");
                 std::process::exit(1);
             });
-            let pr_comment = get_arg(&args, "--pr").filter(|p| p != "0");
-            let repo = get_arg(&args, "--repo");
+            let pr_comment = get_arg(args, "--pr").filter(|p| p != "0");
+            let repo = get_arg(args, "--repo");
             cmd_poll(
                 &host,
                 port,

--- a/manabrew-rs/crates/parity/src/main.rs
+++ b/manabrew-rs/crates/parity/src/main.rs
@@ -394,6 +394,7 @@ fn load_data_or_exit(cli: &Cli) -> runner::LoadedData {
 }
 
 /// Resolve `--issue-threshold`: explicit CLI value > `ISSUE_THRESHOLD` env > default.
+#[allow(dead_code)]
 fn resolve_issue_threshold(cli_val: i64) -> i64 {
     if cli_val != 5 {
         return cli_val;
@@ -406,6 +407,7 @@ fn resolve_issue_threshold(cli_val: i64) -> i64 {
 }
 
 /// Resolve `--github-repo`: explicit CLI value > `GITHUB_REPO` env > unset.
+#[allow(dead_code)]
 fn resolve_github_repo(cli_val: Option<String>) -> Option<String> {
     cli_val.or_else(|| std::env::var("GITHUB_REPO").ok().filter(|s| !s.is_empty()))
 }

--- a/manabrew-rs/crates/parity/src/runtime.rs
+++ b/manabrew-rs/crates/parity/src/runtime.rs
@@ -23,6 +23,7 @@ pub const PARITY_THREAD_STACK_SIZE: usize = 64 * 1024 * 1024;
 /// on the current thread so callers can pass `&mut JavaServer` without extra
 /// locking. CLI and debugger side-by-side runs should use this helper instead
 /// of hand-rolling their own thread shape.
+#[allow(clippy::type_complexity)]
 pub fn run_parallel<RustFn, JavaFn, RustOut, JavaOut>(
     rust_thread_name: &str,
     rust_fn: RustFn,
@@ -492,6 +493,7 @@ fn compare_results(
     }
 }
 
+#[allow(clippy::result_large_err)]
 fn compare_results_with_java_data(
     config: &RunConfig,
     rust_result: Result<GameTrace, String>,

--- a/manabrew-rs/crates/self-hosted-node/src/engine_backend/java_backend.rs
+++ b/manabrew-rs/crates/self-hosted-node/src/engine_backend/java_backend.rs
@@ -1051,6 +1051,7 @@ impl JavaRuntimeConfig {
 }
 
 #[cfg(forge_backend)]
+#[allow(clippy::too_many_arguments)]
 pub fn run_hosted_engine_game(
     game_id: String,
     player_names: Vec<String>,
@@ -1084,6 +1085,7 @@ pub fn run_hosted_engine_game(
 }
 
 #[cfg(not(forge_backend))]
+#[allow(clippy::too_many_arguments)]
 pub fn run_hosted_engine_game(
     _game_id: String,
     _player_names: Vec<String>,

--- a/manabrew-rs/crates/self-hosted-node/src/engine_backend/rust_backend.rs
+++ b/manabrew-rs/crates/self-hosted-node/src/engine_backend/rust_backend.rs
@@ -25,6 +25,7 @@ use tracing::{info, warn};
 use super::HostedGameOver;
 use crate::config::workspace_root;
 
+#[allow(clippy::too_many_arguments)]
 pub fn run_hosted_engine_game(
     game_id: String,
     player_names: Vec<String>,

--- a/manabrew-rs/crates/self-hosted-node/src/host.rs
+++ b/manabrew-rs/crates/self-hosted-node/src/host.rs
@@ -1888,9 +1888,9 @@ fn spawn_remote_prompt_forwarder(
             let Ok(session) = engine_session.lock() else {
                 break;
             };
-            if !session
+            if session
                 .as_ref()
-                .is_some_and(|session| session.game_id() == game_id)
+                .is_none_or(|session| session.game_id() != game_id)
             {
                 break;
             }
@@ -1973,9 +1973,9 @@ fn spawn_game_over_forwarder(
             let Ok(session) = session_handle.lock() else {
                 return;
             };
-            if !session
+            if session
                 .as_ref()
-                .is_some_and(|session| session.game_id() == game_id)
+                .is_none_or(|session| session.game_id() != game_id)
             {
                 warn!(
                     game_id,

--- a/manabrew-rs/crates/wasm/src/limited_api.rs
+++ b/manabrew-rs/crates/wasm/src/limited_api.rs
@@ -891,12 +891,7 @@ fn template_for_pool(pool: &[PaperCard], variant: Option<&str>) -> SealedTemplat
 }
 
 fn drain_winston_ai(draft: &mut WinstonDraft) {
-    loop {
-        match draft.tick() {
-            WinstonOutcome::Picked { .. } => continue,
-            WinstonOutcome::AwaitingHuman | WinstonOutcome::Complete => break,
-        }
-    }
+    while let WinstonOutcome::Picked { .. } = draft.tick() {}
 }
 
 #[wasm_bindgen]

--- a/src-tauri/src/limited_manager.rs
+++ b/src-tauri/src/limited_manager.rs
@@ -309,12 +309,7 @@ impl LimitedManager {
 
     fn drain_winston_ai(draft: &mut WinstonDraft) {
         use forge_limited::WinstonOutcome;
-        loop {
-            match draft.tick() {
-                WinstonOutcome::Picked { .. } => continue,
-                WinstonOutcome::AwaitingHuman | WinstonOutcome::Complete => break,
-            }
-        }
+        while let WinstonOutcome::Picked { .. } = draft.tick() {}
     }
 
     pub fn start_gauntlet_from_sealed(


### PR DESCRIPTION
## Summary

- fix Clippy warnings across the engine, limited, server, parity, debugger, WASM, and Tauri crates
- add missing parity-debugger rendering for produced mana and numeric SVar expressions
- run the full `yarn lint:all` gate from the pre-commit hook after staged-file formatting
- preserve parity-oriented API shapes with narrowly scoped lint allowances

## Why

The workspace lint gate failed with warnings denied, masking additional diagnostics in crates compiled later in the workspace. This restores a clean lint baseline and prevents future commits from landing unless the complete frontend, TypeScript, formatting, and Rust lint gate passes.

## Test plan

- committed through the updated pre-commit hook, exercising `lint-staged` and `yarn lint:all`
- `yarn lint:all` with the documented Tauri dev resource overlay
- `cargo clippy --workspace --lib --bins --exclude manabrew -- -D warnings`
- Tauri-only Clippy with the dev resource overlay
- `git diff --check`