### PR TITLE
chore(lint): fix rust clippy drift

### DIFF
--- a/manabrew-rs/crates/forge-carddb/src/parser.rs
+++ b/manabrew-rs/crates/forge-carddb/src/parser.rs
@@ -276,7 +276,7 @@ impl CardScriptParser {
         if self.faces[idx].is_none() {
             // This shouldn't happen in well-formed scripts (Name comes first),
             // but handle gracefully
-            self.faces[idx] = Some(CardFace::new(format!("__unnamed_face_{}", idx)));
+            self.faces[idx] = Some(CardFace::new(format!("__unnamed_face_{idx}")));
         }
     }
 
@@ -293,7 +293,7 @@ impl CardScriptParser {
         let specialize_names = ["W", "U", "B", "R", "G"];
         for (i, name) in specialize_names.iter().enumerate() {
             if let Some(face) = self.faces[i + 2].take() {
-                specialized.insert(format!("Specialize{}", name), face);
+                specialized.insert(format!("Specialize{name}"), face);
             }
         }
 

--- a/manabrew-rs/crates/forge-foundation/src/mana.rs
+++ b/manabrew-rs/crates/forge-foundation/src/mana.rs
@@ -740,7 +740,7 @@ impl ManaCost {
 
 impl std::fmt::Debug for ManaCost {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ManaCost({})", self)
+        write!(f, "ManaCost({self})")
     }
 }
 
@@ -752,7 +752,7 @@ impl std::fmt::Display for ManaCost {
         // X shards first
         for s in &self.shards {
             if *s == ManaCostShard::X {
-                write!(f, "{}", s)?;
+                write!(f, "{s}")?;
             }
         }
         if self.generic_cost > 0 || (self.generic_cost == 0 && self.shards.is_empty()) {
@@ -760,7 +760,7 @@ impl std::fmt::Display for ManaCost {
         }
         for s in &self.shards {
             if *s != ManaCostShard::X {
-                write!(f, "{}", s)?;
+                write!(f, "{s}")?;
             }
         }
         if self.generic_cost < 0 {

--- a/manabrew-rs/crates/forge-foundation/src/phase.rs
+++ b/manabrew-rs/crates/forge-foundation/src/phase.rs
@@ -110,7 +110,7 @@ impl PhaseType {
         }
         for &phase in &Self::TURN_ORDER {
             if phase.script_name().eq_ignore_ascii_case(s)
-                || format!("{:?}", phase).eq_ignore_ascii_case(s)
+                || format!("{phase:?}").eq_ignore_ascii_case(s)
             {
                 return Some(phase);
             }

--- a/manabrew-rs/crates/forge-foundation/src/zone.rs
+++ b/manabrew-rs/crates/forge-foundation/src/zone.rs
@@ -103,7 +103,7 @@ impl ZoneType {
             _ => {
                 // Case-insensitive fallback
                 for zt in Self::ALL.iter() {
-                    if format!("{:?}", zt).eq_ignore_ascii_case(s) {
+                    if format!("{zt:?}").eq_ignore_ascii_case(s) {
                         return Some(*zt);
                     }
                 }
@@ -137,7 +137,7 @@ impl ZoneType {
 
 impl std::fmt::Display for ZoneType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/manabrew-rs/crates/manabot/src/native.rs
+++ b/manabrew-rs/crates/manabot/src/native.rs
@@ -60,7 +60,7 @@ async fn run_bot_session(
 ) -> Result<SessionEnd, String> {
     let (socket, _) = connect_async(relay_url)
         .await
-        .map_err(|error| format!("Failed to connect bot to {}: {}", relay_url, error))?;
+        .map_err(|error| format!("Failed to connect bot to {relay_url}: {error}"))?;
     let (mut sink, mut stream) = socket.split();
 
     let mut state = BotState::new(config);

--- a/manabrew-rs/crates/manabot/src/state.rs
+++ b/manabrew-rs/crates/manabot/src/state.rs
@@ -116,7 +116,7 @@ impl BotState {
                         }]
                     }
                 } else {
-                    self.fail(format!("authentication failed: {:?}", error))
+                    self.fail(format!("authentication failed: {error:?}"))
                 }
             }
             (Phase::AwaitingRoomJoin, ServerMessage::RoomUpdate { room })
@@ -143,7 +143,7 @@ impl BotState {
                 }
             }
             (Phase::AwaitingRoomJoin, ServerMessage::Error { message, .. }) => {
-                self.fail(format!("room join failed: {}", message))
+                self.fail(format!("room join failed: {message}"))
             }
             (Phase::AwaitingGameStart, ServerMessage::GameStarted { player_order, .. }) => {
                 match player_order

--- a/manabrew-rs/crates/manabrew-agent-interface/src/agent_impl/mod.rs
+++ b/manabrew-rs/crates/manabrew-agent-interface/src/agent_impl/mod.rs
@@ -1397,8 +1397,7 @@ impl<R: Responder> PlayerAgent for PromptAgent<R> {
                     .unwrap_or_else(|| format!("Player {}", active_player.0));
                 self.responder.send_log(GameLogEntryDto::from_event(
                     manabrew_engine::agent::GameLogEvent::rule(format!(
-                        "TURN {} — {}",
-                        turn_number, active_player_name
+                        "TURN {turn_number} — {active_player_name}"
                     ))
                     .with_player(active_player),
                 ));

--- a/manabrew-rs/crates/manabrew-agent-interface/src/ids_codec.rs
+++ b/manabrew-rs/crates/manabrew-agent-interface/src/ids_codec.rs
@@ -1,7 +1,7 @@
 use manabrew_engine::ids::{CardId, PlayerId};
 
 pub fn player_slot(index: usize) -> String {
-    format!("player-{}", index)
+    format!("player-{index}")
 }
 
 pub fn player_id_str(pid: PlayerId) -> String {
@@ -13,7 +13,7 @@ pub fn card_id_str(cid: CardId) -> String {
 }
 
 pub fn stack_id_str(id: u32) -> String {
-    format!("stack-{}", id)
+    format!("stack-{id}")
 }
 
 pub fn parse_player_slot(slot: &str) -> Option<usize> {

--- a/manabrew-rs/crates/manabrew-engine/src/ability/ability_factory.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/ability_factory.rs
@@ -246,8 +246,7 @@ pub fn build_spell_ability_from_host_card(
     let parsed = ParsedParams::parse(ability_text);
     let record_type = AbilityRecordType::from_parsed(&parsed).unwrap_or_else(|| {
         panic!(
-            "AbilityFactory::build_spell_ability requires AB$/SP$/ST$/DB$ ability text; got: {:?}",
-            ability_text
+            "AbilityFactory::build_spell_ability requires AB$/SP$/ST$/DB$ ability text; got: {ability_text:?}"
         )
     });
     let params = Params::from_parsed(&parsed);

--- a/manabrew-rs/crates/manabrew-engine/src/ability/ability_key.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/ability_key.rs
@@ -301,6 +301,6 @@ pub fn add_card_zone_table_params(
 
     trigger_params.insert(
         "ChangeZoneTable".to_string(),
-        format!("{:?}", change_zone_table),
+        format!("{change_zone_table:?}"),
     );
 }

--- a/manabrew-rs/crates/manabrew-engine/src/ability/ability_utils.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/ability_utils.rs
@@ -1467,7 +1467,7 @@ pub fn x_count(game: &GameState, card_id: CardId, expr: &str, sa: &SpellAbility)
     let full_expr = if expr.starts_with("Count$") || expr.starts_with("Number$") {
         expr.to_string()
     } else {
-        format!("Count${}", expr)
+        format!("Count${expr}")
     };
     crate::svar::resolve_count_svar_for_sa(&full_expr, game, card_id, controller, sa)
 }
@@ -2252,7 +2252,7 @@ pub fn add_splice_effect(sa: &mut SpellAbility, game: &GameState, splice_card_id
     let name = splice_card.card_name.clone();
     if !sa.description.is_empty() {
         sa.description
-            .push_str(&format!(" (Splicing {} onto it)", name));
+            .push_str(&format!(" (Splicing {name} onto it)"));
     }
 }
 

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/add_turn_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/add_turn_effect.rs
@@ -61,7 +61,7 @@ pub fn create_cant_set_schemes_in_motion_effect(ctx: &mut EffectContext, sa: &Sp
     // Create a minimal effect card (mirrors Java's createEffect helper)
     let effect_card = crate::card::Card::new(
         crate::ids::CardId(0),
-        format!("{}'s Effect", card_name),
+        format!("{card_name}'s Effect"),
         controller,
         CardTypeLine::default(),
         ManaCost::no_cost(),

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/airbend_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/airbend_effect.rs
@@ -106,7 +106,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
         // it's still exiled. Mirrors Java `AirbendEffect.resolve`.
         let card_name_for_effect = ctx.game.card(card_id).card_name.clone();
         let host_name = host_image.clone().unwrap_or_else(|| "Airbend".to_string());
-        let effect_name = format!("{} ({})", host_name, card_name_for_effect);
+        let effect_name = format!("{host_name} ({card_name_for_effect})");
 
         let mut effect = Card::new(
             CardId(0),

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/amass_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/amass_effect.rs
@@ -121,8 +121,8 @@ fn create_army_token(
     token.set_is_token(true);
     token.set_s_var("TokenScript", army_script);
     token.set_s_var("TokenSpawningAbility", _sa.ability_text.clone());
-    token.card_name = format!("{} Army Token", amass_type);
-    token.type_line = CardTypeLine::parse(&format!("Creature - {} Army", amass_type));
+    token.card_name = format!("{amass_type} Army Token");
+    token.type_line = CardTypeLine::parse(&format!("Creature - {amass_type} Army"));
 
     let token_table = TOKEN_EFFECT_BASE.make_token_table_internal(controller, token, 1);
     let mut trigger_list = CardZoneTable::default();
@@ -160,10 +160,9 @@ fn add_type_effect(
     effect.set_temp_effect_host(Some(target)); // Removed when target leaves play
 
     let static_text = format!(
-        "Mode$ Continuous | Affected$ Card.IsRemembered | EffectZone$ Command | AddType$ {}",
-        amass_type
+        "Mode$ Continuous | Affected$ Card.IsRemembered | EffectZone$ Command | AddType$ {amass_type}"
     );
-    if let Some(parsed) = parse_static_ability(&format!("S$ {}", static_text)) {
+    if let Some(parsed) = parse_static_ability(&format!("S$ {static_text}")) {
         effect.add_static_ability(parsed);
     }
 

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/bid_life_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/bid_life_effect.rs
@@ -47,6 +47,6 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
         ctx.game.card_mut(sid).add_remembered_player(highest_bidder);
         ctx.game
             .card_mut(sid)
-            .set_s_var("HighestLifeBid", format!("Number${}", highest_bid));
+            .set_s_var("HighestLifeBid", format!("Number${highest_bid}"));
     }
 }

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/cast_from_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/cast_from_effect.rs
@@ -121,7 +121,7 @@ pub fn offer_cast_or_alternative(
     ctx.agents[controller.index()].confirm_action(
         controller,
         Some("CastFromEffect"),
-        &format!("{}: {} or {}?", card_name, cast_label, alt_label),
+        &format!("{card_name}: {cast_label} or {alt_label}?"),
         &[cast_label.to_string(), alt_label.to_string()],
         Some(card_id),
         None,
@@ -174,7 +174,7 @@ fn push_spell_to_stack(
     );
     super::emit_targeting_triggers(ctx, card_id, &trigger_sa);
 
-    let mut event = GameLogEvent::stack(format!("{}: cast {}", label, card_name))
+    let mut event = GameLogEvent::stack(format!("{label}: cast {card_name}"))
         .with_player(controller)
         .with_source_card(card_id);
     if let Some(target_id) = chosen_target {

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/change_x_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/change_x_effect.rs
@@ -15,5 +15,5 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
     ctx.game
         .card_mut(source_id)
         .svars
-        .insert("X".to_string(), format!("Number${}", new_x));
+        .insert("X".to_string(), format!("Number${new_x}"));
 }

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/change_zone_effect/helpers.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/change_zone_effect/helpers.rs
@@ -561,7 +561,7 @@ fn create_warp_effect(ctx: &mut EffectContext, sa: &SpellAbility, exiled_card_id
     let card_name = ctx.game.card(exiled_card_id).card_name.clone();
     let mut effect = Card::new(
         CardId(0),
-        format!("Warped {}", card_name),
+        format!("Warped {card_name}"),
         controller,
         CardTypeLine::parse("Effect"),
         ManaCost::parse("0"),
@@ -576,7 +576,7 @@ fn create_warp_effect(ctx: &mut EffectContext, sa: &SpellAbility, exiled_card_id
     effect.add_remembered_card(exiled_card_id);
     effect.set_forget_on_moved_origin(Some(ZoneType::Exile));
     let static_text = "Mode$ Continuous | MayPlay$ True | EffectZone$ Command | Affected$ Card.IsRemembered+nonLand | AffectedZone$ Exile";
-    if let Some(parsed) = parse_static_ability(&format!("S$ {}", static_text)) {
+    if let Some(parsed) = parse_static_ability(&format!("S$ {static_text}")) {
         effect.add_static_ability(parsed);
     }
     let eid = ctx.game.create_card(effect);

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/change_zone_effect/hidden.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/change_zone_effect/hidden.rs
@@ -148,8 +148,7 @@ pub(super) fn resolve_hidden_origin(
                 ordered.retain(|&cid| {
                     let card_name = ctx.game.card(cid).card_name.clone();
                     let prompt = format!(
-                        "Do you want to move {} from {} to {}?",
-                        card_name, origin_zone, dest_zone,
+                        "Do you want to move {card_name} from {origin_zone} to {dest_zone}?",
                     );
                     ctx.agents[chooser.index()].confirm_action(
                         chooser,
@@ -562,7 +561,7 @@ fn offer_panglacial_cast(
         let cast = ctx.agents[controller.index()].confirm_action(
             controller,
             Some("PanglacialCast"),
-            &format!("Cast {} from library while searching?", name),
+            &format!("Cast {name} from library while searching?"),
             &[],
             Some(pg_id),
             None,

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/change_zone_effect/known.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/change_zone_effect/known.rs
@@ -193,10 +193,8 @@ pub(super) fn resolve_known_origin(
             .into_iter()
             .filter(|&cid| {
                 let card_name = ctx.game.card(cid).card_name.clone();
-                let prompt = format!(
-                    "Do you want to move {} from {} to {}?",
-                    card_name, origin_zone, dest_zone,
-                );
+                let prompt =
+                    format!("Do you want to move {card_name} from {origin_zone} to {dest_zone}?",);
                 ctx.agents[chooser.index()].confirm_action(
                     chooser,
                     None,

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/charm_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/charm_effect.rs
@@ -517,7 +517,7 @@ pub fn make_formated_description(
         let mode_desc = params
             .get_cloned(keys::SPELL_DESCRIPTION)
             .unwrap_or_else(|| text.clone());
-        description.push_str(&format!("• {}\n", mode_desc));
+        description.push_str(&format!("• {mode_desc}\n"));
         let _ = i; // index for potential numbering
     }
     description

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/choose_sector_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/choose_sector_effect.rs
@@ -13,6 +13,6 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
         let sector = ctx.rng.next_int(6) + 1;
         ctx.game
             .card_mut(source)
-            .set_s_var("ChosenSector", format!("Number${}", sector));
+            .set_s_var("ChosenSector", format!("Number${sector}"));
     }
 }

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/control_exchange_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/control_exchange_effect.rs
@@ -59,7 +59,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
         let confirm = ctx.agents[controller.index()].confirm_action(
             controller,
             Some("ControlExchange"),
-            &format!("Exchange control of {} and {}?", name1, name2),
+            &format!("Exchange control of {name1} and {name2}?"),
             &[],
             None,
             None,

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/control_gain_variant_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/control_gain_variant_effect.rs
@@ -73,7 +73,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
         }
         _ => {
             // Other modes (multiplayer-specific) are logged and skipped
-            eprintln!("[ControlGainVariant] Unimplemented mode: {}", mode);
+            eprintln!("[ControlGainVariant] Unimplemented mode: {mode}");
         }
     }
 }

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/cost_payment.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/cost_payment.rs
@@ -729,7 +729,7 @@ pub(super) fn resolve_effect_with_unless_cost(
         let prompt = if cost_display.is_empty() {
             "Pay this cost?".to_string()
         } else {
-            format!("Pay {}?", cost_display)
+            format!("Pay {cost_display}?")
         };
         let card_name = sa.source.map(|cid| ctx.game.card(cid).card_name.as_str());
         ctx.agents[payer.index()].snapshot_state(ctx.game, ctx.mana_pools);
@@ -968,10 +968,10 @@ fn effect_cost_part_kind(part: &CostPart) -> &'static str {
 
 pub(crate) fn effect_cost_part_display(part: &CostPart) -> String {
     match part {
-        CostPart::PayLife(v) => format!("{} {{LIFE}}", v),
-        CostPart::DamageYou(v) => format!("{} damage", v),
-        CostPart::Draw(v) => format!("draw {}", v),
-        CostPart::Mill(v) => format!("mill {}", v),
+        CostPart::PayLife(v) => format!("{v} {{LIFE}}"),
+        CostPart::DamageYou(v) => format!("{v} damage"),
+        CostPart::Draw(v) => format!("draw {v}"),
+        CostPart::Mill(v) => format!("mill {v}"),
         other => effect_cost_part_kind(other).to_string(),
     }
 }

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/counters_put_or_remove_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/counters_put_or_remove_effect.rs
@@ -30,7 +30,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
     let counter_type = sa.ir.counter_type.clone().or_else(|| {
         // Sort keys for deterministic fallback (HashMap iteration is random).
         let mut keys: Vec<_> = ctx.game.card(target_id).counters.keys().cloned().collect();
-        keys.sort_by(|a, b| format!("{:?}", a).cmp(&format!("{:?}", b)));
+        keys.sort_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")));
         keys.into_iter().next()
     });
     let Some(counter_type) = counter_type else {
@@ -85,7 +85,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
             crate::trigger::TriggerType::CounterRemoved,
             crate::event::RunParams {
                 card: Some(target_id),
-                counter_type: Some(format!("{:?}", counter_type)),
+                counter_type: Some(format!("{counter_type:?}")),
                 counter_amount: Some(amount),
                 cause_player: Some(controller),
                 ..Default::default()

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/counters_remove_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/counters_remove_effect.rs
@@ -106,7 +106,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
         TriggerType::CounterRemoved,
         RunParams {
             card: Some(card_id),
-            counter_type: Some(format!("{:?}", counter_type)),
+            counter_type: Some(format!("{counter_type:?}")),
             counter_amount: Some(actual),
             ..Default::default()
         },

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/draw_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/draw_effect.rs
@@ -54,7 +54,7 @@ fn draw_for_player(
         let accepted = ctx.agents[target.index()].confirm_action(
             target,
             None,
-            &format!("Do you want to draw {} card(s)?", actual_num),
+            &format!("Do you want to draw {actual_num} card(s)?"),
             &[],
             sa.source,
             Some(crate::ability::api_type::ApiType::Draw),

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/effect_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/effect_effect.rs
@@ -107,7 +107,7 @@ fn resolve_impl(ctx: &mut EffectContext, sa: &SpellAbility) {
         .iter()
         .filter_map(|svar_name| ctx.game.card(source_id).get_s_var(svar_name))
         .filter_map(|raw| {
-            let mut static_ability = parse_static_ability(&format!("S$ {}", raw))?;
+            let mut static_ability = parse_static_ability(&format!("S$ {raw}"))?;
             static_ability.ir.active_zones = vec![ZoneType::Command];
             static_ability.ir.has_zone_keys = true;
             static_ability.base.set_intrinsic(true);
@@ -239,7 +239,7 @@ fn resolve_effect_name(sa: &SpellAbility, host_name: &str) -> String {
         return name.to_string();
     }
     let suffix = if sa.ir.boon { "'s Boon" } else { "'s Effect" };
-    format!("{}{}", host_name, suffix)
+    format!("{host_name}{suffix}")
 }
 
 fn player_has_effect_named(ctx: &EffectContext, player: PlayerId, name: &str) -> bool {

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/explore_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/explore_effect.rs
@@ -106,7 +106,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
             // Use confirm_action here to match that RNG-consuming path.
             let card_name = ctx.game.card(top_card).card_name.clone();
             let _explorer_name = ctx.game.card(explorer_id).card_name.clone();
-            let msg = format!("Put {} into your graveyard?", card_name);
+            let msg = format!("Put {card_name} into your graveyard?");
             let put_in_gy = ctx.agents[controller.index()].confirm_action(
                 controller,
                 None,

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/life_lose_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/life_lose_effect.rs
@@ -59,7 +59,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
         ctx.game
             .card_mut(source_id)
             .svars
-            .insert("AFLifeLost".to_string(), format!("Number${}", amount));
+            .insert("AFLifeLost".to_string(), format!("Number${amount}"));
     }
 
     // Per-player `LifeLost` trigger.

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/move_counter_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/move_counter_effect.rs
@@ -88,7 +88,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
         TriggerType::CounterRemoved,
         RunParams {
             card: Some(from),
-            counter_type: Some(format!("{:?}", counter_type)),
+            counter_type: Some(format!("{counter_type:?}")),
             counter_amount: Some(actual),
             ..Default::default()
         },

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/play_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/play_effect.rs
@@ -51,7 +51,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
         let accepted = ctx.agents[controller.index()].confirm_action(
             controller,
             None,
-            &format!("Do you want to play {}?", card_name),
+            &format!("Do you want to play {card_name}?"),
             &[],
             Some(card_id),
             Some(crate::ability::api_type::ApiType::Play),
@@ -269,7 +269,7 @@ fn push_spell_to_stack(
     );
     super::emit_targeting_triggers(ctx, card_id, &trigger_sa);
 
-    let mut event = GameLogEvent::stack(format!("{}: cast {}", label, card_name))
+    let mut event = GameLogEvent::stack(format!("{label}: cast {card_name}"))
         .with_player(controller)
         .with_source_card(card_id);
     if let Some(target_id) = chosen_target {
@@ -298,8 +298,7 @@ pub fn add_replace_graveyard_effect(
     );
     effect.remembered_cards.push(card_id);
     let raw = format!(
-        "R$ Event$ Moved | ValidCard$ Card.IsRemembered | Origin$ Stack | Destination$ Graveyard | NewDestination$ {} | ForgetOnMoved$ Origin | Description$ If that card would be put into your graveyard this turn, put it into {} instead.",
-        dest_zone, dest_zone
+        "R$ Event$ Moved | ValidCard$ Card.IsRemembered | Origin$ Stack | Destination$ Graveyard | NewDestination$ {dest_zone} | ForgetOnMoved$ Origin | Description$ If that card would be put into your graveyard this turn, put it into {dest_zone} instead."
     );
     crate::player::player_factory_util::add_replacement_effect(&mut effect, &raw);
     effect.exile_when_no_remembered = true;

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/play_land_variant_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/play_land_variant_effect.rs
@@ -19,5 +19,5 @@ fn resolve(_ctx: &mut EffectContext, _sa: &crate::spellability::SpellAbility) {
     let err = crate::ability::IllegalAbilityException::new(
         "PlayLandVariant effect not yet fully implemented",
     );
-    eprintln!("{}", err);
+    eprintln!("{err}");
 }

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/plot_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/plot_effect.rs
@@ -28,7 +28,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
 
     crate::agent::notify_all_agents(
         ctx.agents,
-        crate::agent::GameLogEvent::action(format!("Plotted: {}", card_name))
+        crate::agent::GameLogEvent::action(format!("Plotted: {card_name}"))
             .with_player(player)
             .with_card(card_id),
     );

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/pump_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/pump_effect.rs
@@ -139,7 +139,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
         keywords.push("CanBlockAny".to_string());
     }
     if let Some(amt) = sa.ir.can_block_amount.as_deref() {
-        keywords.push(format!("CanBlock:{}", amt));
+        keywords.push(format!("CanBlock:{amt}"));
     }
 
     let is_perpetual = sa.ir.perpetual_duration;

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/reveal_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/reveal_effect.rs
@@ -38,7 +38,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
         for &id in revealed {
             let name = ctx.game.card(id).card_name.clone();
             agent.notify(crate::agent::notification::GameNotification::Event(
-                GameLogEvent::rule(format!("Revealed: {}", name)).with_card(id),
+                GameLogEvent::rule(format!("Revealed: {name}")).with_card(id),
             ));
         }
     }

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/roll_dice_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/roll_dice_effect.rs
@@ -30,7 +30,7 @@ pub fn make_formated_description(game: &GameState, sa: &SpellAbility) -> String 
     let sides = sa.ir.sides.unwrap_or(6);
     let card_name = game.card(source_id).card_name.clone();
 
-    let mut desc = format!("{} — Roll a d{}.", card_name, sides);
+    let mut desc = format!("{card_name} — Roll a d{sides}.");
 
     if let Some(result_str) = sa.ir.result_sub_abilities_text.as_deref() {
         desc.push('\n');
@@ -44,7 +44,7 @@ pub fn make_formated_description(game: &GameState, sa: &SpellAbility) -> String 
                     let effect_desc = params
                         .get_cloned(crate::parsing::keys::SPELL_DESCRIPTION)
                         .unwrap_or_else(|| svar_name.to_string());
-                    desc.push_str(&format!("  {}: {}\n", threshold, effect_desc));
+                    desc.push_str(&format!("  {threshold}: {effect_desc}\n"));
                 }
             }
         }
@@ -379,7 +379,7 @@ fn roll_for_player(
         .join(", ");
     crate::agent::notify_all_agents(
         ctx.agents,
-        GameLogEvent::rule(format!("Rolled {} (d{})", rolled_text, sides)).with_player(player),
+        GameLogEvent::rule(format!("Rolled {rolled_text} (d{sides})")).with_player(player),
     );
     if !ignored_rolls.is_empty() {
         let ignored_text = ignored_rolls
@@ -558,7 +558,7 @@ pub fn roll_to_visit_attractions(
         .join(", ");
     crate::agent::notify_all_agents(
         agents,
-        GameLogEvent::rule(format!("Rolled {} (d6)", rolled_text)).with_player(player),
+        GameLogEvent::rule(format!("Rolled {rolled_text} (d6)")).with_player(player),
     );
     if !ignored_rolls.is_empty() {
         let ignored_text = ignored_rolls

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/sacrifice_all_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/sacrifice_all_effect.rs
@@ -57,7 +57,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
             let prompt = if cost_display.is_empty() {
                 "Pay this cost?".to_string()
             } else {
-                format!("Pay {}?", cost_display)
+                format!("Pay {cost_display}?")
             };
             ctx.agents[payer.index()].snapshot_state(ctx.game, ctx.mana_pools);
             let wants_to_pay = ctx.agents[payer.index()].pay_cost_to_prevent_effect(

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/sacrifice_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/sacrifice_effect.rs
@@ -129,7 +129,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
         let prompt = if cost_display.is_empty() {
             "Pay this cost?".to_string()
         } else {
-            format!("Pay {}?", cost_display)
+            format!("Pay {cost_display}?")
         };
         ctx.agents[controller.index()].snapshot_state(ctx.game, ctx.mana_pools);
         let wants_to_pay = ctx.agents[controller.index()].pay_cost_to_prevent_effect(

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/set_state_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/set_state_effect.rs
@@ -133,7 +133,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
                 "Unknown SetState mode: {:?}",
                 mode.map(ToString::to_string)
             ));
-            eprintln!("{}", err);
+            eprintln!("{err}");
         }
     }
 }

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/skip_phase_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/skip_phase_effect.rs
@@ -16,7 +16,7 @@ pub fn create_skip_phase_effect(
         "Combat" | "BeginCombat" => game.player_mut(player).skip_next_combat = true,
         "Untap" => game.player_mut(player).skip_next_untap = true,
         _ => {
-            eprintln!("SkipPhaseEffect: Unknown phase to skip: {:?}", phase);
+            eprintln!("SkipPhaseEffect: Unknown phase to skip: {phase:?}");
         }
     }
 }
@@ -69,10 +69,9 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
             "Untap" => ctx.game.player_set_skip_untap(target),
             _ => {
                 let err = crate::ability::IllegalAbilityException::new(format!(
-                    "Unknown phase to skip: {:?}",
-                    phase
+                    "Unknown phase to skip: {phase:?}"
                 ));
-                eprintln!("{}", err);
+                eprintln!("{err}");
             }
         }
     }

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/store_s_var_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/store_s_var_effect.rs
@@ -72,7 +72,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
             .parse::<i32>()
             .unwrap_or_else(|_| crate::svar::evaluate_svar(&expression, sa)),
     };
-    let resolved_value = format!("Number${}", resolved_number);
+    let resolved_value = format!("Number${resolved_number}");
 
     ctx.game
         .card_mut(source_id)

--- a/manabrew-rs/crates/manabrew-engine/src/ability/effects/vote_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/effects/vote_effect.rs
@@ -105,7 +105,7 @@ fn resolve(ctx: &mut EffectContext, sa: &crate::spellability::SpellAbility) {
     if sa.param_is_true(keys::STORE_VOTE_NUM) {
         if let Some(source_id) = sa.source {
             for (choice, voters_list) in &vote_counts {
-                let svar_name = format!("VoteNum{}", choice);
+                let svar_name = format!("VoteNum{choice}");
                 let svar_val = format!("Number${}", voters_list.len());
                 ctx.game.card_mut(source_id).set_s_var(svar_name, svar_val);
             }

--- a/manabrew-rs/crates/manabrew-engine/src/ability/illegal_ability_exception.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/illegal_ability_exception.rs
@@ -21,7 +21,7 @@ impl IllegalAbilityException {
     /// Create from a spell ability description and effect name.
     pub fn with_effect(sa_desc: &str, effect_name: &str) -> Self {
         Self {
-            message: format!("{} (effect {})", sa_desc, effect_name),
+            message: format!("{sa_desc} (effect {effect_name})"),
         }
     }
 }

--- a/manabrew-rs/crates/manabrew-engine/src/ability/spell_ability_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/ability/spell_ability_effect.rs
@@ -448,7 +448,7 @@ pub fn create_effect(game: &mut GameState, sa: &SpellAbility, name: &str, _image
         .unwrap_or_default();
 
     let effect_name = if name.is_empty() {
-        format!("{} Effect", source_name)
+        format!("{source_name} Effect")
     } else {
         name.to_string()
     };
@@ -953,8 +953,7 @@ pub fn replace_dying(game: &mut GameState, sa: &SpellAbility) -> Vec<CardId> {
         .unwrap_or("Card.IsRemembered");
     let zone = sa.ir.replace_dying_zone_text.as_deref().unwrap_or("Exile");
     let mut replacement_raw = format!(
-        "R$ Event$ Moved | ValidLKI$ {} | Origin$ Battlefield | Destination$ Graveyard | NewDestination$ {} | Description$ If that permanent would die this turn, exile it instead.",
-        valid, zone
+        "R$ Event$ Moved | ValidLKI$ {valid} | Origin$ Battlefield | Destination$ Graveyard | NewDestination$ {zone} | Description$ If that permanent would die this turn, exile it instead."
     );
     if sa.ir.replace_dying_exiled_with {
         replacement_raw.push_str(" | ExiledWithEffectSource$ True");

--- a/manabrew-rs/crates/manabrew-engine/src/action.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/action.rs
@@ -1326,8 +1326,7 @@ impl GameState {
                 let accepted = if let Some(agents) = agents.as_deref_mut() {
                     let name = self.card(cid).card_name.clone();
                     let message = format!(
-                        "{}: If a commander is in a graveyard or in exile and that card was put into that zone since the last time state-based actions were checked, its owner may put it into the command zone.",
-                        name
+                        "{name}: If a commander is in a graveyard or in exile and that card was put into that zone since the last time state-based actions were checked, its owner may put it into the command zone."
                     );
                     agents[pid.index()].confirm_action(
                         pid,

--- a/manabrew-rs/crates/manabrew-engine/src/card/card_assembly.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/card/card_assembly.rs
@@ -78,7 +78,7 @@ pub(crate) fn parse_card_components(face: &forge_carddb::CardFace) -> ParsedComp
     // Parse static abilities from S: lines (need S$ prefix for the parser)
     let mut static_abilities = Vec::new();
     for raw in &face.static_abilities {
-        let prefixed = format!("S$ {}", raw);
+        let prefixed = format!("S$ {raw}");
         if let Some(sa) =
             parse_classified_or_warn(parse_static_ability(&prefixed), "StaticAbility", raw)
         {
@@ -91,7 +91,7 @@ pub(crate) fn parse_card_components(face: &forge_carddb::CardFace) -> ParsedComp
         .replacements
         .iter()
         .filter_map(|raw| {
-            let prefixed = format!("R$ {}", raw);
+            let prefixed = format!("R$ {raw}");
             parse_classified_or_warn(
                 parse_replacement_effect(&prefixed),
                 "ReplacementEffect",
@@ -140,8 +140,7 @@ pub(crate) fn synthesize_derived(components: &mut ParsedComponents, existing_tri
         if has_exert {
             if let Some(svar_name) = sa.ir.trigger_text.as_deref() {
                 let raw = format!(
-                    "Mode$ Exerted | ValidCard$ Card.Self | Execute$ {} | TriggerZones$ Battlefield",
-                    svar_name
+                    "Mode$ Exerted | ValidCard$ Card.Self | Execute$ {svar_name} | TriggerZones$ Battlefield"
                 );
                 if let Some(mut trig) = parse_trigger(&raw, &mut next_trig_id) {
                     trig.execute = svar_name.to_string();
@@ -260,8 +259,7 @@ pub(crate) fn assemble_card(
             card.set_s_var("RoomRightSplitCost", &unlock_cost);
             // Build an activated ability for unlocking the second door.
             let ab_text = format!(
-                "AB$ UnlockDoor | Cost$ {} | SorcerySpeed$ True | CardState$ RightSplit | SpellDescription$ Unlock {}",
-                unlock_cost, unlock_name
+                "AB$ UnlockDoor | Cost$ {unlock_cost} | SorcerySpeed$ True | CardState$ RightSplit | SpellDescription$ Unlock {unlock_name}"
             );
             let next_idx = card.activated_abilities.len();
             if let Some(ab) = crate::ability::activated::parse_activated_ability(&ab_text, next_idx)
@@ -313,7 +311,7 @@ pub(crate) fn assemble_card(
                 .iter()
                 .filter_map(|raw| {
                     parse_classified_or_warn(
-                        parse_static_ability(&format!("S$ {}", raw)),
+                        parse_static_ability(&format!("S$ {raw}")),
                         "StaticAbility",
                         raw,
                     )
@@ -325,7 +323,7 @@ pub(crate) fn assemble_card(
                 .iter()
                 .filter_map(|raw| {
                     parse_classified_or_warn(
-                        parse_replacement_effect(&format!("R$ {}", raw)),
+                        parse_replacement_effect(&format!("R$ {raw}")),
                         "ReplacementEffect",
                         raw,
                     )

--- a/manabrew-rs/crates/manabrew-engine/src/card/card_factory_util.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/card/card_factory_util.rs
@@ -202,8 +202,7 @@ pub fn add_etb_keyword_replacements(card: &mut Card) {
             .replace('|', "/");
 
         let mut raw = format!(
-            "R$ Event$ Moved | Layer$ {} | ValidCard$ {} | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ {} | Description$ {}",
-            layer, valid, svar_name, desc
+            "R$ Event$ Moved | Layer$ {layer} | ValidCard$ {valid} | Destination$ Battlefield | ReplacementResult$ Updated | ReplaceWith$ {svar_name} | Description$ {desc}"
         );
         if optional {
             raw.push_str(" | Optional$ True");
@@ -299,16 +298,12 @@ pub fn add_madness_replacement(card: &mut Card) {
             "Madness: If you discard this card, discard it into exile.".to_string()
         } else {
             let display = forge_foundation::ManaCost::parse(cost);
-            format!(
-                "Madness {}: If you discard this card, discard it into exile.",
-                display
-            )
+            format!("Madness {display}: If you discard this card, discard it into exile.")
         };
         let repl_str = format!(
             "R$ Event$ Moved | ActiveZones$ Hand | ValidCard$ Card.Self | Discard$ True \
              | Secondary$ True | NewDestination$ Exile \
-             | Description$ {}",
-            desc
+             | Description$ {desc}"
         );
         if let Some(repl) = parse_replacement_effect(&repl_str) {
             card.add_replacement_effect(repl);
@@ -332,18 +327,16 @@ pub fn add_flashback_replacement(card: &mut Card) {
         .find_map(|kw| kw.strip_prefix("Flashback:"))
         .map(|c| {
             let mc = forge_foundation::ManaCost::parse(c.trim());
-            format!("{}", mc)
+            format!("{mc}")
         })
         .unwrap_or_default();
     let desc = format!(
-        "Flashback {} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
-        cost_display
+        "Flashback {cost_display} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
     );
     let repl_str = format!(
         "R$ Event$ Moved | ValidCard$ Card.Self | Origin$ Stack | ExcludeDestination$ Exile \
          | FlashbackCast$ True | Secondary$ True | NewDestination$ Exile \
-         | Description$ {}",
-        desc
+         | Description$ {desc}"
     );
     if let Some(repl) = parse_replacement_effect(&repl_str) {
         card.add_replacement_effect(repl);
@@ -360,14 +353,12 @@ pub fn add_harmonize_replacement(card: &mut Card) {
     };
     let cost_display = forge_foundation::ManaCost::parse(cost);
     let desc = format!(
-        "Harmonize {} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {{X}}, where X is its power. Then exile this spell.)",
-        cost_display
+        "Harmonize {cost_display} (You may cast this card from your graveyard for its harmonize cost. You may tap a creature you control to reduce that cost by {{X}}, where X is its power. Then exile this spell.)"
     );
     let repl_str = format!(
         "R$ Event$ Moved | ValidCard$ Card.Self | Origin$ Stack | ExcludeDestination$ Exile \
          | HarmonizeCast$ True | Secondary$ True | NewDestination$ Exile \
-         | Description$ {}",
-        desc
+         | Description$ {desc}"
     );
     if let Some(repl) = parse_replacement_effect(&repl_str) {
         card.add_replacement_effect(repl);

--- a/manabrew-rs/crates/manabrew-engine/src/card/keyword_gen.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/card/keyword_gen.rs
@@ -72,8 +72,7 @@ impl Card {
                 });
                 if !already_produces {
                     let raw = format!(
-                        "AB$ Mana | Cost$ T | Produced$ {} | SpellDescription$ {}",
-                        letter, desc
+                        "AB$ Mana | Cost$ T | Produced$ {letter} | SpellDescription$ {desc}"
                     );
                     let idx = self.abilities.len();
                     self.abilities.push(raw.clone());
@@ -91,8 +90,7 @@ impl Card {
         // Cycling: K:Cycling:{cost} → AB$ Draw | Cost$ {cost} Discard<1/CARDNAME> | ActivationZone$ Hand
         if let Some(cycling_cost) = self.get_keyword_cost("Cycling") {
             let ab_text = format!(
-                "AB$ Draw | Cost$ {} Discard<1/CARDNAME> | ActivationZone$ Hand | NumCards$ 1 | Defined$ You",
-                cycling_cost
+                "AB$ Draw | Cost$ {cycling_cost} Discard<1/CARDNAME> | ActivationZone$ Hand | NumCards$ 1 | Defined$ You"
             );
             let next_idx = self.activated_abilities.len();
             if let Some(ab) = parse_activated_ability(&ab_text, next_idx) {
@@ -123,8 +121,7 @@ impl Card {
                             + &cycle_type[1..]
                     );
                     let ab_text = format!(
-                        "AB$ ChangeZone | Cost$ {} Discard<1/CARDNAME> | ActivationZone$ Hand | PrecostDesc$ {} | Origin$ Library | Destination$ Hand | ChangeType$ {}",
-                        mana_cost, precost_desc, cycle_type
+                        "AB$ ChangeZone | Cost$ {mana_cost} Discard<1/CARDNAME> | ActivationZone$ Hand | PrecostDesc$ {precost_desc} | Origin$ Library | Destination$ Hand | ChangeType$ {cycle_type}"
                     );
                     let next_idx = self.activated_abilities.len();
                     if let Some(ab) = parse_activated_ability(&ab_text, next_idx) {
@@ -153,8 +150,7 @@ impl Card {
                 .unwrap_or("Creature.YouCtrl");
             if !equip_cost.is_empty() {
                 let ab_text = format!(
-                    "AB$ Attach | Cost$ {} | ValidTgts$ {} | SorcerySpeed$ True | SpellDescription$ Equip {}",
-                    equip_cost, target_filter, equip_cost
+                    "AB$ Attach | Cost$ {equip_cost} | ValidTgts$ {target_filter} | SorcerySpeed$ True | SpellDescription$ Equip {equip_cost}"
                 );
                 let next_idx = self.activated_abilities.len();
                 if let Some(ab) = parse_activated_ability(&ab_text, next_idx) {
@@ -176,8 +172,7 @@ impl Card {
                     let magnitude = parts[0].trim();
                     let mana_cost = parts[1].trim();
                     let ab_text = format!(
-                        "AB$ PutCounter | Cost$ {} | Adapt$ True | CounterNum$ {} | CounterType$ P1P1 | StackDescription$ SpellDescription | SpellDescription$ Adapt {}",
-                        mana_cost, magnitude, magnitude
+                        "AB$ PutCounter | Cost$ {mana_cost} | Adapt$ True | CounterNum$ {magnitude} | CounterType$ P1P1 | StackDescription$ SpellDescription | SpellDescription$ Adapt {magnitude}"
                     );
                     let next_idx = self.activated_abilities.len();
                     if let Some(ab) = parse_activated_ability(&ab_text, next_idx) {
@@ -198,8 +193,7 @@ impl Card {
             if let Some(n_str) = crate::keyword::extract_keyword_cost_str(kw, "Crew") {
                 let n = n_str.trim();
                 let ab_text = format!(
-                    "AB$ Animate | Cost$ tapXType<Any/Creature.Other+withTotalPowerGE{{{}}}> | Defined$ Self | Types$ Artifact,Creature | Secondary$ True | SpellDescription$ Crew {}",
-                    n, n
+                    "AB$ Animate | Cost$ tapXType<Any/Creature.Other+withTotalPowerGE{{{n}}}> | Defined$ Self | Types$ Artifact,Creature | Secondary$ True | SpellDescription$ Crew {n}"
                 );
                 let next_idx = self.activated_abilities.len();
                 if let Some(ab) = parse_activated_ability(&ab_text, next_idx) {
@@ -239,8 +233,7 @@ impl Card {
             if let Some(cost_str) = crate::keyword::extract_keyword_cost_str(kw, "Embalm") {
                 let cost = cost_str.trim();
                 let ab_text = format!(
-                    "AB$ CopyPermanent | Cost$ {} ExileFromGrave<1/CARDNAME> | ActivationZone$ Graveyard | SorcerySpeed$ True | Defined$ Self | SetColor$ White | AddTypes$ Zombie | SpellDescription$ Embalm",
-                    cost
+                    "AB$ CopyPermanent | Cost$ {cost} ExileFromGrave<1/CARDNAME> | ActivationZone$ Graveyard | SorcerySpeed$ True | Defined$ Self | SetColor$ White | AddTypes$ Zombie | SpellDescription$ Embalm"
                 );
                 let next_idx = self.activated_abilities.len();
                 if let Some(ab) = parse_activated_ability(&ab_text, next_idx) {
@@ -259,8 +252,7 @@ impl Card {
             if let Some(cost_str) = crate::keyword::extract_keyword_cost_str(kw, "Eternalize") {
                 let cost = cost_str.trim();
                 let ab_text = format!(
-                    "AB$ CopyPermanent | Cost$ {} ExileFromGrave<1/CARDNAME> | ActivationZone$ Graveyard | SorcerySpeed$ True | Defined$ Self | SetColor$ Black | SetPower$ 4 | SetToughness$ 4 | AddTypes$ Zombie | SpellDescription$ Eternalize",
-                    cost
+                    "AB$ CopyPermanent | Cost$ {cost} ExileFromGrave<1/CARDNAME> | ActivationZone$ Graveyard | SorcerySpeed$ True | Defined$ Self | SetColor$ Black | SetPower$ 4 | SetToughness$ 4 | AddTypes$ Zombie | SpellDescription$ Eternalize"
                 );
                 let next_idx = self.activated_abilities.len();
                 if let Some(ab) = parse_activated_ability(&ab_text, next_idx) {
@@ -301,8 +293,7 @@ impl Card {
         // Exiles the card from hand; plotted cards can later be cast for free.
         if let Some(plot_cost) = self.get_keyword_cost("Plot") {
             let ab_text = format!(
-                "AB$ Plot | Cost$ {} | ActivationZone$ Hand | SorcerySpeed$ True | Secondary$ True | SpellDescription$ Plot",
-                plot_cost
+                "AB$ Plot | Cost$ {plot_cost} | ActivationZone$ Hand | SorcerySpeed$ True | Secondary$ True | SpellDescription$ Plot"
             );
             let next_idx = self.activated_abilities.len();
             if let Some(ab) = parse_activated_ability(&ab_text, next_idx) {
@@ -391,8 +382,7 @@ impl Card {
                     }
 
                     let mut effect = format!(
-                        "Mode$ Continuous | Affected$ Card.Self | ClassLevel$ {} | {}",
-                        level_num, params
+                        "Mode$ Continuous | Affected$ Card.Self | ClassLevel$ {level_num} | {params}"
                     );
                     if !desc_parts.is_empty() {
                         effect.push_str(" | Description$ ");
@@ -418,8 +408,7 @@ impl Card {
             if let Some(n_str) = crate::keyword::extract_keyword_cost_str(kw, "Crew") {
                 let n = n_str.trim();
                 let ab_text = format!(
-                    "AB$ Animate | Cost$ tapXType<Any/Creature.Other+withTotalPowerGE{{{}}}> | Defined$ Self | Types$ Artifact,Creature | Secondary$ True | SpellDescription$ Crew {}",
-                    n, n
+                    "AB$ Animate | Cost$ tapXType<Any/Creature.Other+withTotalPowerGE{{{n}}}> | Defined$ Self | Types$ Artifact,Creature | Secondary$ True | SpellDescription$ Crew {n}"
                 );
                 let next_idx = self.activated_abilities.len();
                 if let Some(ab) = parse_activated_ability(&ab_text, next_idx) {
@@ -879,8 +868,7 @@ impl Card {
                 .entry("TrigMadnessPlay".to_string())
                 .or_insert_with(|| {
                     format!(
-                        "DB$ Play | Defined$ Self | ValidSA$ Spell | PlayCost$ {} | Optional$ True | RememberPlayed$ True | SubAbility$ MadnessMoveToYard",
-                        madness_cost
+                        "DB$ Play | Defined$ Self | ValidSA$ Spell | PlayCost$ {madness_cost} | Optional$ True | RememberPlayed$ True | SubAbility$ MadnessMoveToYard"
                     )
                 });
             self.svars
@@ -896,8 +884,7 @@ impl Card {
         if let Some(partner_name) = kw.strip_prefix("Partner with:") {
             let mut partner_name = partner_name.trim().to_string();
             let raw = format!(
-                "Mode$ ChangesZone | Destination$ Battlefield | ValidCard$ Card.Self | Secondary$ True | TriggerDescription$ Partner with {}",
-                partner_name
+                "Mode$ ChangesZone | Destination$ Battlefield | ValidCard$ Card.Self | Secondary$ True | TriggerDescription$ Partner with {partner_name}"
             );
             if let Some(mut trig) = parse_trigger(&raw, next_id) {
                 trig.execute = "TrigPartnerWith".to_string();
@@ -908,8 +895,7 @@ impl Card {
                 .entry("TrigPartnerWith".to_string())
                 .or_insert_with(|| {
                     format!(
-                        "DB$ ChangeZone | ValidTgts$ Player | Origin$ Library | Destination$ Hand | ChangeType$ Card.named{} | Hidden$ True | Chooser$ Targeted | Optional$ True",
-                        partner_name
+                        "DB$ ChangeZone | ValidTgts$ Player | Origin$ Library | Destination$ Hand | ChangeType$ Card.named{partner_name} | Hidden$ True | Chooser$ Targeted | Optional$ True"
                     )
                 });
         }

--- a/manabrew-rs/crates/manabrew-engine/src/card/mod.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/card/mod.rs
@@ -80,7 +80,7 @@ fn parse_literal_target_count(expr: &str) -> Option<i32> {
 }
 
 pub fn make_plotted_keyword(turn: u32) -> String {
-    format!("{}{}", KEYWORD_PLOTTED_PREFIX, turn)
+    format!("{KEYWORD_PLOTTED_PREFIX}{turn}")
 }
 
 /// Extract the turn number from a `"Plotted:{turn}"` keyword, if present.
@@ -1396,7 +1396,7 @@ impl Card {
 
     /// Check "Hexproof from <color>" variants (e.g. "Hexproof from blue").
     pub fn has_hexproof_from(&self, color: &str) -> bool {
-        let target = format!("Hexproof from {}", color);
+        let target = format!("Hexproof from {color}");
         self.keywords.contains_string_ignore_case(&target)
             || self.granted_keywords.contains_string_ignore_case(&target)
     }
@@ -1422,7 +1422,7 @@ impl Card {
 
     /// Check "Protection from <quality>" (e.g. "Protection from red").
     pub fn has_protection_from(&self, quality: &str) -> bool {
-        let target = format!("Protection from {}", quality);
+        let target = format!("Protection from {quality}");
         self.keywords.contains_string_ignore_case(&target)
             || self.granted_keywords.contains_string_ignore_case(&target)
     }

--- a/manabrew-rs/crates/manabrew-engine/src/card_trait_base.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/card_trait_base.rs
@@ -682,7 +682,7 @@ pub trait CardTrait {
         src_card: Option<&Card>,
     ) -> bool {
         let b = self.base();
-        let invert_key = format!("Invert{}", param);
+        let invert_key = format!("Invert{param}");
         let invert = b.has_param(&invert_key);
         if b.has_param(param) {
             let raw = b.get_param(param).unwrap_or("");

--- a/manabrew-rs/crates/manabrew-engine/src/cost/cost_adjustment.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/cost/cost_adjustment.rs
@@ -140,7 +140,7 @@ fn matches_cost_adjustment_activator(
             player_predicates::is_opponent_of(game, caster, source.controller)
         }
         _ => {
-            eprintln!("[WARN] Unknown cost adjustment Activator: {:?}", activator);
+            eprintln!("[WARN] Unknown cost adjustment Activator: {activator:?}");
             false
         }
     }

--- a/manabrew-rs/crates/manabrew-engine/src/cost/cost_exile.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/cost/cost_exile.rs
@@ -93,7 +93,7 @@ pub fn can_pay(
                 let mut unique_types = std::collections::BTreeSet::new();
                 for cid in &candidates {
                     for t in &game.card(*cid).type_line.core_types {
-                        unique_types.insert(format!("{:?}", t));
+                        unique_types.insert(format!("{t:?}"));
                     }
                 }
                 if (unique_types.len() as i32) < n {

--- a/manabrew-rs/crates/manabrew-engine/src/cost/cost_payment.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/cost/cost_payment.rs
@@ -369,7 +369,7 @@ fn refund_cost_part(game: &mut GameState, source: CardId, player: PlayerId, part
         // Most cost parts (sacrifice, discard, exile, return, etc.) are not
         // individually refundable — zone changes are rolled back by GameSnapshot.
         _ => {
-            eprintln!("[WARN] Unhandled cost part refund: {:?}", part);
+            eprintln!("[WARN] Unhandled cost part refund: {part:?}");
         }
     }
 }

--- a/manabrew-rs/crates/manabrew-engine/src/cost/cost_unattach.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/cost/cost_unattach.rs
@@ -16,7 +16,7 @@ pub fn to_string(part: &super::CostPart) -> String {
         super::CostPart::Unattach { type_filter, .. } => type_filter.clone(),
         _ => "equipment".to_string(),
     };
-    format!("Unattach {}", desc)
+    format!("Unattach {desc}")
 }
 
 /// Pay by detaching the target card from whatever it's attached to.

--- a/manabrew-rs/crates/manabrew-engine/src/cost/cost_untap_type.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/cost/cost_untap_type.rs
@@ -19,9 +19,9 @@ pub fn to_string(part: &super::CostPart) -> String {
             // Simplified inline since the full utility isn't ported yet.
             let desc = type_filter.as_str();
             if matches!(amount.as_literal(), Some(1)) {
-                sb.push_str(&format!("a tapped {}", desc));
+                sb.push_str(&format!("a tapped {desc}"));
             } else {
-                sb.push_str(&format!("{} tapped {}s", amount, desc));
+                sb.push_str(&format!("{amount} tapped {desc}s"));
             }
 
             if type_filter.contains("OppCtrl") {

--- a/manabrew-rs/crates/manabrew-engine/src/cost/mod.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/cost/mod.rs
@@ -579,11 +579,11 @@ impl Cost {
 
 pub fn convert_amount_type_to_words(amount: i32, amount_expr: &str, noun: &str) -> String {
     if amount_expr == "X" {
-        format!("X {}", noun)
+        format!("X {noun}")
     } else if amount == 1 {
-        format!("a {}", noun)
+        format!("a {noun}")
     } else {
-        format!("{} {}s", amount, noun)
+        format!("{amount} {noun}s")
     }
 }
 
@@ -652,9 +652,9 @@ pub fn to_simple_string(cost: &Cost) -> String {
         match part {
             CostPart::Tap => out.push("{T}".to_string()),
             CostPart::Untap => out.push("{Q}".to_string()),
-            CostPart::Mana { cost, .. } => out.push(format!("{}", cost)),
-            CostPart::PayLife(v) => out.push(format!("Pay {} life", v)),
-            _ => out.push(format!("{:?}", part)),
+            CostPart::Mana { cost, .. } => out.push(format!("{cost}")),
+            CostPart::PayLife(v) => out.push(format!("Pay {v} life")),
+            _ => out.push(format!("{part:?}")),
         }
     }
     out.join(", ")
@@ -668,9 +668,9 @@ pub fn to_prompt_string(cost: &Cost) -> String {
         match part {
             CostPart::Tap => out.push("{T}".to_string()),
             CostPart::Untap => out.push("{Q}".to_string()),
-            CostPart::Mana { cost, .. } => out.push(format!("{}", cost)),
-            CostPart::PayLife(v) => out.push(format!("{} {{LIFE}}", v)),
-            _ => out.push(format!("{:?}", part)),
+            CostPart::Mana { cost, .. } => out.push(format!("{cost}")),
+            CostPart::PayLife(v) => out.push(format!("{v} {{LIFE}}")),
+            _ => out.push(format!("{part:?}")),
         }
     }
     out.join(", ")

--- a/manabrew-rs/crates/manabrew-engine/src/game_loop/cast_spell.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/game_loop/cast_spell.rs
@@ -210,7 +210,7 @@ impl GameLoop {
         game.player_record_land_play(player);
         crate::agent::notify_all_agents(
             agents,
-            crate::agent::GameLogEvent::action(format!("Played land: {}", play_name))
+            crate::agent::GameLogEvent::action(format!("Played land: {play_name}"))
                 .with_player(player)
                 .with_card(card_id),
         );
@@ -629,7 +629,7 @@ impl GameLoop {
                     );
                     crate::agent::notify_all_agents(
                         agents,
-                        crate::agent::GameLogEvent::rule(format!("Foretold: {}", card_name))
+                        crate::agent::GameLogEvent::rule(format!("Foretold: {card_name}"))
                             .with_player(player)
                             .with_card(card_id),
                     );
@@ -676,8 +676,7 @@ impl GameLoop {
                     crate::agent::notify_all_agents(
                         agents,
                         crate::agent::GameLogEvent::rule(format!(
-                            "Suspended: {} with {} time counters",
-                            card_name, counters
+                            "Suspended: {card_name} with {counters} time counters"
                         ))
                         .with_player(player)
                         .with_card(card_id),
@@ -1041,7 +1040,7 @@ impl GameLoop {
                         let desc = params
                             .get_cloned(keys::SPELL_DESCRIPTION)
                             .unwrap_or_else(|| name.to_string());
-                        mode_descriptions.push(format!("+ {} — {}", cost, desc));
+                        mode_descriptions.push(format!("+ {cost} — {desc}"));
                         mode_costs.push(cost);
                         original_indices.push(idx);
                     }
@@ -1381,8 +1380,7 @@ impl GameLoop {
                 );
             if !meets {
                 eprintln!(
-                    "[RUST-MUST-TARGET] Cast rejected for {} — MustTarget restriction not met",
-                    card_name
+                    "[RUST-MUST-TARGET] Cast rejected for {card_name} — MustTarget restriction not met"
                 );
                 rollback_cast!();
             }
@@ -2265,9 +2263,9 @@ impl GameLoop {
         };
         let chosen_target = entry.spell_ability.target_chosen.target_card;
         let stack_message = if is_flashback {
-            format!("Cast: {} [Flashback from Graveyard]", card_name)
+            format!("Cast: {card_name} [Flashback from Graveyard]")
         } else {
-            format!("Cast: {}", card_name)
+            format!("Cast: {card_name}")
         };
         crate::perf::increment(crate::perf::Metric::StackEntryClones, 1);
         let sa_for_trigger = self.push_spell_ability_to_stack(
@@ -2306,12 +2304,9 @@ impl GameLoop {
             if storm_count > 0 {
                 crate::agent::notify_all_agents(
                     agents,
-                    crate::agent::GameLogEvent::stack(format!(
-                        "Storm count: {} copies",
-                        storm_count
-                    ))
-                    .with_player(player)
-                    .with_card(card_id),
+                    crate::agent::GameLogEvent::stack(format!("Storm count: {storm_count} copies"))
+                        .with_player(player)
+                        .with_card(card_id),
                 );
                 for i in 0..storm_count {
                     if crate::card::card_factory::spell_ability_cant_be_copied(
@@ -2348,7 +2343,7 @@ impl GameLoop {
                     }
                     game.stack.push(copy);
                     self.log_stack_push(
-                        &format!("{} (Storm copy)", card_name),
+                        &format!("{card_name} (Storm copy)"),
                         &game.player(player).name,
                     );
 
@@ -2370,7 +2365,7 @@ impl GameLoop {
         if replicate_count > 0 {
             crate::agent::notify_all_agents(
                 agents,
-                crate::agent::GameLogEvent::stack(format!("Replicate: {} copies", replicate_count))
+                crate::agent::GameLogEvent::stack(format!("Replicate: {replicate_count} copies"))
                     .with_player(player)
                     .with_card(card_id),
             );
@@ -2409,7 +2404,7 @@ impl GameLoop {
                 }
                 game.stack.push(copy);
                 self.log_stack_push(
-                    &format!("{} (Replicate copy)", card_name),
+                    &format!("{card_name} (Replicate copy)"),
                     &game.player(player).name,
                 );
 
@@ -2509,7 +2504,7 @@ impl GameLoop {
                 && agents[player.index()].confirm_action(
                     player,
                     None,
-                    &format!("Do you want to play {}?", card_name),
+                    &format!("Do you want to play {card_name}?"),
                     &[],
                     Some(cascade_card_id),
                     Some(crate::ability::api_type::ApiType::Play),
@@ -2545,7 +2540,7 @@ impl GameLoop {
                     self.log_stack_push(&card_name, &game.player(player).name);
                     crate::agent::notify_all_agents(
                         agents,
-                        crate::agent::GameLogEvent::stack(format!("Cascade cast: {}", card_name))
+                        crate::agent::GameLogEvent::stack(format!("Cascade cast: {card_name}"))
                             .with_player(player)
                             .with_card(cascade_card_id),
                     );

--- a/manabrew-rs/crates/manabrew-engine/src/game_loop/combat_phase.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/game_loop/combat_phase.rs
@@ -323,7 +323,7 @@ impl GameLoop {
                 if cost > 0 {
                     let controller = game.card(attacker_id).controller;
                     let attacker_name = game.card(attacker_id).card_name.clone();
-                    let description = format!("Pay {{{}}} to attack with {}", cost, attacker_name);
+                    let description = format!("Pay {{{cost}}} to attack with {attacker_name}");
 
                     // Loop: let the agent tap lands / pay / decline
                     loop {

--- a/manabrew-rs/crates/manabrew-engine/src/game_loop/cost_payment.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/game_loop/cost_payment.rs
@@ -3517,7 +3517,7 @@ impl GameLoop {
                 RunParams {
                     card: Some(chosen),
                     player: Some(player),
-                    counter_type: Some(format!("{:?}", ct_to_remove)),
+                    counter_type: Some(format!("{ct_to_remove:?}")),
                     counter_amount: Some(1),
                     ..Default::default()
                 },

--- a/manabrew-rs/crates/manabrew-engine/src/game_loop/game_action.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/game_loop/game_action.rs
@@ -519,8 +519,7 @@ impl GameLoop {
         crate::agent::notify_all_agents(
             agents,
             crate::agent::GameLogEvent::action(format!(
-                "Activated ability: {} | source={}",
-                ability_kind, card_name
+                "Activated ability: {ability_kind} | source={card_name}"
             ))
             .with_player(player)
             .with_source_card(card_id),
@@ -986,7 +985,7 @@ impl GameLoop {
         } else {
             ab.ability_kind.as_str()
         };
-        let stack_message = format!("Activated ability: {} | source={}", ability_kind, card_name);
+        let stack_message = format!("Activated ability: {ability_kind} | source={card_name}");
         let sa_for_trigger = self.push_spell_ability_to_stack(
             game,
             agents,
@@ -995,7 +994,7 @@ impl GameLoop {
                 source_card: card_id,
                 entry,
                 pending_stack_id: None,
-                stack_log_name: format!("{} ability", card_name),
+                stack_log_name: format!("{card_name} ability"),
                 stack_message,
                 target_card,
                 event_kind: SpellAbilityLogEventKind::Action,

--- a/manabrew-rs/crates/manabrew-engine/src/game_loop/phase_handler.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/game_loop/phase_handler.rs
@@ -965,8 +965,7 @@ impl GameLoop {
                 crate::agent::notify_all_agents(
                     agents,
                     crate::agent::GameLogEvent::stack(format!(
-                        "Suspend: casting {} for free!",
-                        card_name
+                        "Suspend: casting {card_name} for free!"
                     ))
                     .with_player(active)
                     .with_card(card_id),

--- a/manabrew-rs/crates/manabrew-engine/src/game_loop/stack_resolution.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/game_loop/stack_resolution.rs
@@ -138,8 +138,7 @@ impl GameLoop {
             crate::agent::notify_all_agents(
                 agents,
                 crate::agent::GameLogEvent::warning(format!(
-                    "{} fizzles (all targets invalid)",
-                    stack_item_name
+                    "{stack_item_name} fizzles (all targets invalid)"
                 ))
                 .with_player(entry.spell_ability.activating_player),
             );
@@ -628,10 +627,8 @@ impl GameLoop {
                         .get_keyword_cost(if is_mega { "Megamorph" } else { "Morph" })
                         .unwrap_or_else(|| "3".to_string());
                     let mega_param = if is_mega { " | Mega$ True" } else { "" };
-                    let ab_text = format!(
-                        "AB$ SetState | Cost$ {} | Mode$ TurnFaceUp{}",
-                        morph_cost, mega_param
-                    );
+                    let ab_text =
+                        format!("AB$ SetState | Cost$ {morph_cost} | Mode$ TurnFaceUp{mega_param}");
                     let ab_index = c.activated_abilities.len();
                     if let Some(parsed) =
                         crate::ability::activated::parse_activated_ability(&ab_text, ab_index)
@@ -1056,8 +1053,7 @@ impl GameLoop {
             .unwrap_or_else(|| "Unknown source".to_string());
         let effect_kind = Self::effect_kind_for_sa(sa);
         let mut event = crate::agent::GameLogEvent::stack(format!(
-            "Effect resolved: {} | source={}",
-            effect_kind, source_name
+            "Effect resolved: {effect_kind} | source={source_name}"
         ))
         .with_player(sa.activating_player);
         if let Some(source_id) = sa.source {

--- a/manabrew-rs/crates/manabrew-engine/src/keyword/mod.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/keyword/mod.rs
@@ -73,14 +73,14 @@ pub struct EscapeInfo {
 /// E.g. "Ward:2" with name "Ward" → Some("2").
 /// Used by keyword_gen for inline cost extraction from individual keyword strings.
 pub fn extract_keyword_cost_str<'a>(kw: &'a str, name: &str) -> Option<&'a str> {
-    let prefix = format!("{}:", name);
+    let prefix = format!("{name}:");
     kw.strip_prefix(&prefix)
 }
 
 /// Parse a keyword cost from a card's keywords list.
 /// E.g. keywords contains "Flashback:2 R", name = "Flashback" -> Some("2 R")
 pub fn parse_keyword_cost(keywords: &[String], name: &str) -> Option<String> {
-    let prefix = format!("{}:", name);
+    let prefix = format!("{name}:");
     for kw in keywords {
         if let Some(cost) = kw.strip_prefix(&prefix) {
             return Some(cost.to_string());
@@ -99,7 +99,7 @@ pub fn extract_keyword_cost(
     collection: &keyword_collection::KeywordCollection,
     name: &str,
 ) -> Option<String> {
-    let prefix = format!("{}:", name);
+    let prefix = format!("{name}:");
     for kw in collection.iter_strings() {
         if let Some(cost) = kw.strip_prefix(&prefix) {
             return Some(cost.to_string());
@@ -113,7 +113,7 @@ pub fn extract_keyword_cost_from_all<'a>(
     collections: impl IntoIterator<Item = &'a keyword_collection::KeywordCollection>,
     name: &str,
 ) -> Option<String> {
-    let prefix = format!("{}:", name);
+    let prefix = format!("{name}:");
     for coll in collections {
         for kw in coll.iter_strings() {
             if let Some(cost) = kw.strip_prefix(&prefix) {

--- a/manabrew-rs/crates/manabrew-engine/src/keyword/partner.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/keyword/partner.rs
@@ -33,7 +33,7 @@ impl Partner {
     /// Get the display title.
     pub fn get_title(&self) -> String {
         if let Some(ref with) = self.with {
-            format!("Partner \u{2014} {}", with)
+            format!("Partner \u{2014} {with}")
         } else {
             self.base.keyword.display_name().to_string()
         }

--- a/manabrew-rs/crates/manabrew-engine/src/parsing/mod.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/parsing/mod.rs
@@ -590,8 +590,7 @@ impl Params {
             self.0
                 .get(key)
                 .is_some_and(|value| value.eq_ignore_ascii_case("True")),
-            "semantic boolean param {} diverged from string params",
-            key
+            "semantic boolean param {key} diverged from string params"
         );
         result
     }
@@ -605,8 +604,7 @@ impl Params {
         debug_assert_eq!(
             result,
             self.0.get(key).and_then(|value| value.trim().parse().ok()),
-            "semantic i32 param {} diverged from string params",
-            key
+            "semantic i32 param {key} diverged from string params"
         );
         result
     }
@@ -624,8 +622,7 @@ impl Params {
         debug_assert_eq!(
             result,
             self.0.get(key).and_then(|value| value.trim().parse().ok()),
-            "semantic usize param {} diverged from string params",
-            key
+            "semantic usize param {key} diverged from string params"
         );
         result
     }
@@ -642,8 +639,7 @@ impl Params {
         debug_assert_eq!(
             result,
             self.0.get(key).and_then(|value| legacy_zone_type(value)),
-            "semantic zone param {} diverged from string params",
-            key
+            "semantic zone param {key} diverged from string params"
         );
         result
     }
@@ -664,8 +660,7 @@ impl Params {
                 .get(key)
                 .map(|value| legacy_zone_types(value))
                 .unwrap_or_default(),
-            "semantic zone-list param {} diverged from string params",
-            key
+            "semantic zone-list param {key} diverged from string params"
         );
         result
     }
@@ -782,7 +777,7 @@ impl Params {
         match self.get(key) {
             Some(v) => Some(v),
             None => {
-                eprintln!("[parse] missing required param '{}' in {}", key, context);
+                eprintln!("[parse] missing required param '{key}' in {context}");
                 None
             }
         }
@@ -1626,7 +1621,7 @@ pub fn parse_or_warn<T>(result: Option<T>, kind: &str, raw: &str) -> Option<T> {
         };
         if should_warn {
             let preview: String = trimmed.chars().take(100).collect();
-            eprintln!("[parse] failed to parse {} from: {}", kind, preview);
+            eprintln!("[parse] failed to parse {kind} from: {preview}");
         }
     }
     result

--- a/manabrew-rs/crates/manabrew-engine/src/replacement/replacement_effect.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/replacement/replacement_effect.rs
@@ -451,13 +451,10 @@ impl ReplacementEffect {
                     node.set_triggering_object(AbilityKey::Card, card_csv.as_str());
                     node.set_triggering_object(AbilityKey::ReplacedCard, card_csv.as_str());
                     node.set_triggering_object(AbilityKey::Affected, card_csv.as_str());
-                    node.set_triggering_object(
-                        AbilityKey::Origin,
-                        format!("{:?}", origin).as_str(),
-                    );
+                    node.set_triggering_object(AbilityKey::Origin, format!("{origin:?}").as_str());
                     node.set_triggering_object(
                         AbilityKey::Destination,
-                        format!("{:?}", destination).as_str(),
+                        format!("{destination:?}").as_str(),
                     );
                 }
                 ReplacementEvent::DamageToCard {
@@ -531,7 +528,7 @@ impl ReplacementEffect {
                     node.set_triggering_object(AbilityKey::Object, target_csv.as_str());
                     node.set_triggering_object(
                         AbilityKey::CounterMap,
-                        format!("{:?}:{}", counter_type, count).as_str(),
+                        format!("{counter_type:?}:{count}").as_str(),
                     );
                 }
                 ReplacementEvent::Draw {
@@ -634,7 +631,7 @@ impl ReplacementEffect {
                     node.set_triggering_object(AbilityKey::Card, target_csv.as_str());
                     node.set_triggering_object(
                         AbilityKey::CounterMap,
-                        format!("{:?}:{}", counter_type, count).as_str(),
+                        format!("{counter_type:?}:{count}").as_str(),
                     );
                 }
                 ReplacementEvent::Attached { card, target } => {

--- a/manabrew-rs/crates/manabrew-engine/src/spellability/ability_sub.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/spellability/ability_sub.rs
@@ -40,7 +40,7 @@ pub fn resolve(sa: &SpellAbility) -> String {
 
     // Last resort: describe via API type
     match sa.api {
-        Some(api) => format!("{:?} (sub-ability)", api),
+        Some(api) => format!("{api:?} (sub-ability)"),
         None => "Sub-ability".to_string(),
     }
 }

--- a/manabrew-rs/crates/manabrew-engine/src/spellability/mod.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/spellability/mod.rs
@@ -960,9 +960,9 @@ impl SpellAbility {
     /// Generate a unique key for this ability.
     /// Mirrors Java's `SpellAbility.yieldKey()`.
     pub fn yield_key(&self) -> String {
-        let api_str = self.api.map(|a| format!("{:?}", a)).unwrap_or_default();
+        let api_str = self.api.map(|a| format!("{a:?}")).unwrap_or_default();
         let source_str = self.source.map(|s| format!("{}", s.0)).unwrap_or_default();
-        format!("{}_{}", api_str, source_str)
+        format!("{api_str}_{source_str}")
     }
 
     /// Build a description from params.
@@ -1188,7 +1188,7 @@ impl SpellAbility {
         crate::perf::increment(crate::perf::Metric::SpellAbilityClones, 1);
         let mut copied = self.clone();
         if let Some(ref cost) = self.pay_costs {
-            let cost_str = format!("{:?}", cost);
+            let cost_str = format!("{cost:?}");
             let replaced = cost_str.replace(old, new);
             copied.pay_costs = Some(parse_cost(&replaced));
         }

--- a/manabrew-rs/crates/manabrew-engine/src/staticability/layer.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/staticability/layer.rs
@@ -591,10 +591,9 @@ pub fn apply_continuous_effects(game: &mut GameState) {
                         .unwrap_or(0)
                         .saturating_add(1);
                     let mut next_id_mut = next_id;
-                    let execute = format!("TrigWardGranted{}", next_id);
+                    let execute = format!("TrigWardGranted{next_id}");
                     let raw = format!(
-                        "Mode$ BecomesTarget | ValidSource$ SpellAbility.OppCtrl | ValidTarget$ Card.Self | Secondary$ True | Execute$ {} | TriggerZones$ Battlefield | TriggerDescription$ Ward",
-                        execute
+                        "Mode$ BecomesTarget | ValidSource$ SpellAbility.OppCtrl | ValidTarget$ Card.Self | Secondary$ True | Execute$ {execute} | TriggerZones$ Battlefield | TriggerDescription$ Ward"
                     );
                     if let Some(mut trig) = crate::trigger::parse_trigger(&raw, &mut next_id_mut) {
                         trig.execute = execute.clone();

--- a/manabrew-rs/crates/manabrew-engine/src/trigger/trigger_attacker_blocked.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/trigger/trigger_attacker_blocked.rs
@@ -84,6 +84,6 @@ impl TriggerBehavior for TriggerAttackerBlocked {
                 }
             })
             .unwrap_or(0);
-        format!("Attacker: {}, Number Blockers: {}", attacker, num_blockers)
+        format!("Attacker: {attacker}, Number Blockers: {num_blockers}")
     }
 }

--- a/manabrew-rs/crates/manabrew-engine/src/trigger/trigger_counter_added.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/trigger/trigger_counter_added.rs
@@ -108,9 +108,9 @@ impl TriggerBehavior for TriggerCounterAdded {
         let card = sa.get_triggering_object(crate::ability::AbilityKey::Card);
         let player = sa.get_triggering_object(crate::ability::AbilityKey::Player);
         if let Some(c) = card {
-            format!("AddedOnce: {}", c)
+            format!("AddedOnce: {c}")
         } else if let Some(p) = player {
-            format!("AddedOnce: {}", p)
+            format!("AddedOnce: {p}")
         } else {
             String::new()
         }

--- a/manabrew-rs/crates/manabrew-engine/src/trigger/trigger_entered_room.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/trigger/trigger_entered_room.rs
@@ -70,7 +70,7 @@ impl TriggerBehavior for TriggerEnteredRoom {
         sa: &SpellAbility,
     ) -> String {
         sa.get_triggering_object(crate::ability::AbilityKey::RoomName)
-            .map(|r| format!("Room: {}", r))
+            .map(|r| format!("Room: {r}"))
             .unwrap_or_default()
     }
 }

--- a/manabrew-rs/crates/manabrew-engine/src/trigger/trigger_explores.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/trigger/trigger_explores.rs
@@ -63,7 +63,7 @@ impl TriggerBehavior for TriggerExplores {
                 .unwrap_or_default()
         );
         if let Some(explored) = sa.get_triggering_object(crate::ability::AbilityKey::Explored) {
-            sb.push_str(&format!(", Explored: {}", explored));
+            sb.push_str(&format!(", Explored: {explored}"));
         }
         sb
     }

--- a/manabrew-rs/crates/manabrew-engine/src/trigger/trigger_fight_once.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/trigger/trigger_fight_once.rs
@@ -59,6 +59,6 @@ impl TriggerBehavior for TriggerFightOnce {
         let parts: Vec<&str> = fighters_csv.split(',').collect();
         let f1 = parts.first().copied().unwrap_or("");
         let f2 = parts.get(1).copied().unwrap_or("");
-        format!("Fighter 1: {}, Fighter 2: {}", f1, f2)
+        format!("Fighter 1: {f1}, Fighter 2: {f2}")
     }
 }

--- a/manabrew-rs/crates/manabrew-engine/src/trigger/trigger_handler.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/trigger/trigger_handler.rs
@@ -436,8 +436,7 @@ impl TriggerHandler {
 
             let trigger_msg = if pt.description.is_empty() {
                 format!(
-                    "Trigger fired: mode={} | api={} | source={}",
-                    trigger_mode, trigger_api, source_name
+                    "Trigger fired: mode={trigger_mode} | api={trigger_api} | source={source_name}"
                 )
             } else {
                 format!(

--- a/manabrew-rs/crates/manabrew-engine/src/trigger/wrapped_ability.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/trigger/wrapped_ability.rs
@@ -250,7 +250,7 @@ impl WrappedAbility {
         self.wrapped
             .param_value("Keyword")
             .map(|v| {
-                let kw_str = format!("{:?}", kw);
+                let kw_str = format!("{kw:?}");
                 v.eq_ignore_ascii_case(&kw_str)
             })
             .unwrap_or(false)

--- a/manabrew-rs/crates/manabrew-hub/src/storage.rs
+++ b/manabrew-rs/crates/manabrew-hub/src/storage.rs
@@ -707,7 +707,7 @@ impl Storage {
             let engines_json = preset
                 .engines
                 .as_ref()
-                .map(|engines| serde_json::to_string(engines))
+                .map(serde_json::to_string)
                 .transpose()
                 .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))?;
             tx.execute(

--- a/manabrew-rs/crates/manabrew-server/src/connection.rs
+++ b/manabrew-rs/crates/manabrew-server/src/connection.rs
@@ -508,7 +508,7 @@ async fn authenticate(
                     success: false,
                     player_id: None,
                     reconnected: None,
-                    error: Some(format!("Username '{}' is already taken", username)),
+                    error: Some(format!("Username '{username}' is already taken")),
                 };
                 send_msg(sender, &reply);
                 return Err(ServerError::DuplicateUsername(username));

--- a/manabrew-rs/crates/manabrew-server/src/error.rs
+++ b/manabrew-rs/crates/manabrew-server/src/error.rs
@@ -25,10 +25,10 @@ pub enum ServerError {
 impl fmt::Display for ServerError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::AuthFailed(msg) => write!(f, "Authentication failed: {}", msg),
+            Self::AuthFailed(msg) => write!(f, "Authentication failed: {msg}"),
             Self::AuthTimeout => write!(f, "Authentication timed out"),
-            Self::RoomNotFound(id) => write!(f, "Room not found: {}", id),
-            Self::RoomFull(id) => write!(f, "Room is full: {}", id),
+            Self::RoomNotFound(id) => write!(f, "Room not found: {id}"),
+            Self::RoomFull(id) => write!(f, "Room is full: {id}"),
             Self::IncorrectPassword => write!(f, "Incorrect room password"),
             Self::NotInRoom => write!(f, "You are not in a room"),
             Self::NotHost => write!(f, "Only the host can do that"),
@@ -37,12 +37,12 @@ impl fmt::Display for ServerError {
             Self::GameAlreadyStarted => write!(f, "Game has already started"),
             Self::GameNotInProgress => write!(f, "No game is in progress"),
             Self::FormatNotChosen => write!(f, "A format must be chosen before starting"),
-            Self::InvalidDraftConfig(msg) => write!(f, "Invalid draft config: {}", msg),
+            Self::InvalidDraftConfig(msg) => write!(f, "Invalid draft config: {msg}"),
             Self::InvalidResumeToken => write!(f, "Invalid resume token"),
-            Self::AlreadyInRoom(id) => write!(f, "Already in room: {}", id),
-            Self::DuplicateUsername(name) => write!(f, "Username already taken: {}", name),
-            Self::WebSocket(e) => write!(f, "WebSocket error: {}", e),
-            Self::Serde(e) => write!(f, "Serialization error: {}", e),
+            Self::AlreadyInRoom(id) => write!(f, "Already in room: {id}"),
+            Self::DuplicateUsername(name) => write!(f, "Username already taken: {name}"),
+            Self::WebSocket(e) => write!(f, "WebSocket error: {e}"),
+            Self::Serde(e) => write!(f, "Serialization error: {e}"),
         }
     }
 }

--- a/manabrew-rs/crates/parity-debugger/src/main.rs
+++ b/manabrew-rs/crates/parity-debugger/src/main.rs
@@ -2325,8 +2325,7 @@ impl eframe::App for App {
                                     ui.colored_label(
                                         theme::FG_2,
                                         format!(
-                                            "decisions {} · callbacks {}",
-                                            decision_count, callback_count
+                                            "decisions {decision_count} · callbacks {callback_count}"
                                         ),
                                     );
                                 }
@@ -3550,7 +3549,7 @@ fn render_deck_modal(ctx: &egui::Context, app: &mut App) {
                                 .collect();
                             for (idx, name, deck1, deck2) in preset_rows {
                                 let searchable =
-                                    format!("{} {} {}", name, deck1, deck2).to_ascii_lowercase();
+                                    format!("{name} {deck1} {deck2}").to_ascii_lowercase();
                                 if !query.is_empty() && !searchable.contains(&query) {
                                     continue;
                                 }
@@ -3558,7 +3557,7 @@ fn render_deck_modal(ctx: &egui::Context, app: &mut App) {
                                 if selectable_modal_row(
                                     ui,
                                     &name,
-                                    &format!("{} vs {}", deck1, deck2),
+                                    &format!("{deck1} vs {deck2}"),
                                     "↵",
                                     selected,
                                 )
@@ -4318,7 +4317,7 @@ fn render_timeline_rows(
             },
             "●",
         );
-        row_ui.colored_label(theme::FG_3, format!("#{:02}", idx));
+        row_ui.colored_label(theme::FG_3, format!("#{idx:02}"));
         row_ui.colored_label(theme::FG_2, format!("T{}", key.turn));
         row_ui.colored_label(row_kind_color(&key.phase), phase_label);
         row_ui.label(format!("P{}", key.priority_player));
@@ -4472,12 +4471,12 @@ fn render_compare_timeline_rows(
             },
             "●",
         );
-        row_ui.colored_label(theme::FG_3, format!("#{:02}", idx));
+        row_ui.colored_label(theme::FG_3, format!("#{idx:02}"));
         row_ui.colored_label(theme::FG_2, format!("T{}", row.key.turn));
         row_ui.colored_label(row_kind_color(&row.key.phase), phase_label);
         row_ui.label(format!("P{}", row.key.priority_player));
         if occurrence > 1 {
-            row_ui.colored_label(theme::FG_3, format!("·{}", occurrence));
+            row_ui.colored_label(theme::FG_3, format!("·{occurrence}"));
         }
         if row.rust_index.is_none() {
             row_ui.colored_label(theme::RUST, "rust ·");
@@ -5069,7 +5068,7 @@ fn render_action_space_event_card(ui: &mut egui::Ui, callback: &CallbackRecord) 
             // Skip path: harness emits "SKIPPED <reason>" when it bails on enumeration.
             if let Some(reason) = raw.strip_prefix("SKIPPED") {
                 ui.label(
-                    egui::RichText::new(format!("skipped:{}", reason))
+                    egui::RichText::new(format!("skipped:{reason}"))
                         .monospace()
                         .italics()
                         .color(theme::FG_3),

--- a/manabrew-rs/crates/parity/src/callback_fmt.rs
+++ b/manabrew-rs/crates/parity/src/callback_fmt.rs
@@ -160,7 +160,7 @@ impl ParityFormat for (Option<CardId>, i32) {
             Some(c) => ctx.card(*c),
             None => "defender".to_string(),
         };
-        format!("{}={}", target_str, dmg)
+        format!("{target_str}={dmg}")
     }
 }
 
@@ -247,7 +247,7 @@ impl ParityFormat for PlayerAction {
                 format!("ActivateMana({}, {:?})", ctx.card(*cid), idx)
             }
             // For other variants, fall back to Debug but resolve card IDs where possible.
-            other => format!("{:?}", other),
+            other => format!("{other:?}"),
         }
     }
 }
@@ -354,7 +354,7 @@ fn fmt_mana_atom_set(atom: u16) -> String {
 
 impl ParityFormat for RollSwapChoice {
     fn parity_fmt(&self, _ctx: &FmtCtx<'_>) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 
@@ -483,28 +483,28 @@ impl CallbackArgDisplay for CardId {
         if let Some(ctx) = ctx {
             ctx.card(*self)
         } else {
-            format!("{:?}", self)
+            format!("{self:?}")
         }
     }
 }
 impl CallbackArgDisplay for ZoneType {
     fn callback_arg_display(&self, _ctx: Option<&FmtCtx<'_>>) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 impl CallbackArgDisplay for DefenderId {
     fn callback_arg_display(&self, _ctx: Option<&FmtCtx<'_>>) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 impl CallbackArgDisplay for BinaryChoiceKind {
     fn callback_arg_display(&self, _ctx: Option<&FmtCtx<'_>>) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 impl CallbackArgDisplay for ApiType {
     fn callback_arg_display(&self, _ctx: Option<&FmtCtx<'_>>) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 

--- a/manabrew-rs/crates/parity/src/card_pool.rs
+++ b/manabrew-rs/crates/parity/src/card_pool.rs
@@ -257,11 +257,11 @@ fn format_example_line(example: &ScriptScanExample) -> String {
     let key = example
         .key
         .as_ref()
-        .map(|key| format!(" key={}", key))
+        .map(|key| format!(" key={key}"))
         .unwrap_or_default();
     let values = match (&example.previous_value, &example.value) {
-        (Some(previous), Some(value)) => format!(" [{} -> {}]", previous, value),
-        (_, Some(value)) => format!(" [{}]", value),
+        (Some(previous), Some(value)) => format!(" [{previous} -> {value}]"),
+        (_, Some(value)) => format!(" [{value}]"),
         _ => String::new(),
     };
     format!(
@@ -376,7 +376,7 @@ impl CardPool {
             // Check static abilities
             if all_parse {
                 for raw in &face.static_abilities {
-                    let prefixed = format!("S$ {}", raw);
+                    let prefixed = format!("S$ {raw}");
                     if parse_static_ability(&prefixed).is_none() {
                         all_parse = false;
                         break;
@@ -387,7 +387,7 @@ impl CardPool {
             // Check replacement effects
             if all_parse {
                 for raw in &face.replacements {
-                    let prefixed = format!("R$ {}", raw);
+                    let prefixed = format!("R$ {raw}");
                     if parse_replacement_effect(&prefixed).is_none() {
                         all_parse = false;
                         break;
@@ -999,7 +999,7 @@ fn record_param_diagnostics(face: &CardFace, stats: &mut PoolStats) {
         record_raw_param_diagnostics(raw, &face.name, idx + 1, "Replacement", stats);
     }
     for (idx, raw) in face.static_abilities.iter().enumerate() {
-        let prefixed = format!("S$ {}", raw);
+        let prefixed = format!("S$ {raw}");
         record_raw_param_diagnostics(&prefixed, &face.name, idx + 1, "StaticAbility", stats);
     }
 }
@@ -1029,7 +1029,7 @@ fn synthesize_face_script(face: &CardFace) -> String {
     push_script_line(&mut raw, "ManaCost", &face.mana_cost.to_string());
     push_script_line(&mut raw, "Types", &face.type_line.to_string());
     if let (Some(power), Some(toughness)) = (face.int_power, face.int_toughness) {
-        push_script_line(&mut raw, "PT", &format!("{}/{}", power, toughness));
+        push_script_line(&mut raw, "PT", &format!("{power}/{toughness}"));
     }
     for keyword in &face.keywords {
         push_script_line(&mut raw, "K", keyword);
@@ -1047,7 +1047,7 @@ fn synthesize_face_script(face: &CardFace) -> String {
         push_script_line(&mut raw, "R", replacement);
     }
     for (name, value) in &face.svars {
-        push_script_line(&mut raw, "SVar", &format!("{}:{}", name, value));
+        push_script_line(&mut raw, "SVar", &format!("{name}:{value}"));
     }
     raw
 }
@@ -1085,7 +1085,7 @@ fn record_raw_param_diagnostics(
         }
         if stats.examples.len() < 16 {
             stats.examples.push(ScriptScanExample {
-                file: format!("{} {}", card_name, source),
+                file: format!("{card_name} {source}"),
                 line_no,
                 kind,
                 segment: diagnostic.segment.to_string(),

--- a/manabrew-rs/crates/parity/src/comparator.rs
+++ b/manabrew-rs/crates/parity/src/comparator.rs
@@ -74,7 +74,7 @@ pub fn compare(index: usize, rust: &StateSnapshot, java: &StateSnapshot) -> Vec<
     // Per-player comparison
     let max_players = rust.players.len().max(java.players.len());
     for i in 0..max_players {
-        let prefix = format!("players[{}]", i);
+        let prefix = format!("players[{i}]");
         match (rust.players.get(i), java.players.get(i)) {
             (Some(rp), Some(jp)) => {
                 compare_players(&mut divs, index, turn, &phase, &prefix, rp, jp);
@@ -84,7 +84,7 @@ pub fn compare(index: usize, rust: &StateSnapshot, java: &StateSnapshot) -> Vec<
                     index,
                     turn,
                     &phase,
-                    &format!("{}.exists", prefix),
+                    &format!("{prefix}.exists"),
                     &"present",
                     &"missing",
                 ));
@@ -94,7 +94,7 @@ pub fn compare(index: usize, rust: &StateSnapshot, java: &StateSnapshot) -> Vec<
                     index,
                     turn,
                     &phase,
-                    &format!("{}.exists", prefix),
+                    &format!("{prefix}.exists"),
                     &"missing",
                     &"present",
                 ));
@@ -146,7 +146,7 @@ fn compare_players(
             snapshot_index: index,
             turn,
             phase: phase.to_string(),
-            field: format!("{}.library_top", prefix),
+            field: format!("{prefix}.library_top"),
             rust_value: format!("{:?}", rust.library_top),
             java_value: format!("{:?}", java.library_top),
         });
@@ -158,7 +158,7 @@ fn compare_players(
         index,
         turn,
         phase,
-        &format!("{}.graveyard", prefix),
+        &format!("{prefix}.graveyard"),
         &rust.graveyard,
         &java.graveyard,
     );
@@ -167,7 +167,7 @@ fn compare_players(
         index,
         turn,
         phase,
-        &format!("{}.hand", prefix),
+        &format!("{prefix}.hand"),
         &rust.hand,
         &java.hand,
     );
@@ -176,7 +176,7 @@ fn compare_players(
         index,
         turn,
         phase,
-        &format!("{}.exile", prefix),
+        &format!("{prefix}.exile"),
         &rust.exile,
         &java.exile,
     );
@@ -187,7 +187,7 @@ fn compare_players(
         index,
         turn,
         phase,
-        &format!("{}.battlefield", prefix),
+        &format!("{prefix}.battlefield"),
         &rust.battlefield,
         &java.battlefield,
     );
@@ -208,8 +208,8 @@ fn compare_name_list(
             turn,
             phase,
             field,
-            &format!("{:?}", rust),
-            &format!("{:?}", java),
+            &format!("{rust:?}"),
+            &format!("{java:?}"),
         ));
     }
 }
@@ -230,14 +230,14 @@ fn compare_battlefield(
             index,
             turn,
             phase,
-            &format!("{}.count", prefix),
+            &format!("{prefix}.count"),
             &rust.len(),
             &java.len(),
         ));
     }
 
     for i in 0..max {
-        let card_prefix = format!("{}[{}]", prefix, i);
+        let card_prefix = format!("{prefix}[{i}]");
         match (rust.get(i), java.get(i)) {
             (Some(rc), Some(jc)) => {
                 if rc.name != jc.name {
@@ -245,7 +245,7 @@ fn compare_battlefield(
                         index,
                         turn,
                         phase,
-                        &format!("{}.name", card_prefix),
+                        &format!("{card_prefix}.name"),
                         &rc.name,
                         &jc.name,
                     ));
@@ -255,7 +255,7 @@ fn compare_battlefield(
                         index,
                         turn,
                         phase,
-                        &format!("{}.tapped", card_prefix),
+                        &format!("{card_prefix}.tapped"),
                         &rc.tapped,
                         &jc.tapped,
                     ));
@@ -265,7 +265,7 @@ fn compare_battlefield(
                         index,
                         turn,
                         phase,
-                        &format!("{}.power", card_prefix),
+                        &format!("{card_prefix}.power"),
                         &format!("{:?}", rc.power),
                         &format!("{:?}", jc.power),
                     ));
@@ -275,7 +275,7 @@ fn compare_battlefield(
                         index,
                         turn,
                         phase,
-                        &format!("{}.toughness", card_prefix),
+                        &format!("{card_prefix}.toughness"),
                         &format!("{:?}", rc.toughness),
                         &format!("{:?}", jc.toughness),
                     ));
@@ -285,7 +285,7 @@ fn compare_battlefield(
                         index,
                         turn,
                         phase,
-                        &format!("{}.damage", card_prefix),
+                        &format!("{card_prefix}.damage"),
                         &rc.damage,
                         &jc.damage,
                     ));
@@ -305,7 +305,7 @@ fn compare_battlefield(
                         index,
                         turn,
                         phase,
-                        &format!("{}.summoning_sick", card_prefix),
+                        &format!("{card_prefix}.summoning_sick"),
                         &rc.summoning_sick,
                         &jc.summoning_sick,
                     ));
@@ -315,7 +315,7 @@ fn compare_battlefield(
                         index,
                         turn,
                         phase,
-                        &format!("{}.counters", card_prefix),
+                        &format!("{card_prefix}.counters"),
                         &format!("{:?}", rc.counters),
                         &format!("{:?}", jc.counters),
                     ));
@@ -325,7 +325,7 @@ fn compare_battlefield(
                         index,
                         turn,
                         phase,
-                        &format!("{}.controller", card_prefix),
+                        &format!("{card_prefix}.controller"),
                         &rc.controller,
                         &jc.controller,
                     ));
@@ -336,7 +336,7 @@ fn compare_battlefield(
                     index,
                     turn,
                     phase,
-                    &format!("{}.exists", card_prefix),
+                    &format!("{card_prefix}.exists"),
                     &rc.name,
                     &"<missing>",
                 ));
@@ -346,7 +346,7 @@ fn compare_battlefield(
                     index,
                     turn,
                     phase,
-                    &format!("{}.exists", card_prefix),
+                    &format!("{card_prefix}.exists"),
                     &"<missing>",
                     &jc.name,
                 ));

--- a/manabrew-rs/crates/parity/src/deck_generator.rs
+++ b/manabrew-rs/crates/parity/src/deck_generator.rs
@@ -138,7 +138,7 @@ pub fn generate_deck(rng: &mut JavaRandom, pool: &CardPool) -> DeckSpec {
 /// (e.g., "Zuko, Firebending Master").
 pub fn format_inline(spec: &DeckSpec) -> String {
     spec.iter()
-        .map(|(name, count)| format!("{}*{}", name, count))
+        .map(|(name, count)| format!("{name}*{count}"))
         .collect::<Vec<_>>()
         .join("|")
 }
@@ -160,16 +160,15 @@ pub fn parse_inline(s: &str) -> Result<DeckSpec, String> {
                 let count_str = &entry[pos + 1..];
                 let count: usize = count_str
                     .parse()
-                    .map_err(|_| format!("Invalid count '{}' in entry '{}'", count_str, entry))?;
+                    .map_err(|_| format!("Invalid count '{count_str}' in entry '{entry}'"))?;
                 if name.is_empty() {
-                    return Err(format!("Empty card name in entry '{}'", entry));
+                    return Err(format!("Empty card name in entry '{entry}'"));
                 }
                 result.push((name, count));
             }
             None => {
                 return Err(format!(
-                    "Invalid entry '{}': expected 'Name*Count' format",
-                    entry
+                    "Invalid entry '{entry}': expected 'Name*Count' format"
                 ));
             }
         }

--- a/manabrew-rs/crates/parity/src/deterministic_agent.rs
+++ b/manabrew-rs/crates/parity/src/deterministic_agent.rs
@@ -881,7 +881,7 @@ impl PlayerAgent for DeterministicAgent {
             ));
         }
         if let Some(stack_id) = sa.target_chosen.target_stack_entry {
-            target_names.push(format!("Stack({})", stack_id));
+            target_names.push(format!("Stack({stack_id})"));
         }
         if !target_names.is_empty() {
             self.emit_callback(

--- a/manabrew-rs/crates/parity/src/java_bridge.rs
+++ b/manabrew-rs/crates/parity/src/java_bridge.rs
@@ -117,7 +117,7 @@ impl JavaBridge {
             cmd.arg("-Dforge.parity.rng.trace=true");
         }
         if let Ok(bounds) = std::env::var("FORGE_RNG_BT_BOUNDS") {
-            cmd.arg(format!("-Dforge.parity.rng.bt.bounds={}", bounds));
+            cmd.arg(format!("-Dforge.parity.rng.bt.bounds={bounds}"));
         }
         if std::env::var("FORGE_RNG_BT_UNBOUNDED").is_ok() {
             cmd.arg("-Dforge.parity.rng.bt.unbounded=true");
@@ -167,7 +167,7 @@ impl JavaBridge {
             if forge_gui.join("res").join("cardsfolder").exists() {
                 let forge_gui_str = format!("{}/", forge_gui.display());
                 if verbose {
-                    eprintln!("[parity]   auto-detected forge-home: {}", forge_gui_str);
+                    eprintln!("[parity]   auto-detected forge-home: {forge_gui_str}");
                 }
                 cmd.arg("--forge-home").arg(forge_gui_str);
             }
@@ -177,7 +177,7 @@ impl JavaBridge {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
-            .map_err(|e| JavaBridgeError::SpawnError(format!("Failed to spawn java: {}", e)))?;
+            .map_err(|e| JavaBridgeError::SpawnError(format!("Failed to spawn java: {e}")))?;
 
         // Read stderr in a background thread for diagnostics
         let stderr = child.stderr.take();
@@ -201,7 +201,7 @@ impl JavaBridge {
                         || line.contains("[rng-java-bt")
                         || line.contains("  at ")
                     {
-                        eprintln!("[java] {}", line);
+                        eprintln!("[java] {line}");
                     }
                 }
             }
@@ -219,7 +219,7 @@ impl JavaBridge {
 
         for line_result in reader.lines() {
             let line = line_result.map_err(|e| {
-                JavaBridgeError::ProtocolError(format!("Failed to read stdout: {}", e))
+                JavaBridgeError::ProtocolError(format!("Failed to read stdout: {e}"))
             })?;
 
             let line = line.trim().to_string();
@@ -250,11 +250,8 @@ impl JavaBridge {
                 }
                 Err(e) => {
                     if verbose {
-                        eprintln!(
-                            "[parity] Warning: failed to parse Java output as snapshot: {}",
-                            e
-                        );
-                        eprintln!("[parity]   line: {}", line);
+                        eprintln!("[parity] Warning: failed to parse Java output as snapshot: {e}");
+                        eprintln!("[parity]   line: {line}");
                     }
                 }
             }
@@ -264,21 +261,18 @@ impl JavaBridge {
         let _ = stderr_handle.join();
         let status = child
             .wait()
-            .map_err(|e| JavaBridgeError::SpawnError(format!("Failed to wait for java: {}", e)))?;
+            .map_err(|e| JavaBridgeError::SpawnError(format!("Failed to wait for java: {e}")))?;
 
         if !status.success() {
             let code = status.code().unwrap_or(-1);
             if verbose {
-                eprintln!("[parity] Java process exited with code {}", code);
+                eprintln!("[parity] Java process exited with code {code}");
             }
             return Err(JavaBridgeError::ProcessError(code));
         }
 
         if verbose {
-            eprintln!(
-                "[parity] Java harness completed: {} snapshot(s)",
-                snapshot_count
-            );
+            eprintln!("[parity] Java harness completed: {snapshot_count} snapshot(s)");
         }
         Ok(JavaMatchupData { log })
     }
@@ -363,9 +357,9 @@ impl JavaServer {
         // Pass preset decks directory list as JVM system property (must come before -jar).
         // See `decks_dir_property` for multi-dir semantics.
         let dd_prop = decks_dir_property(config.decks_dir.as_deref());
-        cmd.arg(format!("-Dpreset.decks.dir={}", dd_prop));
+        cmd.arg(format!("-Dpreset.decks.dir={dd_prop}"));
         if verbose {
-            eprintln!("[parity]   preset.decks.dir = {}", dd_prop);
+            eprintln!("[parity]   preset.decks.dir = {dd_prop}");
         }
 
         // Forward RNG trace flag to Java engine
@@ -373,7 +367,7 @@ impl JavaServer {
             cmd.arg("-Dforge.parity.rng.trace=true");
         }
         if let Ok(bounds) = std::env::var("FORGE_RNG_BT_BOUNDS") {
-            cmd.arg(format!("-Dforge.parity.rng.bt.bounds={}", bounds));
+            cmd.arg(format!("-Dforge.parity.rng.bt.bounds={bounds}"));
         }
         if std::env::var("FORGE_RNG_BT_UNBOUNDED").is_ok() {
             cmd.arg("-Dforge.parity.rng.bt.unbounded=true");
@@ -403,7 +397,7 @@ impl JavaServer {
             if forge_gui.join("res").join("cardsfolder").exists() {
                 let forge_gui_str = format!("{}/", forge_gui.display());
                 if verbose {
-                    eprintln!("[parity]   auto-detected forge-home: {}", forge_gui_str);
+                    eprintln!("[parity]   auto-detected forge-home: {forge_gui_str}");
                 }
                 cmd.arg("--forge-home").arg(forge_gui_str);
             }
@@ -414,7 +408,7 @@ impl JavaServer {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
-            .map_err(|e| JavaBridgeError::SpawnError(format!("Failed to spawn java: {}", e)))?;
+            .map_err(|e| JavaBridgeError::SpawnError(format!("Failed to spawn java: {e}")))?;
 
         let stdin = child
             .stdin
@@ -447,7 +441,7 @@ impl JavaServer {
                         || line.contains("[rng-java-bt")
                         || line.contains("  at ")
                     {
-                        eprintln!("[java] {}", line);
+                        eprintln!("[java] {line}");
                     }
                 }
             }
@@ -494,18 +488,18 @@ impl JavaServer {
 
         // Write request as a single JSON line
         let request_json = serde_json::to_string(&request).map_err(|e| {
-            JavaBridgeError::ProtocolError(format!("Failed to serialize request: {}", e))
+            JavaBridgeError::ProtocolError(format!("Failed to serialize request: {e}"))
         })?;
 
         self.stdin.write_all(request_json.as_bytes()).map_err(|e| {
-            JavaBridgeError::ProtocolError(format!("Failed to write to stdin: {}", e))
-        })?;
-        self.stdin.write_all(b"\n").map_err(|e| {
-            JavaBridgeError::ProtocolError(format!("Failed to write newline: {}", e))
+            JavaBridgeError::ProtocolError(format!("Failed to write to stdin: {e}"))
         })?;
         self.stdin
+            .write_all(b"\n")
+            .map_err(|e| JavaBridgeError::ProtocolError(format!("Failed to write newline: {e}")))?;
+        self.stdin
             .flush()
-            .map_err(|e| JavaBridgeError::ProtocolError(format!("Failed to flush stdin: {}", e)))?;
+            .map_err(|e| JavaBridgeError::ProtocolError(format!("Failed to flush stdin: {e}")))?;
 
         let mut log = Vec::new();
         let mut snapshot_count = 0usize;
@@ -514,7 +508,7 @@ impl JavaServer {
         loop {
             line_buf.clear();
             let bytes_read = self.stdout.read_line(&mut line_buf).map_err(|e| {
-                JavaBridgeError::ProtocolError(format!("Failed to read stdout: {}", e))
+                JavaBridgeError::ProtocolError(format!("Failed to read stdout: {e}"))
             })?;
 
             if bytes_read == 0 {
@@ -532,8 +526,7 @@ impl JavaServer {
                 if sentinel.done {
                     if let Some(err) = sentinel.error {
                         return Err(JavaBridgeError::ProtocolError(format!(
-                            "Java game error: {}",
-                            err
+                            "Java game error: {err}"
                         )));
                     }
                     break;
@@ -564,8 +557,7 @@ impl JavaServer {
                 Err(e) => {
                     if self.verbose {
                         eprintln!(
-                            "[parity] Warning: failed to parse Java output: {} (line: {})",
-                            e, line
+                            "[parity] Warning: failed to parse Java output: {e} (line: {line})"
                         );
                     }
                 }
@@ -573,10 +565,7 @@ impl JavaServer {
         }
 
         if self.verbose {
-            eprintln!(
-                "[parity] Java server matchup completed: {} snapshot(s)",
-                snapshot_count
-            );
+            eprintln!("[parity] Java server matchup completed: {snapshot_count} snapshot(s)");
         }
         Ok(JavaMatchupData { log })
     }
@@ -621,18 +610,18 @@ impl JavaServer {
         };
 
         let request_json = serde_json::to_string(&request).map_err(|e| {
-            JavaBridgeError::ProtocolError(format!("Failed to serialize request: {}", e))
+            JavaBridgeError::ProtocolError(format!("Failed to serialize request: {e}"))
         })?;
 
         self.stdin.write_all(request_json.as_bytes()).map_err(|e| {
-            JavaBridgeError::ProtocolError(format!("Failed to write to stdin: {}", e))
-        })?;
-        self.stdin.write_all(b"\n").map_err(|e| {
-            JavaBridgeError::ProtocolError(format!("Failed to write newline: {}", e))
+            JavaBridgeError::ProtocolError(format!("Failed to write to stdin: {e}"))
         })?;
         self.stdin
+            .write_all(b"\n")
+            .map_err(|e| JavaBridgeError::ProtocolError(format!("Failed to write newline: {e}")))?;
+        self.stdin
             .flush()
-            .map_err(|e| JavaBridgeError::ProtocolError(format!("Failed to flush stdin: {}", e)))?;
+            .map_err(|e| JavaBridgeError::ProtocolError(format!("Failed to flush stdin: {e}")))?;
 
         let mut log = Vec::new();
         let mut snapshot_count = 0usize;
@@ -642,7 +631,7 @@ impl JavaServer {
         loop {
             line_buf.clear();
             let bytes_read = self.stdout.read_line(&mut line_buf).map_err(|e| {
-                JavaBridgeError::ProtocolError(format!("Failed to read stdout: {}", e))
+                JavaBridgeError::ProtocolError(format!("Failed to read stdout: {e}"))
             })?;
 
             if bytes_read == 0 {
@@ -660,8 +649,7 @@ impl JavaServer {
                 if sentinel.done {
                     if let Some(err) = sentinel.error {
                         return Err(JavaBridgeError::ProtocolError(format!(
-                            "Java game error: {}",
-                            err
+                            "Java game error: {err}"
                         )));
                     }
                     break;
@@ -711,8 +699,7 @@ impl JavaServer {
                 Err(e) => {
                     if self.verbose {
                         eprintln!(
-                            "[parity] Warning: failed to parse Java output: {} (line: {})",
-                            e, line
+                            "[parity] Warning: failed to parse Java output: {e} (line: {line})"
                         );
                     }
                 }
@@ -749,7 +736,7 @@ impl JavaServer {
             match self.child.try_wait() {
                 Ok(Some(status)) => {
                     if self.verbose {
-                        eprintln!("[parity] Java server exited: {}", status);
+                        eprintln!("[parity] Java server exited: {status}");
                     }
                     return;
                 }
@@ -764,7 +751,7 @@ impl JavaServer {
                 }
                 Err(e) => {
                     if self.verbose {
-                        eprintln!("[parity] Error waiting for Java server: {}", e);
+                        eprintln!("[parity] Error waiting for Java server: {e}");
                     }
                     return;
                 }
@@ -874,14 +861,13 @@ fn resolve_java_bin(verbose: bool) -> String {
         let version = extract_jdk_version(&dir_name).unwrap_or(17); // assume OK if can't parse
         if version >= 17 && bin.exists() {
             if verbose {
-                eprintln!("[parity]   using JAVA_HOME (Java {}): {}", version, home);
+                eprintln!("[parity]   using JAVA_HOME (Java {version}): {home}");
             }
             return bin.to_string_lossy().to_string();
         }
         if verbose {
             eprintln!(
-                "[parity]   JAVA_HOME points to Java {} (<17), searching for newer JDK...",
-                version
+                "[parity]   JAVA_HOME points to Java {version} (<17), searching for newer JDK..."
             );
         }
     }
@@ -945,10 +931,10 @@ pub enum JavaBridgeError {
 impl std::fmt::Display for JavaBridgeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            JavaBridgeError::SpawnError(msg) => write!(f, "Failed to spawn Java: {}", msg),
-            JavaBridgeError::ProtocolError(msg) => write!(f, "Protocol error: {}", msg),
+            JavaBridgeError::SpawnError(msg) => write!(f, "Failed to spawn Java: {msg}"),
+            JavaBridgeError::ProtocolError(msg) => write!(f, "Protocol error: {msg}"),
             JavaBridgeError::ProcessError(code) => {
-                write!(f, "Java process exited with code {}", code)
+                write!(f, "Java process exited with code {code}")
             }
         }
     }

--- a/manabrew-rs/crates/parity/src/java_cache.rs
+++ b/manabrew-rs/crates/parity/src/java_cache.rs
@@ -259,7 +259,7 @@ impl JavaCache {
         };
         // Shard by first 2 hex chars to avoid giant flat directories
         let shard = &hash[..2];
-        self.cache_dir.join(shard).join(format!("{}.json", hash))
+        self.cache_dir.join(shard).join(format!("{hash}.json"))
     }
 }
 

--- a/manabrew-rs/crates/parity/src/java_random.rs
+++ b/manabrew-rs/crates/parity/src/java_random.rs
@@ -110,7 +110,7 @@ impl GameRng for JavaGameRng {
         let v = self.0.borrow_mut().next_int(bound);
         if std::env::var("FORGE_RNG_BT").is_ok() && bound == 1 {
             let bt = std::backtrace::Backtrace::force_capture();
-            eprintln!("[RNG_BT] next_int(1) backtrace:\n{}", bt);
+            eprintln!("[RNG_BT] next_int(1) backtrace:\n{bt}");
         }
         v
     }

--- a/manabrew-rs/crates/parity/src/main.rs
+++ b/manabrew-rs/crates/parity/src/main.rs
@@ -387,7 +387,7 @@ fn load_data_or_exit(cli: &Cli) -> runner::LoadedData {
     match runner::load_data(cli.cards_dir.as_deref(), cli.is_verbose()) {
         Ok(d) => d,
         Err(e) => {
-            eprintln!("[parity] Load error: {}", e);
+            eprintln!("[parity] Load error: {e}");
             std::process::exit(1);
         }
     }
@@ -498,10 +498,7 @@ fn run_multi_game_mode(cli: &Cli) {
         match ServerPool::spawn(workers, &server_config) {
             Ok(pool) => {
                 if cli.is_verbose() {
-                    eprintln!(
-                        "[parity] Multi-game mode: {} Java worker(s), {} games",
-                        workers, total
-                    );
+                    eprintln!("[parity] Multi-game mode: {workers} Java worker(s), {total} games");
                 }
                 let completed = AtomicUsize::new(0);
                 let mut indexed: Vec<(usize, MatchupResult)> = seeds
@@ -568,7 +565,7 @@ fn run_multi_game_mode(cli: &Cli) {
                 results
             }
             Err(e) => {
-                eprintln!("[parity] Failed to spawn Java server pool: {}", e);
+                eprintln!("[parity] Failed to spawn Java server pool: {e}");
                 eprintln!("[parity] Falling back to one-shot mode");
                 let mut results: Vec<MatchupResult> = Vec::with_capacity(total);
                 for (i, seed) in seeds.iter().copied().enumerate() {
@@ -736,10 +733,7 @@ fn game_seeds(start_seed: u64, games: usize) -> Vec<u64> {
     (0..games)
         .map(|i| {
             start_seed.checked_add(i as u64).unwrap_or_else(|| {
-                eprintln!(
-                    "[parity] Seed overflow: start_seed={} games={}",
-                    start_seed, games
-                );
+                eprintln!("[parity] Seed overflow: start_seed={start_seed} games={games}");
                 std::process::exit(1);
             })
         })
@@ -752,7 +746,7 @@ fn run_rust_only_mode(cli: &Cli) {
     let data = match runner::load_data(config.cards_dir.as_deref(), cli.is_verbose()) {
         Ok(d) => d,
         Err(e) => {
-            eprintln!("[parity] Load error: {}", e);
+            eprintln!("[parity] Load error: {e}");
             std::process::exit(1);
         }
     };
@@ -761,7 +755,7 @@ fn run_rust_only_mode(cli: &Cli) {
         Ok(trace) => {
             let mut output = match cli.format.as_str() {
                 "json" => serde_json::to_string_pretty(&trace)
-                    .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e)),
+                    .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}")),
                 _ => report::format_trace_text(&trace),
             };
             if cli.format != "json" {
@@ -781,7 +775,7 @@ fn run_rust_only_mode(cli: &Cli) {
             write_output(cli, &output);
         }
         Err(e) => {
-            eprintln!("[parity] Error: {}", e);
+            eprintln!("[parity] Error: {e}");
             std::process::exit(1);
         }
     }
@@ -864,7 +858,7 @@ fn run_matrix_mode(cli: &Cli) {
     let valid = available_presets(&decks_dirs);
     for d in &deck_names {
         if !valid.contains(d) {
-            eprintln!("[parity] Unknown deck '{}'. Available: {:?}", d, valid);
+            eprintln!("[parity] Unknown deck '{d}'. Available: {valid:?}");
             std::process::exit(1);
         }
     }
@@ -936,7 +930,7 @@ fn run_matrix_mode(cli: &Cli) {
         match ServerPool::spawn(num_workers.max(1), &server_config) {
             Ok(pool) => Some(pool),
             Err(e) => {
-                eprintln!("[parity] Failed to spawn Java server pool: {}", e);
+                eprintln!("[parity] Failed to spawn Java server pool: {e}");
                 eprintln!("[parity] Falling back to one-shot mode");
                 None
             }
@@ -967,10 +961,7 @@ fn run_matrix_mode(cli: &Cli) {
                 Some(c)
             }
             Err(e) => {
-                eprintln!(
-                    "[parity] Failed to open Java cache: {} (continuing without)",
-                    e
-                );
+                eprintln!("[parity] Failed to open Java cache: {e} (continuing without)");
                 None
             }
         }
@@ -1419,7 +1410,7 @@ fn render_side_by_side(
             let passed = abs_snap < divergent_snapshot;
             let color = if passed { "\x1b[32m" } else { "\x1b[31m" };
             let status_label = if passed { "✅" } else { "❌" };
-            let label = format!(" snapshot {} {} ", abs_snap, status_label);
+            let label = format!(" snapshot {abs_snap} {status_label} ");
             let total = lw + rw + ROW_LABEL_WIDTH + SEPARATOR_WIDTH;
             let pad = total.saturating_sub(label.chars().count());
             let left = pad / 2;
@@ -1523,9 +1514,9 @@ fn run_fuzz_mode(cli: &Cli) {
     // Discover card pool
     let (pool, pool_stats) = CardPool::discover(&data.db);
     if cli.is_verbose() {
-        eprintln!("[parity] {}", pool_stats);
+        eprintln!("[parity] {pool_stats}");
         for example in pool_stats.example_lines() {
-            eprintln!("[parity] pool diagnostic example: {}", example);
+            eprintln!("[parity] pool diagnostic example: {example}");
         }
     }
 
@@ -1549,7 +1540,7 @@ fn run_fuzz_mode(cli: &Cli) {
         match JavaServer::spawn(&server_config) {
             Ok(s) => Some(s),
             Err(e) => {
-                eprintln!("[parity] Failed to spawn Java server: {}", e);
+                eprintln!("[parity] Failed to spawn Java server: {e}");
                 eprintln!("[parity] Falling back to one-shot mode");
                 None
             }
@@ -1579,8 +1570,8 @@ fn run_fuzz_mode(cli: &Cli) {
         let deck2_inline = deck_generator::format_inline(&deck2_spec);
 
         let config = RunConfig {
-            deck1: format!("inline:{}", deck1_inline),
-            deck2: format!("inline:{}", deck2_inline),
+            deck1: format!("inline:{deck1_inline}"),
+            deck2: format!("inline:{deck2_inline}"),
             seed: game_seed,
             max_turns: cli.max_turns,
             cards_dir: cli.cards_dir.clone(),
@@ -1617,7 +1608,7 @@ fn run_fuzz_mode(cli: &Cli) {
                         run_single_matchup_server(&config, &data, srv)
                     }
                     Err(e) => {
-                        eprintln!("[parity] Failed to respawn Java server: {}", e);
+                        eprintln!("[parity] Failed to respawn Java server: {e}");
                         // Fall back to one-shot for this iteration
                         if let Some(ref jar_path) = cli.java_jar {
                             run_single_matchup_oneshot(&config, &data, jar_path)
@@ -1724,14 +1715,14 @@ fn run_fuzz_mode(cli: &Cli) {
 fn write_output(cli: &Cli, output: &str) {
     if let Some(ref path) = cli.output {
         match std::fs::write(path, output) {
-            Ok(_) => eprintln!("[parity] Report written to {:?}", path),
+            Ok(_) => eprintln!("[parity] Report written to {path:?}"),
             Err(e) => {
-                eprintln!("[parity] Failed to write report: {}", e);
+                eprintln!("[parity] Failed to write report: {e}");
                 std::process::exit(1);
             }
         }
     } else {
-        println!("{}", output);
+        println!("{output}");
     }
 }
 
@@ -1745,10 +1736,7 @@ fn collect_unique_deck_cards(deck1: &str, deck2: &str, decks_dirs: &[&str]) -> V
                 }
             }
             Err(e) => {
-                eprintln!(
-                    "[parity] Coverage warning: failed to parse deck '{}': {}",
-                    deck, e
-                );
+                eprintln!("[parity] Coverage warning: failed to parse deck '{deck}': {e}");
             }
         }
     }
@@ -1796,16 +1784,13 @@ fn build_coverage_report_from_cards(deck_cards: &[String], covered_cards: &[Stri
 
     let mut out = String::new();
     out.push_str("\n=== Coverage Report ===\n\n");
-    out.push_str(&format!(
-        "Covered cards: {}/{} ({:.1}%)\n",
-        covered, total, pct
-    ));
+    out.push_str(&format!("Covered cards: {covered}/{total} ({pct:.1}%)\n"));
     if uncovered.is_empty() {
         out.push_str("Uncovered cards: none\n");
     } else {
         out.push_str("Uncovered cards:\n");
         for name in uncovered {
-            out.push_str(&format!("  - {}\n", name));
+            out.push_str(&format!("  - {name}\n"));
         }
     }
     out

--- a/manabrew-rs/crates/parity/src/protocol.rs
+++ b/manabrew-rs/crates/parity/src/protocol.rs
@@ -277,13 +277,13 @@ impl ChoiceLogEntry {
         let mut s = String::new();
         s.push_str(&self.name);
         if let Some(n) = self.choices {
-            s.push_str(&format!("[{}]", n));
+            s.push_str(&format!("[{n}]"));
         }
         if !self.outcome.is_empty() {
             s.push_str(&format!(" -> {}", self.outcome));
         }
         if let Some(cc) = self.rng_call_count {
-            s.push_str(&format!(" \x1b[33m{{{}}}\x1b[0m", cc));
+            s.push_str(&format!(" \x1b[33m{{{cc}}}\x1b[0m"));
         }
         s
     }

--- a/manabrew-rs/crates/parity/src/report.rs
+++ b/manabrew-rs/crates/parity/src/report.rs
@@ -30,7 +30,7 @@ pub fn build_report(trace: &GameTrace, divergences: Vec<Divergence>) -> ParityRe
 
 /// Format a parity report as a JSON string.
 pub fn format_json(report: &ParityReport) -> String {
-    serde_json::to_string_pretty(report).unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
+    serde_json::to_string_pretty(report).unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"))
 }
 
 /// Format a parity report as human-readable text.
@@ -85,7 +85,7 @@ pub fn format_text_with_snapshots(
 
 /// Format a matrix report as a JSON string.
 pub fn format_matrix_json(report: &MatrixReport) -> String {
-    serde_json::to_string_pretty(report).unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
+    serde_json::to_string_pretty(report).unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"))
 }
 
 /// Format a matrix report as human-readable text.
@@ -257,7 +257,7 @@ pub fn format_matrix_text(report: &MatrixReport) -> String {
 
 /// Format a fuzz report as a JSON string.
 pub fn format_fuzz_json(report: &FuzzReport) -> String {
-    serde_json::to_string_pretty(report).unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
+    serde_json::to_string_pretty(report).unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"))
 }
 
 /// Format a fuzz report as human-readable text.
@@ -334,7 +334,7 @@ pub fn format_fuzz_text(report: &FuzzReport) -> String {
 
             match &r.result.error_message {
                 Some(msg) => {
-                    out.push_str(&format!("     Error: {}\n", msg));
+                    out.push_str(&format!("     Error: {msg}\n"));
                 }
                 None => {
                     if let Some(ref div) = r.result.first_divergence {
@@ -365,10 +365,10 @@ fn completion_label(
 ) -> String {
     match status {
         MatchupStatus::Skipped => skip_reason
-            .map(|reason| format!("SKIPPED: {}", reason))
+            .map(|reason| format!("SKIPPED: {reason}"))
             .unwrap_or_else(|| "SKIPPED".to_string()),
         MatchupStatus::Fail => failed_turn
-            .map(|t| format!("FAILED AT TURN {}", t))
+            .map(|t| format!("FAILED AT TURN {t}"))
             .unwrap_or_else(|| "FAILED".to_string()),
         MatchupStatus::Pass => {
             if let Some(reason) = skip_reason {
@@ -377,7 +377,7 @@ fn completion_label(
                 }
             }
             finished_turn
-                .map(|turn| format!("FINISHED TURN {}", turn))
+                .map(|turn| format!("FINISHED TURN {turn}"))
                 .unwrap_or_else(|| {
                     let _ = max_turns;
                     "STOPPED AT MAX".to_string()
@@ -569,17 +569,13 @@ fn format_card_snapshot(c: &CardSnapshot) -> String {
         s.push_str(" (T)");
     }
     if let (Some(p), Some(t)) = (c.power, c.toughness) {
-        s.push_str(&format!(" {}/{}", p, t));
+        s.push_str(&format!(" {p}/{t}"));
     }
     if c.damage > 0 {
         s.push_str(&format!(" dmg={}", c.damage));
     }
     if !c.counters.is_empty() {
-        let counters: Vec<String> = c
-            .counters
-            .iter()
-            .map(|(k, v)| format!("{}={}", k, v))
-            .collect();
+        let counters: Vec<String> = c.counters.iter().map(|(k, v)| format!("{k}={v}")).collect();
         s.push_str(&format!(" [{}]", counters.join(",")));
     }
     s
@@ -609,7 +605,7 @@ pub fn format_trace_text(trace: &GameTrace) -> String {
             out.push_str(&format!(
                 "  GAME OVER — winner: {}\n",
                 snap.winner
-                    .map(|w| format!("P{}", w))
+                    .map(|w| format!("P{w}"))
                     .unwrap_or_else(|| "draw".into()),
             ));
         }
@@ -635,7 +631,7 @@ pub fn format_trace_text(trace: &GameTrace) -> String {
                             s.push_str(" (T)");
                         }
                         if let (Some(p), Some(t)) = (c.power, c.toughness) {
-                            s.push_str(&format!(" {}/{}", p, t));
+                            s.push_str(&format!(" {p}/{t}"));
                         }
                         s
                     })

--- a/manabrew-rs/crates/parity/src/runner.rs
+++ b/manabrew-rs/crates/parity/src/runner.rs
@@ -535,7 +535,7 @@ impl PlayerAgent for CapturingAgent {
                 }
             }
             GameNotification::PhaseChanged { phase } => {
-                self.current_phase = format!("{:?}", phase);
+                self.current_phase = format!("{phase:?}");
                 if let Some(ref mut game) = self.last_game_state {
                     game.turn.phase = *phase;
                 }
@@ -952,18 +952,18 @@ pub fn load_data(cards_dir: Option<&str>, verbose: bool) -> Result<LoadedData, S
     } = bundle;
     if verbose {
         let script_stats = crate::card_pool::scan_raw_script_diagnostics(cards_path);
-        eprintln!("[parity] {}", script_stats);
+        eprintln!("[parity] {script_stats}");
         for example in script_stats.example_lines() {
-            eprintln!("[parity] script diagnostic example: {}", example);
+            eprintln!("[parity] script diagnostic example: {example}");
         }
         for example in script_stats.semantic_raw_example_lines() {
-            eprintln!("[parity] script semantic raw example: {}", example);
+            eprintln!("[parity] script semantic raw example: {example}");
         }
         for example in script_stats.svar_raw_dollar_example_lines() {
-            eprintln!("[parity] script raw SVar dollar example: {}", example);
+            eprintln!("[parity] script raw SVar dollar example: {example}");
         }
         for example in script_stats.raw_dsl_domain_example_lines() {
-            eprintln!("[parity] script raw DSL domain example: {}", example);
+            eprintln!("[parity] script raw DSL domain example: {example}");
         }
         if !script_stats.svar_raw_dollar_shapes.is_empty() {
             eprintln!("[parity] script raw SVar dollar shapes:");
@@ -1005,20 +1005,15 @@ pub fn load_data(cards_dir: Option<&str>, verbose: bool) -> Result<LoadedData, S
             .unwrap_or_default();
         if !type_list_path.exists() {
             return Err(format!(
-                "TypeLists.txt not found at {:?}. This file is required for creature type data.",
-                type_list_path
+                "TypeLists.txt not found at {type_list_path:?}. This file is required for creature type data."
             ));
         }
         if verbose {
-            eprintln!("[parity] Loading type lists from {:?} ...", type_list_path);
+            eprintln!("[parity] Loading type lists from {type_list_path:?} ...");
         }
         let _t_types_read = Instant::now();
-        let content = std::fs::read_to_string(&type_list_path).map_err(|e| {
-            format!(
-                "Failed to read TypeLists.txt at {:?}: {}",
-                type_list_path, e
-            )
-        })?;
+        let content = std::fs::read_to_string(&type_list_path)
+            .map_err(|e| format!("Failed to read TypeLists.txt at {type_list_path:?}: {e}"))?;
         let _t_types_parse = Instant::now();
         manabrew_engine::game::TypeRegistry::load(&content);
         if verbose {

--- a/manabrew-rs/crates/parity/src/runtime.rs
+++ b/manabrew-rs/crates/parity/src/runtime.rs
@@ -106,7 +106,7 @@ impl JavaServerPool {
         }
         let mut server = self.servers[0]
             .lock()
-            .map_err(|e| JavaBridgeError::ProtocolError(format!("Mutex poisoned: {}", e)))?;
+            .map_err(|e| JavaBridgeError::ProtocolError(format!("Mutex poisoned: {e}")))?;
         server.run_matchup_streaming(
             deck1,
             deck2,
@@ -199,7 +199,7 @@ impl<'a> ParityRuntime<'a> {
     pub fn run_rust_only(&self, config: &RunConfig) -> MatchupResult {
         match runner::run_with_data(config, self.data) {
             Ok(trace) => build_rust_only_result(config, trace),
-            Err(e) => MatchupResult::error(config, format!("Rust engine error: {}", e)),
+            Err(e) => MatchupResult::error(config, format!("Rust engine error: {e}")),
         }
     }
 
@@ -361,10 +361,7 @@ impl<'a> ParityRuntime<'a> {
                     Ok(t) => t,
                     Err(e) => {
                         return RuntimeMatchup {
-                            result: MatchupResult::error(
-                                config,
-                                format!("Rust engine error: {}", e),
-                            ),
+                            result: MatchupResult::error(config, format!("Rust engine error: {e}")),
                             duration_ms: start.elapsed().as_millis() as u64,
                             cache_hit: false,
                         };
@@ -505,7 +502,7 @@ fn compare_results_with_java_data(
         Err(e) => {
             return Err(MatchupResult::error(
                 config,
-                format!("Rust engine error: {}", e),
+                format!("Rust engine error: {e}"),
             ));
         }
     };
@@ -514,7 +511,7 @@ fn compare_results_with_java_data(
         Err(e) => {
             return Err(MatchupResult::error(
                 config,
-                format!("{}: {}", java_error_prefix, e),
+                format!("{java_error_prefix}: {e}"),
             ));
         }
     };
@@ -576,7 +573,7 @@ pub fn dump_snapshot_timeline(
     for i in 0..max_len {
         let left = rust_lines.get(i).map(String::as_str).unwrap_or("");
         let right = java_lines.get(i).map(String::as_str).unwrap_or("");
-        eprintln!("{:col_w$} | {}", left, right, col_w = col_w);
+        eprintln!("{left:col_w$} | {right}");
     }
     eprintln!(
         "Rust: {} snapshots, Java: {} snapshots",

--- a/manabrew-rs/crates/parity/src/snapshot.rs
+++ b/manabrew-rs/crates/parity/src/snapshot.rs
@@ -180,10 +180,7 @@ fn counters_to_java_string(counters: &BTreeMap<String, i32>) -> String {
     if counters.is_empty() {
         return "{}".to_string();
     }
-    let entries: Vec<String> = counters
-        .iter()
-        .map(|(k, v)| format!("{}={}", k, v))
-        .collect();
+    let entries: Vec<String> = counters.iter().map(|(k, v)| format!("{k}={v}")).collect();
     format!("{{{}}}", entries.join(", "))
 }
 

--- a/manabrew-rs/crates/parity/src/utils/decks.rs
+++ b/manabrew-rs/crates/parity/src/utils/decks.rs
@@ -20,7 +20,7 @@ struct PresetDeckFile {
 fn load_preset_deck(name: &str, decks_dirs: &[&str]) -> Result<Vec<(String, usize)>, String> {
     let mut tried = Vec::with_capacity(decks_dirs.len());
     for dir in decks_dirs {
-        let path = std::path::Path::new(dir).join(format!("{}.json", name));
+        let path = std::path::Path::new(dir).join(format!("{name}.json"));
         if !path.exists() {
             tried.push(path.display().to_string());
             continue;
@@ -67,7 +67,7 @@ pub fn resolve_deck_spec(spec: &str, decks_dirs: &[&str]) -> Result<Vec<(String,
 
 fn parse_deck_file(path: &str) -> Result<Vec<(String, usize)>, String> {
     let contents =
-        std::fs::read_to_string(path).map_err(|e| format!("Failed to read '{}': {}", path, e))?;
+        std::fs::read_to_string(path).map_err(|e| format!("Failed to read '{path}': {e}"))?;
     let mut deck = Vec::new();
     for (line_num, line) in contents.lines().enumerate() {
         let line = line.trim();
@@ -101,7 +101,7 @@ fn parse_deck_file(path: &str) -> Result<Vec<(String, usize)>, String> {
         deck.push((name.to_string(), count));
     }
     if deck.is_empty() {
-        return Err(format!("Deck file '{}' contains no cards", path));
+        return Err(format!("Deck file '{path}' contains no cards"));
     }
     Ok(deck)
 }
@@ -125,7 +125,7 @@ pub fn build_deck_from_spec(
             }
             None => {
                 if verbose {
-                    eprintln!("[parity] Unknown card '{}' — skipped", name);
+                    eprintln!("[parity] Unknown card '{name}' — skipped");
                 }
             }
         }

--- a/manabrew-rs/crates/self-hosted-node/src/host.rs
+++ b/manabrew-rs/crates/self-hosted-node/src/host.rs
@@ -892,7 +892,7 @@ async fn wait_for_host_room(
             }
             Some(ServerMessage::AuthResult { success, error, .. }) => {
                 if !success {
-                    return Err(format!("authentication failed: {:?}", error).into());
+                    return Err(format!("authentication failed: {error:?}").into());
                 }
             }
             Some(ServerMessage::Error { code, message }) => {
@@ -2110,7 +2110,7 @@ impl RelayClient {
                         info!(username = %self.username, "authenticated");
                         return Ok(());
                     }
-                    return Err(format!("authentication failed: {:?}", error).into());
+                    return Err(format!("authentication failed: {error:?}").into());
                 }
                 Some(other) => {
                     debug!(?other, username = %self.username, "ignored pre-auth message")

--- a/manabrew-rs/crates/wasm/src/bot_api.rs
+++ b/manabrew-rs/crates/wasm/src/bot_api.rs
@@ -21,7 +21,7 @@ impl WasmBot {
     #[wasm_bindgen(constructor)]
     pub fn new(config_json: &str) -> Result<WasmBot, JsValue> {
         let config: BotConfig = serde_json::from_str(config_json)
-            .map_err(|e| JsValue::from_str(&format!("invalid bot config: {}", e)))?;
+            .map_err(|e| JsValue::from_str(&format!("invalid bot config: {e}")))?;
         Ok(WasmBot {
             state: BotState::new(config),
         })

--- a/manabrew-rs/crates/wasm/src/card_loader.rs
+++ b/manabrew-rs/crates/wasm/src/card_loader.rs
@@ -56,7 +56,7 @@ pub fn load_card_archive(bytes: &[u8]) -> Result<u64, JsError> {
             .into(),
         );
         for (file, err) in bundle.cards_result.errors.iter().take(5) {
-            web_sys::console::warn_1(&format!("  - {}: {}", file, err).into());
+            web_sys::console::warn_1(&format!("  - {file}: {err}").into());
         }
     }
 
@@ -114,11 +114,8 @@ pub fn load_card_archive(bytes: &[u8]) -> Result<u64, JsError> {
     }
 
     web_sys::console::log_1(
-        &format!(
-            "[card_loader] Loaded {} cards, {} tokens from archive",
-            cards_loaded, tokens_loaded
-        )
-        .into(),
+        &format!("[card_loader] Loaded {cards_loaded} cards, {tokens_loaded} tokens from archive")
+            .into(),
     );
 
     Ok(((cards_loaded as u64) << 32) | (tokens_loaded as u64))

--- a/manabrew-rs/crates/wasm/src/wasm_api.rs
+++ b/manabrew-rs/crates/wasm/src/wasm_api.rs
@@ -43,13 +43,13 @@ pub fn get_engine_info() -> JsValue {
 /// Used to verify WASM is up and running
 #[wasm_bindgen]
 pub fn echo(msg: &str) -> String {
-    format!("wasm echo: {}", msg)
+    format!("wasm echo: {msg}")
 }
 
 #[wasm_bindgen]
 pub fn parse_deck(deck_json: JsValue) -> Result<JsValue, JsError> {
     let deck: WireDeck = serde_wasm_bindgen::from_value(deck_json)
-        .map_err(|e| JsError::new(&format!("Failed to parse deck: {}", e)))?;
+        .map_err(|e| JsError::new(&format!("Failed to parse deck: {e}")))?;
 
     #[derive(Serialize)]
     struct DeckSummary {
@@ -63,7 +63,7 @@ pub fn parse_deck(deck_json: JsValue) -> Result<JsValue, JsError> {
     };
 
     serde_wasm_bindgen::to_value(&summary)
-        .map_err(|e| JsError::new(&format!("Failed to serialize summary: {}", e)))
+        .map_err(|e| JsError::new(&format!("Failed to serialize summary: {e}")))
 }
 
 /// Parse a game config from JSON.
@@ -73,11 +73,11 @@ pub fn parse_config(config_json: JsValue) -> Result<JsValue, JsError> {
         GameConfig::default()
     } else {
         serde_wasm_bindgen::from_value(config_json)
-            .map_err(|e| JsError::new(&format!("Failed to parse config: {}", e)))?
+            .map_err(|e| JsError::new(&format!("Failed to parse config: {e}")))?
     };
 
     serde_wasm_bindgen::to_value(&config)
-        .map_err(|e| JsError::new(&format!("Failed to serialize config: {}", e)))
+        .map_err(|e| JsError::new(&format!("Failed to serialize config: {e}")))
 }
 
 /// Test that the RNG works in WASM.
@@ -151,9 +151,9 @@ pub fn run_interactive_game(
     let card_db = get_card_db().ok_or_else(|| JsError::new("Card database not loaded"))?;
 
     let human_deck: WireDeck = serde_wasm_bindgen::from_value(human_deck_json)
-        .map_err(|e| JsError::new(&format!("Failed to parse human deck: {}", e)))?;
+        .map_err(|e| JsError::new(&format!("Failed to parse human deck: {e}")))?;
     let ai_decks: Vec<WireDeck> = serde_wasm_bindgen::from_value(ai_decks_json)
-        .map_err(|e| JsError::new(&format!("Failed to parse AI decks: {}", e)))?;
+        .map_err(|e| JsError::new(&format!("Failed to parse AI decks: {e}")))?;
     if ai_decks.is_empty() {
         return Err(JsError::new("At least one AI deck is required"));
     }
@@ -162,7 +162,7 @@ pub fn run_interactive_game(
         GameConfig::default()
     } else {
         serde_wasm_bindgen::from_value(config_json)
-            .map_err(|e| JsError::new(&format!("Failed to parse config: {}", e)))?
+            .map_err(|e| JsError::new(&format!("Failed to parse config: {e}")))?
     };
     let starting_life = config.starting_life;
 
@@ -237,7 +237,7 @@ pub fn run_interactive_game(
         winner_id: outcome.winner.map(|p| p.0),
         game_over: true,
     })
-    .map_err(|e| JsError::new(&format!("Failed to serialize result: {}", e)))
+    .map_err(|e| JsError::new(&format!("Failed to serialize result: {e}")))
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
## Summary
`cargo clippy --fix` plus `cargo fmt` across the workspace. Inlines format args and removes one redundant closure. No behavior change.

## Why
`yarn lint:rust` fails on main, so the pre-commit hook blocks every commit. CI does not lint these crates, so the drift went unnoticed.

## Test plan
- `yarn lint:all` green.
- Whole workspace compiles.
