### PR TITLE
fix(harness): unbreak native builds on unused import

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -484,6 +484,31 @@ jobs:
       - name: Tauri build (Android APK, arm64)
         run: node scripts/mobile-dev.mjs android build --apk --target aarch64
 
+  # The GraalVM jobs below are label-gated, so harness Java went unchecked on
+  # any PR that didn't opt in and violations only surfaced on the release tag.
+  # Checkstyle binds to `validate`: no compile, no codegen, no Rust.
+  forge-harness-checkstyle:
+    name: Forge harness (checkstyle)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.run_forge_room == 'true'
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          clean: true
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      - name: Checkstyle (forge-harness)
+        run: mvn -B -pl forge-harness validate
+
   forge-room-graalvm-windows:
     name: GraalVM build (Windows)
     runs-on: windows-latest

--- a/forge-harness/src/main/java/forge/harness/common/ActionSpace.java
+++ b/forge-harness/src/main/java/forge/harness/common/ActionSpace.java
@@ -1,6 +1,5 @@
 package forge.harness.common;
 
-import forge.ai.ComputerUtilCost;
 import forge.ai.ComputerUtilMana;
 import forge.card.MagicColor;
 import forge.card.mana.ManaAtom;


### PR DESCRIPTION
## Summary

Removes an unused `forge.ai.ComputerUtilCost` import from `ActionSpace.java`, and adds a `Forge harness (checkstyle)` job that runs on any PR touching the harness.

## Why

`v3.8.1` failed both desktop builds at the harness jar step:

```
ActionSpace.java:3:8: Unused import - forge.ai.ComputerUtilCost. [UnusedImports]
```

#643 added the import without using it. The deeper problem is that nothing could have caught it: `build-checks.yml` computes a `run_forge_room` output and `FORGE_ROOM_PATHS` includes `forge-harness/`, but no job consumes it. Both GraalVM jobs gate on the `ci:test-desktop` label instead, so they showed `skipping` on #643 and the violation only surfaced on the release tag.

The new job consumes `run_forge_room`. It stays cheap because checkstyle binds to Maven's `validate` phase, which runs before compile: no native-image, no protocol codegen, no Rust. The label-gated native builds are unchanged.

Note that `main` currently has no required status checks (`contexts: []`), so this job will not block a merge until it is added to branch protection. Job-level `if:` skips report a `skipped` conclusion, which branch protection accepts, so it is safe to require.

## Test plan

- Reproduced the failure locally with the pinned ruleset and checkstyle version from `forge/pom.xml` (10.18.2): `mvn -pl forge-harness validate` fails in 3.7s with exactly the CI error.
- After removing the import it passes in 2.2s, and it is the only violation across the whole harness.
- `prettier --check` clean on the workflow; YAML parses and the job wires to `needs.changes.outputs.run_forge_room`.
- This PR touches `.github/workflows/build-checks.yml`, which is in `FORGE_ROOM_PATHS`, so the new job runs on this PR itself.
