### PR TITLE
fix(forge): allow declining optional trigger costs

### DIFF
--- a/forge-harness/src/main/java/forge/harness/common/HarnessCostPlumbing.java
+++ b/forge-harness/src/main/java/forge/harness/common/HarnessCostPlumbing.java
@@ -114,7 +114,8 @@ public final class HarnessCostPlumbing {
         }
 
         private CardCollectionView chooseCards(final CardCollectionView pool, final int amount, final String title) {
-            return controller.chooseCardsForEffect(pool, ability, title, amount, amount, false, null);
+            return controller.chooseCardsForEffect(
+                    pool, ability, title, amount, amount, ability.isOptionalTrigger(), null);
         }
 
         @Override


### PR DESCRIPTION
## Summary

- allow card-selection costs on optional triggers to be declined
- preserve mandatory selection for ordinary and mandatory ability costs

## Why

Forge treats triggers with nonzero costs as optional and lets players decline by not paying the cost. The harness required the full card selection, so Aziza, Mage Tower Captain and other optional cost-bearing triggers could not be declined.

Fixes #310

## Test plan

- `node scripts/harness.mjs ensure`
- `yarn lint:all`