### PR TITLE
fix(deploy): stop compose bouncing ingress on web rollouts

### DIFF
--- a/compose.production.yml
+++ b/compose.production.yml
@@ -1,9 +1,11 @@
 services:
   # Edge proxy: owns 80/443 + TLS for every host (ops/Caddyfile) and never
-  # runs app code, so app rollouts leave it up — recreating the container
-  # that holds 80/443 severs every live relay websocket. Deploys are listed
-  # `up`s that never recreate it (stock image, no tag interpolation); config
-  # changes land via `caddy reload`.
+  # runs app code, so app rollouts leave it up — stopping the container
+  # that holds 80/443 severs every live relay websocket. Deploys create it
+  # with a dedicated `up --no-recreate` and otherwise never list it; config
+  # changes land via `caddy reload`. No depends_on: compose restarts a
+  # dependent whenever its dependency is recreated, which is exactly the
+  # bounce this container must never take.
   ingress:
     image: caddy:2.10-alpine
     restart: unless-stopped
@@ -20,10 +22,6 @@ services:
       PUSHGATEWAY_PASSWORD_HASH:
       # Bcrypt hash for the api. /admin/* ingress (same single-quote caveat).
       HUB_ADMIN_PASSWORD_HASH:
-    # Ordering only, and only for the migration deploy: the old web container
-    # must release 80/443 before ingress can bind them.
-    depends_on:
-      - manabrew
 
   manabrew:
     # Pre-built in CI (docker-images.yml) and pulled here — the web image is a

--- a/xtask/src/deploy.rs
+++ b/xtask/src/deploy.rs
@@ -569,11 +569,22 @@ fn deploy(root: &Path, opts: &Opts) -> Result<()> {
     }
     pull_images(root, opts, &images)?;
 
-    // ingress is created on first deploy and left alone after: its compose
-    // config never interpolates the tag, so a listed `up` without
-    // --force-recreate is a no-op — recreating it would sever every live
-    // relay websocket.
-    let mut services = vec!["ingress", "manabrew"];
+    // ingress is created on first deploy and never touched again — bouncing
+    // the container that holds 80/443 severs every live relay websocket, and
+    // compose restarts a listed service when a dependency it shares the `up`
+    // with is recreated (that took prod down at v3.6.0). So it gets its own
+    // create-if-missing `up` and stays out of the rollout list; even a
+    // config-hash change waits for a deliberate manual recreate.
+    ssh_streamed(
+        root,
+        &opts.host,
+        &compose(
+            &opts.path,
+            &opts.tag,
+            "up -d --no-deps --no-recreate ingress",
+        ),
+    )?;
+    let mut services = vec!["manabrew"];
     let mut relay_note = String::new();
     if !web_only {
         services.push("manabrew-hub");


### PR DESCRIPTION
## Summary

- drop the migration-only `depends_on: [manabrew]` from the ingress service
- take `ingress` out of the rollout `up` list; a dedicated `up -d --no-deps --no-recreate ingress` creates it on first deploy and never touches it again

## Why

`docker compose up` restarts a listed service when a dependency in the same `up` is recreated. `--no-deps` does not prevent this when both are listed. So every web recreate bounced ingress, and every deploy since the split dropped all relay websockets. #599 never worked in production.

The v3.6.0 deploy made it visible: the relay binary was unchanged and correctly left running, yet every client dropped at 20:21:23 UTC. Box evidence: caddy got a clean SIGTERM (exit 0, RestartCount 0) two seconds before the new web container started, and the post-rollout `caddy reload` reported "config is unchanged". The container was created on Aug 3 and only restarted, so compose's dependency-restart is the only actor that fits.

The `depends_on` existed to make the old web container release 80/443 during the migration deploy. That migration is done; ingress owns the ports.

With ingress unlisted, a future edit to its compose definition no longer risks a recreate on deploy. Recreating it is now always a deliberate manual step.

## Test plan

- `cargo clippy -p xtask` clean (workspace lint drift on main is pre-existing and untouched)
- next release: verify `manabrew-ingress-1` StartedAt is unchanged across the deploy and live websockets survive a web rollout
