### PR TITLE
fix(xtask): cap app version bumps at minor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,10 @@ PR, or manual bump step. On every merge to `main`, CI (`release.yml`) runs
    crates bump 0.x → 0.x+1, cargo's incompatibility boundary), `feat` →
    minor, `fix`/`perf`/`refactor`/`revert` and unconventional messages →
    patch, `docs`/`style`/`chore`/`test`/`build`/`ci` → no bump. Crates that
-   depend on a released crate get at least a patch.
+   depend on a released crate get at least a patch. The desktop app (the
+   plain `vX.Y.Z` tags) is the exception: commits bump it at most minor.
+   Nothing depends on the app's API, so an app major is a product decision.
+   To cut one, hand-set the version.
 2. Commits `chore(release): …` straight to `main` with the new versions
    (Cargo.tomls, `package.json`/`tauri.conf.json` mirrors, `Cargo.lock`,
    `CHANGELOG.md`, `ops/manifest.json`).
@@ -156,8 +159,9 @@ What this means for your PR:
 
 - **The squash-merge title is the commit that drives versioning** — write it
   as a proper conventional commit. A breaking change bumps major on _every_
-  crate the PR touches; if that's too broad, split the PR. For per-commit
-  granularity, use a merge commit instead of squashing.
+  crate the PR touches (the app caps at minor); if that's too broad, split
+  the PR. For per-commit granularity, use a merge commit instead of
+  squashing.
 - The **Release plan** check on the PR shows exactly what would be released
   on merge.
 - To force a specific version (e.g. cutting a milestone), hand-set it in the

--- a/xtask/src/plan.rs
+++ b/xtask/src/plan.rs
@@ -29,7 +29,8 @@ impl fmt::Display for Level {
 
 /// Level implied by one conventional commit. The level applies to EVERY crate
 /// the commit touches (team decision: a breaking PR majors everything it
-/// touches; keep blast radius down by splitting PRs).
+/// touches; keep blast radius down by splitting PRs). Exception: the app
+/// caps at minor in `compute` — its version is a product line, not an API.
 pub fn commit_level(typ: Option<&str>, breaking: bool) -> Level {
     if breaking {
         return Level::Major;
@@ -124,7 +125,12 @@ pub fn compute(ws: &Workspace, root: &Path) -> Result<Vec<Entry>> {
                 .with_context(|| format!("planning {} (untagged fallback)", pkg.name))?;
             log.tagged_version = None;
         }
-        let level = log_level(&log);
+        let mut level = log_level(&log);
+        if is_app {
+            // No API depends on the app: majors are a product decision, made
+            // by hand-bumping Cargo.toml, never implied by a breaking commit.
+            level = level.min(Level::Minor);
+        }
         let sample = log
             .commits
             .iter()


### PR DESCRIPTION
## Summary

- `cargo xtask plan` now caps the app bump at minor. A breaking commit no longer majors the app.
- Crate bumps do not change. A breaking commit still majors every crate it touches.
- To release an app major, hand-set the version in `Cargo.toml`. The release run already honors hand bumps.

## Why

#604 is a breaking protocol change that also touches `src/`. If it merges first, its squash commit moves the app from 3.3.0 to 4.0.0. Nothing depends on the app's API. An app major is a product decision, so it needs a hand bump.

The early deploy gate does not change. It compares only `manabrew-protocol`, `manabrew-server` and `manabrew-hub`, and a breaking commit still majors those.

Merge this before #604.

## Test plan

- `cargo test -p xtask`: 11 passed
- `cargo clippy -p xtask --all-targets` and `cargo fmt --check`: clean
- `cargo xtask plan` runs end to end against the current tree
