### PR TITLE
feat(hub): backfill hosted games into deck play rankings

### DIFF
--- a/manabrew-rs/crates/manabrew-hub/src/main.rs
+++ b/manabrew-rs/crates/manabrew-hub/src/main.rs
@@ -53,15 +53,28 @@ async fn main() {
         .sync_preset_decks(&presets, &chrono::Utc::now().to_rfc3339())
         .expect("sync preset decks");
     if let Some(path) = config.analytics_import_db_path.as_deref() {
-        match storage.import_analytics_deck_plays(path, &chrono::Utc::now().to_rfc3339()) {
-            Ok(AnalyticsImportOutcome::AlreadyCompleted) => {}
-            Ok(AnalyticsImportOutcome::SourceUnavailable) => {
-                tracing::warn!(%path, "analytics deck-play import source unavailable");
+        for hosted in [false, true] {
+            match storage.import_analytics_deck_plays(
+                path,
+                &chrono::Utc::now().to_rfc3339(),
+                hosted,
+            ) {
+                Ok(AnalyticsImportOutcome::AlreadyCompleted) => {}
+                Ok(AnalyticsImportOutcome::SourceUnavailable) => {
+                    tracing::warn!(%path, "analytics deck-play import source unavailable");
+                }
+                Ok(AnalyticsImportOutcome::Imported { imported, skipped }) => {
+                    tracing::info!(
+                        hosted,
+                        imported,
+                        skipped,
+                        "analytics deck-play import completed"
+                    );
+                }
+                Err(error) => {
+                    tracing::warn!(%error, %path, hosted, "analytics deck-play import failed")
+                }
             }
-            Ok(AnalyticsImportOutcome::Imported { imported, skipped }) => {
-                tracing::info!(imported, skipped, "analytics deck-play import completed");
-            }
-            Err(error) => tracing::warn!(%error, %path, "analytics deck-play import failed"),
         }
     }
     let state = Arc::new(AppState {

--- a/manabrew-rs/crates/manabrew-hub/src/storage.rs
+++ b/manabrew-rs/crates/manabrew-hub/src/storage.rs
@@ -551,11 +551,16 @@ impl Storage {
         &self,
         path: &str,
         completed_at: &str,
+        hosted: bool,
     ) -> SqlResult<AnalyticsImportOutcome> {
-        const MIGRATION_KEY: &str = "analytics-deck-plays-v1";
+        let migration_key = if hosted {
+            "analytics-deck-plays-hosted-v1"
+        } else {
+            "analytics-deck-plays-v1"
+        };
         let completed = self.conn.query_row(
             "SELECT EXISTS(SELECT 1 FROM data_migrations WHERE key = ?1)",
-            params![MIGRATION_KEY],
+            params![migration_key],
             |row| row.get::<_, bool>(0),
         )?;
         if completed {
@@ -580,13 +585,13 @@ impl Storage {
                     g.format, g.started_at, COALESCE(g.game_over, 0), g.winner
              FROM game_players gp
              JOIN games g ON g.game_id = gp.game_id
-             WHERE gp.is_bot = 0 AND g.hosted = 0
+             WHERE gp.is_bot = 0 AND g.hosted = ?1
                AND gp.published_deck_id IS NOT NULL
                AND gp.deck_fingerprint IS NOT NULL
                AND g.started_at IS NOT NULL
              ORDER BY g.started_at ASC, gp.game_id ASC, gp.username ASC",
         )?;
-        let rows = stmt.query_map([], |row| {
+        let rows = stmt.query_map(params![hosted as i64], |row| {
             Ok(AnalyticsDeckPlay {
                 game_id: row.get(0)?,
                 username: row.get(1)?,
@@ -609,8 +614,8 @@ impl Storage {
             imported += tx.execute(
                 "INSERT OR IGNORE INTO deck_play_reports
                     (id, deckhub_entry_id, deck_fingerprint, format, source, game_key,
-                     player_key, completed_game, won, played_at)
-                 VALUES (?1, ?2, ?3, ?4, 'relay', ?5, ?6, ?7, ?8, ?9)",
+                     player_key, completed_game, won, played_at, hosted)
+                 VALUES (?1, ?2, ?3, ?4, 'relay', ?5, ?6, ?7, ?8, ?9, ?10)",
                 params![
                     format!("relay:{}", uuid::Uuid::new_v4()),
                     row.deckhub_entry_id,
@@ -622,12 +627,13 @@ impl Storage {
                     (row.completed_game && row.winner.as_deref() == Some(row.username.as_str()))
                         as i64,
                     row.played_at,
+                    hosted as i64,
                 ],
             )?;
         }
         tx.execute(
             "INSERT INTO data_migrations (key, completed_at) VALUES (?1, ?2)",
-            params![MIGRATION_KEY, completed_at],
+            params![migration_key, completed_at],
         )?;
         tx.commit()?;
         Ok(AnalyticsImportOutcome::Imported {


### PR DESCRIPTION
## Summary

- run the analytics deck-play importer once per `hosted` value, each pass under its own data-migration key
- imported rows carry the `hosted` flag, so Highest Win Rate keeps ignoring them
- stacked on #641, which is where hosted games started counting

## Why

#641 makes hosted games count towards the play boards, but only for games played from then on. `import_analytics_deck_plays` still filtered on `g.hosted = 0`, so the roughly 2,300 hosted games already sitting in the events database would never reach `deck_play_reports`. The boards would fill over the following month instead of on the first boot after deploy, and hosted is 93.6% of all play.

Splitting by key rather than dropping the filter means an installation that already completed `analytics-deck-plays-v1` imports only the hosted rows, and a fresh database still runs both passes in order. `INSERT OR IGNORE` against `idx_deck_play_reports_relay_player` covers the overlap with games the live relay has already reported since #641 deployed.

## Test plan

- `cargo clippy -p manabrew-hub --all-targets -D warnings` clean
- 54 hub tests pass, `cargo fmt` clean
- not yet run against a copy of the production events database

## Notes

This publishes nothing new per player. Rows carry no username: `player_key` is `sha256(game_id \0 username)`, salted per game, so rows are neither linkable across games nor reversible without the game UUID, and every board aggregates by deck.

It does deepen one inference that #641 introduces. A published deck's play count now includes solo games against the AI, and entries carry their author's name, so for a deck with few players the public count approximates how much its author practised with it, and Rising says which week. Counting hosted games is what creates that, not this backfill, which only extends it backwards. Ranking by distinct players would fix it, but the per-game salt means `DISTINCT player_key` counts games rather than people, and a stable per-person hash would cost more privacy than it buys. A minimum-plays floor on Most Played, which Rising already has, is the cheaper half-measure.

Worth settling before this runs: erasure in #622 to #626 is a username scrub, and this import re-derives keys from usernames still held in the events database. Nothing identifiable lands in `deck_play_reports`, but it does mean the events database is the store an erasure request has to reach.
