### PR TITLE
fix(limited): restore cube drafts and improve draft workspace

### DIFF
--- a/manabrew-rs/crates/forge-foundation/src/sealed_product/unopened_product.rs
+++ b/manabrew-rs/crates/forge-foundation/src/sealed_product/unopened_product.rs
@@ -53,7 +53,11 @@ impl IUnOpenedProduct for UnOpenedProduct {
                     copy
                 })
                 .collect();
-            self.pool.retain(|c| !to_remove.contains(c));
+            for card in to_remove {
+                if let Some(index) = self.pool.iter().position(|candidate| candidate == &card) {
+                    self.pool.remove(index);
+                }
+            }
         }
 
         pack

--- a/manabrew-rs/crates/forge-limited/src/booster_draft.rs
+++ b/manabrew-rs/crates/forge-limited/src/booster_draft.rs
@@ -46,6 +46,7 @@ pub struct BoosterDraft {
     direction: PassDirection,
     pick_history: Vec<DraftSnapshot>,
     picks_per_pass: u32,
+    pool_limited: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -53,6 +54,8 @@ struct DraftSnapshot {
     current_round: u32,
     direction: PassDirection,
     next_pack_id: u32,
+    pool: Vec<PaperCard>,
+    rng: StdRng,
     seats: Vec<SeatSnapshot>,
 }
 
@@ -132,6 +135,7 @@ impl BoosterDraft {
             direction: PassDirection::Left,
             pick_history: Vec::new(),
             picks_per_pass: PICKS_PER_PASS_DEFAULT,
+            pool_limited: false,
         }
     }
 
@@ -141,6 +145,10 @@ impl BoosterDraft {
 
     pub fn picks_per_pass(&self) -> u32 {
         self.picks_per_pass
+    }
+
+    pub fn set_limited_pool(&mut self, limited: bool) {
+        self.pool_limited = limited;
     }
 
     pub fn can_undo(&self) -> bool {
@@ -158,6 +166,8 @@ impl BoosterDraft {
         self.current_round = snap.current_round;
         self.direction = snap.direction;
         self.next_pack_id = snap.next_pack_id;
+        self.pool = snap.pool;
+        self.rng = snap.rng;
         for (seat, snap) in self.seats.iter_mut().zip(snap.seats.into_iter()) {
             seat.picked = snap.picked;
             seat.last_pick = snap.last_pick;
@@ -180,6 +190,8 @@ impl BoosterDraft {
             current_round: self.current_round,
             direction: self.direction,
             next_pack_id: self.next_pack_id,
+            pool: self.pool.clone(),
+            rng: self.rng.clone(),
             seats: self
                 .seats
                 .iter()
@@ -264,12 +276,16 @@ impl BoosterDraft {
         };
 
         let mut product = UnOpenedProduct::new(self.template.clone(), self.pool.clone());
+        product.set_limited_pool(self.pool_limited);
         for seat in &mut self.seats {
             let cards = product.open(&mut self.rng);
             let mut pack = DraftPack::new(cards, self.next_pack_id);
             pack.set_picks_remaining(self.picks_per_pass);
             self.next_pack_id += 1;
             seat.receive_pack(pack);
+        }
+        if self.pool_limited {
+            self.pool = product.pool().to_vec();
         }
         self.log.add_log_entry(format!(
             "--- Round {} opened ({} packs) ---",

--- a/manabrew-rs/crates/forge-limited/src/winston_draft.rs
+++ b/manabrew-rs/crates/forge-limited/src/winston_draft.rs
@@ -48,9 +48,19 @@ impl WinstonDraft {
     /// shuffled into the central deck. Seat 0 is the human; seat 1 is
     /// the AI.
     pub fn new(template: SealedTemplate, pool: Vec<PaperCard>, pool_packs: usize) -> Self {
+        Self::new_with_pool_limit(template, pool, pool_packs, false)
+    }
+
+    pub fn new_with_pool_limit(
+        template: SealedTemplate,
+        pool: Vec<PaperCard>,
+        pool_packs: usize,
+        pool_limited: bool,
+    ) -> Self {
         assert!(pool_packs >= 1);
         let mut rng = StdRng::from_entropy();
         let mut product = UnOpenedProduct::new(template, pool);
+        product.set_limited_pool(pool_limited);
         let mut deck: Vec<PaperCard> = Vec::new();
         for _ in 0..pool_packs * NUM_PLAYERS {
             for card in product.open(&mut rng) {

--- a/manabrew-rs/crates/wasm/src/limited_api.rs
+++ b/manabrew-rs/crates/wasm/src/limited_api.rs
@@ -7,8 +7,8 @@ use forge_foundation::ColorSet;
 use forge_limited::{
     BoosterDraft, CardRanker, CubeImporter, DraftPack, DraftRankCache, GauntletKind, GauntletMini,
     GauntletOutcome, IBoosterDraft, LimitedDeck, LimitedPoolType, LimitedWinLoseController,
-    SealedCardPoolGenerator, SealedDeckGroup, ThemedChaosDraft, TickOutcome, WinstonDraft,
-    WinstonOutcome, CONSPIRACY_HOOKS,
+    PassDirection, SealedCardPoolGenerator, SealedDeckGroup, ThemedChaosDraft, TickOutcome,
+    WinstonDraft, WinstonOutcome, CONSPIRACY_HOOKS,
 };
 use manabrew_protocol::deck_dto::DeckCardIdentity;
 use rand::rngs::StdRng;
@@ -187,6 +187,9 @@ pub struct DraftSeatDto {
     pub is_human: bool,
     pub picks_made: u32,
     pub last_pick_name: Option<String>,
+    pub current_pack_size: u32,
+    pub packs_waiting: u32,
+    pub awaiting_pick: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -206,6 +209,7 @@ pub struct DraftStateDto {
     pub human_conspiracies: Vec<String>,
     pub picks_per_pass: u32,
     pub picks_remaining_in_pack: u32,
+    pub pass_direction: String,
 }
 
 impl DraftStateDto {
@@ -233,6 +237,16 @@ impl DraftStateDto {
                 is_human: p.is_human,
                 picks_made: p.picked.len() as u32,
                 last_pick_name: p.last_pick.as_ref().map(|c| c.name.clone()),
+                current_pack_size: p.current_pack().map(|pack| pack.len()).unwrap_or(0) as u32,
+                packs_waiting: p
+                    .pack_queue
+                    .len()
+                    .saturating_sub(usize::from(p.current_pack().is_some()))
+                    as u32,
+                awaiting_pick: p
+                    .current_pack()
+                    .map(|pack| !pack.is_empty())
+                    .unwrap_or(false),
             })
             .collect();
         seat_summaries.sort_by_key(|s| s.seat);
@@ -267,6 +281,11 @@ impl DraftStateDto {
             human_conspiracies,
             picks_per_pass: draft.picks_per_pass(),
             picks_remaining_in_pack,
+            pass_direction: match draft.current_direction() {
+                PassDirection::Left => "left",
+                PassDirection::Right => "right",
+            }
+            .to_string(),
         }
     }
 }

--- a/manabrew-rs/crates/wasm/src/limited_api.rs
+++ b/manabrew-rs/crates/wasm/src/limited_api.rs
@@ -175,6 +175,8 @@ pub struct BoosterDraftSetupDto {
     pub seed: Option<u64>,
     #[serde(default)]
     pub picks_per_pass: Option<u32>,
+    #[serde(default)]
+    pub custom_pool: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -317,6 +319,8 @@ pub struct WinstonSetupDto {
     pub variant: Option<String>,
     #[serde(default)]
     pub seed: Option<u64>,
+    #[serde(default)]
+    pub custom_pool: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -450,7 +454,6 @@ struct WasmLimitedState {
     winston: HashMap<String, WinstonDraft>,
     gauntlets: HashMap<String, GauntletMini>,
     rank_cache: Arc<DraftRankCache>,
-    name_index: std::collections::HashSet<String>,
     next_id: u64,
 }
 
@@ -462,7 +465,6 @@ impl WasmLimitedState {
             winston: HashMap::new(),
             gauntlets: HashMap::new(),
             rank_cache: Arc::new(DraftRankCache::new()),
-            name_index: std::collections::HashSet::new(),
             next_id: 0,
         }
     }
@@ -471,27 +473,10 @@ impl WasmLimitedState {
         self.next_id += 1;
         format!("{prefix}-{:x}", self.next_id)
     }
-
-    fn card_name_known(&self, name: &str) -> bool {
-        self.name_index.contains(&name.to_lowercase())
-    }
 }
 
 thread_local! {
     static STATE: RefCell<WasmLimitedState> = RefCell::new(WasmLimitedState::new());
-}
-
-fn rebuild_name_index(state: &mut WasmLimitedState) {
-    let Some(db) = get_card_db() else {
-        return;
-    };
-    state.name_index.clear();
-    // Walk the archive index directly — name validation doesn't require the
-    // cards to be parsed, and a freshly-loaded archive-backed DB has none
-    // parsed yet.
-    for key in db.iter_card_keys() {
-        state.name_index.insert(key);
-    }
 }
 
 /// the same shape `limited_start_sealed` / `limited_start_booster_draft`
@@ -573,31 +558,15 @@ pub fn limited_list_conspiracy_hooks() -> Result<JsValue, JsError> {
     serde_wasm_bindgen::to_value(&out).map_err(|e| JsError::new(&format!("serialize: {e}")))
 }
 
-fn filter_playable(state: &mut WasmLimitedState, pool: &[DeckCardIdentity]) -> Vec<PaperCard> {
-    if state.name_index.is_empty() {
-        rebuild_name_index(state);
-    }
-    pool.iter()
-        .filter(|c| state.card_name_known(&c.name))
-        .map(identity_to_paper_card)
-        .collect()
-}
-
-fn empty_pool_error(supplied: usize) -> String {
-    format!(
-        "no playable cards in pool — supplied {supplied} cards but the engine can't script any of them yet"
-    )
-}
-
 #[wasm_bindgen]
 pub fn limited_start_sealed(setup_json: JsValue) -> Result<JsValue, JsError> {
     let setup: SealedSetupDto =
         serde_wasm_bindgen::from_value(setup_json).map_err(|e| JsError::new(&e.to_string()))?;
     STATE.with(|cell| {
         let mut state = cell.borrow_mut();
-        let card_pool = filter_playable(&mut state, &setup.pool);
+        let card_pool: Vec<PaperCard> = setup.pool.iter().map(identity_to_paper_card).collect();
         if card_pool.is_empty() {
-            return Err(JsError::new(&empty_pool_error(setup.pool.len())));
+            return Err(JsError::new("card pool is empty"));
         }
         let pool_type = match setup.pool_type.as_str() {
             "Full" => LimitedPoolType::Full,
@@ -666,16 +635,20 @@ pub fn limited_start_booster_draft(setup_json: JsValue) -> Result<JsValue, JsErr
         serde_wasm_bindgen::from_value(setup_json).map_err(|e| JsError::new(&e.to_string()))?;
     STATE.with(|cell| {
         let mut state = cell.borrow_mut();
-        let card_pool = filter_playable(&mut state, &setup.pool);
+        let card_pool: Vec<PaperCard> = setup.pool.iter().map(identity_to_paper_card).collect();
         if card_pool.is_empty() {
-            return Err(JsError::new(&empty_pool_error(setup.pool.len())));
+            return Err(JsError::new("card pool is empty"));
         }
         let pod_size = setup.pod_size.clamp(2, 8) as usize;
         let rounds = setup.rounds.clamp(1, 6);
         let ranker = Arc::new(CardRanker::new(state.rank_cache.clone()));
         let color_of: Arc<dyn Fn(&PaperCard) -> ColorSet + Send + Sync> =
             Arc::new(|c: &PaperCard| c.colors);
-        let template = template_for_pool(&card_pool, setup.variant.as_deref());
+        let template = if setup.custom_pool {
+            SealedTemplate::generic_no_slot_booster()
+        } else {
+            template_for_pool(&card_pool, setup.variant.as_deref())
+        };
         let mut draft = BoosterDraft::new(pod_size, rounds, template, card_pool, ranker, color_of);
         if let Some(n) = setup.picks_per_pass {
             draft.set_picks_per_pass(n);
@@ -755,9 +728,9 @@ pub fn limited_start_multiplayer_draft(
         serde_wasm_bindgen::from_value(humans_json).map_err(|e| JsError::new(&e.to_string()))?;
     STATE.with(|cell| {
         let mut state = cell.borrow_mut();
-        let card_pool = filter_playable(&mut state, &setup.pool);
+        let card_pool: Vec<PaperCard> = setup.pool.iter().map(identity_to_paper_card).collect();
         if card_pool.is_empty() {
-            return Err(JsError::new(&empty_pool_error(setup.pool.len())));
+            return Err(JsError::new("card pool is empty"));
         }
         let pod_size = setup.pod_size.clamp(2, 8) as usize;
         let rounds = setup.rounds.clamp(1, 6);
@@ -774,7 +747,11 @@ pub fn limited_start_multiplayer_draft(
         let ranker = Arc::new(CardRanker::new(state.rank_cache.clone()));
         let color_of: Arc<dyn Fn(&PaperCard) -> ColorSet + Send + Sync> =
             Arc::new(|c: &PaperCard| c.colors);
-        let template = template_for_pool(&card_pool, setup.variant.as_deref());
+        let template = if setup.custom_pool {
+            SealedTemplate::generic_no_slot_booster()
+        } else {
+            template_for_pool(&card_pool, setup.variant.as_deref())
+        };
         let mut draft = BoosterDraft::with_human_seats(
             pod_size, rounds, template, card_pool, ranker, color_of, &humans,
         );
@@ -879,12 +856,16 @@ pub fn limited_start_winston(setup_json: JsValue) -> Result<JsValue, JsError> {
         serde_wasm_bindgen::from_value(setup_json).map_err(|e| JsError::new(&e.to_string()))?;
     STATE.with(|cell| {
         let mut state = cell.borrow_mut();
-        let card_pool = filter_playable(&mut state, &setup.pool);
+        let card_pool: Vec<PaperCard> = setup.pool.iter().map(identity_to_paper_card).collect();
         if card_pool.is_empty() {
-            return Err(JsError::new(&empty_pool_error(setup.pool.len())));
+            return Err(JsError::new("card pool is empty"));
         }
         let pool_packs = setup.pool_packs.clamp(2, 12) as usize;
-        let template = template_for_pool(&card_pool, setup.variant.as_deref());
+        let template = if setup.custom_pool {
+            SealedTemplate::generic_no_slot_booster()
+        } else {
+            template_for_pool(&card_pool, setup.variant.as_deref())
+        };
         let draft = WinstonDraft::new(template, card_pool, pool_packs);
         let session_id = state.fresh_id("winston");
         let dto = WinstonStateDto::from_engine(session_id.clone(), &draft);

--- a/manabrew-rs/crates/wasm/src/limited_api.rs
+++ b/manabrew-rs/crates/wasm/src/limited_api.rs
@@ -660,6 +660,13 @@ pub fn limited_start_booster_draft(setup_json: JsValue) -> Result<JsValue, JsErr
         }
         let pod_size = setup.pod_size.clamp(2, 8) as usize;
         let rounds = setup.rounds.clamp(1, 6);
+        let required_cards = pod_size * rounds as usize * 15;
+        if setup.custom_pool && card_pool.len() < required_cards {
+            return Err(JsError::new(&format!(
+                "cube has {} cards but {required_cards} are required for {pod_size} players and {rounds} rounds",
+                card_pool.len()
+            )));
+        }
         let ranker = Arc::new(CardRanker::new(state.rank_cache.clone()));
         let color_of: Arc<dyn Fn(&PaperCard) -> ColorSet + Send + Sync> =
             Arc::new(|c: &PaperCard| c.colors);
@@ -669,6 +676,7 @@ pub fn limited_start_booster_draft(setup_json: JsValue) -> Result<JsValue, JsErr
             template_for_pool(&card_pool, setup.variant.as_deref())
         };
         let mut draft = BoosterDraft::new(pod_size, rounds, template, card_pool, ranker, color_of);
+        draft.set_limited_pool(setup.custom_pool);
         if let Some(n) = setup.picks_per_pass {
             draft.set_picks_per_pass(n);
         }
@@ -683,7 +691,12 @@ pub fn limited_start_booster_draft(setup_json: JsValue) -> Result<JsValue, JsErr
 }
 
 #[wasm_bindgen]
-pub fn limited_pick_card(session_id: String, card_name: String) -> Result<JsValue, JsError> {
+pub fn limited_pick_card(
+    session_id: String,
+    card_name: String,
+    set_code: String,
+    card_number: String,
+) -> Result<JsValue, JsError> {
     STATE.with(|cell| {
         let mut state = cell.borrow_mut();
         let draft = state
@@ -692,7 +705,12 @@ pub fn limited_pick_card(session_id: String, card_name: String) -> Result<JsValu
             .ok_or_else(|| JsError::new(&format!("no draft session for id {session_id}")))?;
         let pack_card = draft
             .current_pack_for_human()
-            .and_then(|p: &DraftPack| p.cards().iter().find(|c| c.name == card_name).cloned())
+            .and_then(|p: &DraftPack| {
+                p.cards()
+                    .iter()
+                    .find(|c| card_identity_matches(c, &card_name, &set_code, &card_number))
+                    .cloned()
+            })
             .ok_or_else(|| JsError::new(&format!("card {card_name:?} not in current pack")))?;
         draft
             .submit_human_pick(pack_card)
@@ -753,6 +771,13 @@ pub fn limited_start_multiplayer_draft(
         }
         let pod_size = setup.pod_size.clamp(2, 8) as usize;
         let rounds = setup.rounds.clamp(1, 6);
+        let required_cards = pod_size * rounds as usize * 15;
+        if setup.custom_pool && card_pool.len() < required_cards {
+            return Err(JsError::new(&format!(
+                "cube has {} cards but {required_cards} are required for {pod_size} players and {rounds} rounds",
+                card_pool.len()
+            )));
+        }
         if humans.is_empty() || humans.len() > pod_size {
             return Err(JsError::new(&format!(
                 "multiplayer draft needs 1..={pod_size} humans, got {}",
@@ -774,6 +799,7 @@ pub fn limited_start_multiplayer_draft(
         let mut draft = BoosterDraft::with_human_seats(
             pod_size, rounds, template, card_pool, ranker, color_of, &humans,
         );
+        draft.set_limited_pool(setup.custom_pool);
         if let Some(n) = setup.picks_per_pass {
             draft.set_picks_per_pass(n);
         }
@@ -792,6 +818,8 @@ pub fn limited_submit_pick(
     session_id: String,
     seat_idx: u32,
     card_name: String,
+    set_code: String,
+    card_number: String,
 ) -> Result<JsValue, JsError> {
     STATE.with(|cell| {
         let mut state = cell.borrow_mut();
@@ -808,7 +836,12 @@ pub fn limited_submit_pick(
         }
         let pack_card = draft
             .current_pack_for_seat(seat)
-            .and_then(|p: &DraftPack| p.cards().iter().find(|c| c.name == card_name).cloned())
+            .and_then(|p: &DraftPack| {
+                p.cards()
+                    .iter()
+                    .find(|c| card_identity_matches(c, &card_name, &set_code, &card_number))
+                    .cloned()
+            })
             .ok_or_else(|| {
                 JsError::new(&format!("card {card_name:?} not in seat {seat}'s pack"))
             })?;
@@ -885,12 +918,30 @@ pub fn limited_start_winston(setup_json: JsValue) -> Result<JsValue, JsError> {
         } else {
             template_for_pool(&card_pool, setup.variant.as_deref())
         };
-        let draft = WinstonDraft::new(template, card_pool, pool_packs);
+        let required_cards = pool_packs * 2 * 15;
+        if setup.custom_pool && card_pool.len() < required_cards {
+            return Err(JsError::new(&format!(
+                "cube has {} cards but {required_cards} are required for {pool_packs} packs per player",
+                card_pool.len()
+            )));
+        }
+        let draft = WinstonDraft::new_with_pool_limit(
+            template,
+            card_pool,
+            pool_packs,
+            setup.custom_pool,
+        );
         let session_id = state.fresh_id("winston");
         let dto = WinstonStateDto::from_engine(session_id.clone(), &draft);
         state.winston.insert(session_id, draft);
         serde_wasm_bindgen::to_value(&dto).map_err(|e| JsError::new(&e.to_string()))
     })
+}
+
+fn card_identity_matches(card: &PaperCard, name: &str, set_code: &str, card_number: &str) -> bool {
+    card.name == name
+        && (set_code.is_empty() || card.set_code.eq_ignore_ascii_case(set_code))
+        && (card_number.is_empty() || card.collector_number == card_number)
 }
 
 fn template_for_pool(pool: &[PaperCard], variant: Option<&str>) -> SealedTemplate {

--- a/src/components/editor/DeckBuilder.tsx
+++ b/src/components/editor/DeckBuilder.tsx
@@ -856,7 +856,7 @@ export function DeckBuilder({
     }
     if (hasUnsupportedCards) {
       toast.warning(
-        `Saved "${currentDeck.name}" — ${unsupportedNames.size} card${unsupportedNames.size === 1 ? " is" : "s are"} missing from local card data; compatibility depends on the selected engine`,
+        `Saved "${currentDeck.name}" — ${unsupportedNames.size} card${unsupportedNames.size === 1 ? " is" : "s are"} unsupported by the Manabrew engine; export remains available for other engines`,
       );
     } else if (!deckValidation.legal) {
       toast.warning(
@@ -872,7 +872,7 @@ export function DeckBuilder({
     setUnsavedState(snapshot, snapshot);
     if (hasUnsupportedCards) {
       toast.warning(
-        `Saved "${currentDeck.name}" as draft — ${unsupportedNames.size} card${unsupportedNames.size === 1 ? " is" : "s are"} missing from local card data`,
+        `Saved "${currentDeck.name}" as draft — ${unsupportedNames.size} card${unsupportedNames.size === 1 ? " is" : "s are"} unsupported by the Manabrew engine`,
       );
     } else {
       toast.success(`Draft "${currentDeck.name}" saved`);
@@ -1095,7 +1095,7 @@ export function DeckBuilder({
                 )}
                 title={
                   hasUnsupportedCards
-                    ? `${unsupportedNames.size} card${unsupportedNames.size === 1 ? " is" : "s are"} missing from local card data — engine compatibility is checked when playing`
+                    ? `${unsupportedNames.size} card${unsupportedNames.size === 1 ? " is" : "s are"} unsupported by the Manabrew engine — export remains available`
                     : !isDeckLegal
                       ? `${deckValidation.errors[0] ?? "Deck is not legal in this format"} — saves with a warning`
                       : hasUnsavedChanges
@@ -1219,7 +1219,7 @@ export function DeckBuilder({
 
           <fieldset disabled={isReadOnly} className="contents">
             <div className={cn(isReadOnly && "opacity-60 bg-muted/15")}>
-              <DeckValidationPanel />
+              <DeckValidationPanel unsupportedNames={unsupportedNames} />
               <div
                 ref={setMainDropRef}
                 className={cn("transition-colors", isOverMain && !isOverSide && "bg-primary/5")}

--- a/src/components/editor/DeckBuilder.tsx
+++ b/src/components/editor/DeckBuilder.tsx
@@ -524,7 +524,7 @@ export function DeckBuilder({
         : { legal: false, errors: [] as string[] },
     [currentDeck, deckFormat],
   );
-  const isDeckLegal = !hasUnsupportedCards && deckValidation.legal;
+  const isDeckLegal = deckValidation.legal;
 
   const filterTerms = useMemo(() => parseFilterTerms(deckFilter), [deckFilter]);
   const matchesFilters = useCallback(
@@ -856,7 +856,7 @@ export function DeckBuilder({
     }
     if (hasUnsupportedCards) {
       toast.warning(
-        `Saved "${currentDeck.name}" — ${unsupportedNames.size} card${unsupportedNames.size === 1 ? "" : "s"} not implemented by the engine`,
+        `Saved "${currentDeck.name}" — ${unsupportedNames.size} card${unsupportedNames.size === 1 ? " is" : "s are"} missing from local card data; compatibility depends on the selected engine`,
       );
     } else if (!deckValidation.legal) {
       toast.warning(
@@ -872,7 +872,7 @@ export function DeckBuilder({
     setUnsavedState(snapshot, snapshot);
     if (hasUnsupportedCards) {
       toast.warning(
-        `Saved "${currentDeck.name}" as draft — ${unsupportedNames.size} card${unsupportedNames.size === 1 ? "" : "s"} not implemented by the engine`,
+        `Saved "${currentDeck.name}" as draft — ${unsupportedNames.size} card${unsupportedNames.size === 1 ? " is" : "s are"} missing from local card data`,
       );
     } else {
       toast.success(`Draft "${currentDeck.name}" saved`);
@@ -1095,7 +1095,7 @@ export function DeckBuilder({
                 )}
                 title={
                   hasUnsupportedCards
-                    ? `${unsupportedNames.size} card${unsupportedNames.size === 1 ? "" : "s"} not implemented by the engine — saves with a warning`
+                    ? `${unsupportedNames.size} card${unsupportedNames.size === 1 ? " is" : "s are"} missing from local card data — engine compatibility is checked when playing`
                     : !isDeckLegal
                       ? `${deckValidation.errors[0] ?? "Deck is not legal in this format"} — saves with a warning`
                       : hasUnsavedChanges
@@ -1219,7 +1219,7 @@ export function DeckBuilder({
 
           <fieldset disabled={isReadOnly} className="contents">
             <div className={cn(isReadOnly && "opacity-60 bg-muted/15")}>
-              <DeckValidationPanel unsupportedNames={unsupportedNames} />
+              <DeckValidationPanel />
               <div
                 ref={setMainDropRef}
                 className={cn("transition-colors", isOverMain && !isOverSide && "bg-primary/5")}

--- a/src/components/editor/DeckListView.tsx
+++ b/src/components/editor/DeckListView.tsx
@@ -469,7 +469,7 @@ function DraggableStackCard({
       {unsupported && (
         <div
           className="absolute top-1 right-1 z-30 rounded-full bg-warning/90 text-white p-0.5 shadow"
-          title="Not implemented by the engine - deck can only be saved as draft"
+          title="Missing from local card data; compatibility depends on the selected engine"
         >
           <AlertTriangle className="h-3 w-3" />
         </div>
@@ -701,7 +701,7 @@ function CardVisual({
       {unsupported && (
         <div
           className="absolute top-1 right-1 z-30 rounded-full bg-warning/90 text-white p-0.5 shadow"
-          title="Not implemented by the engine - deck can only be saved as draft"
+          title="Missing from local card data; compatibility depends on the selected engine"
         >
           <AlertTriangle className="h-3 w-3" />
         </div>
@@ -888,14 +888,14 @@ function CardRow({
       {unsupported && (
         <AlertTriangle
           className="h-3 w-3 text-warning shrink-0"
-          aria-label="Card not supported by the engine"
+          aria-label="Card missing from local card data"
         />
       )}
       <span
         className={cn("text-sm flex-1 truncate", unsupported && "text-warning")}
         title={
           unsupported
-            ? `${name} - not implemented by the engine; deck can only be saved as draft`
+            ? `${name} - missing from local card data; compatibility depends on the selected engine`
             : name
         }
       >

--- a/src/components/editor/DeckListView.tsx
+++ b/src/components/editor/DeckListView.tsx
@@ -469,7 +469,7 @@ function DraggableStackCard({
       {unsupported && (
         <div
           className="absolute top-1 right-1 z-30 rounded-full bg-warning/90 text-white p-0.5 shadow"
-          title="Missing from local card data; compatibility depends on the selected engine"
+          title="Unsupported by the Manabrew engine; export remains available for other engines"
         >
           <AlertTriangle className="h-3 w-3" />
         </div>
@@ -701,7 +701,7 @@ function CardVisual({
       {unsupported && (
         <div
           className="absolute top-1 right-1 z-30 rounded-full bg-warning/90 text-white p-0.5 shadow"
-          title="Missing from local card data; compatibility depends on the selected engine"
+          title="Unsupported by the Manabrew engine; export remains available for other engines"
         >
           <AlertTriangle className="h-3 w-3" />
         </div>
@@ -888,14 +888,14 @@ function CardRow({
       {unsupported && (
         <AlertTriangle
           className="h-3 w-3 text-warning shrink-0"
-          aria-label="Card missing from local card data"
+          aria-label="Card unsupported by the Manabrew engine"
         />
       )}
       <span
         className={cn("text-sm flex-1 truncate", unsupported && "text-warning")}
         title={
           unsupported
-            ? `${name} - missing from local card data; compatibility depends on the selected engine`
+            ? `${name} - unsupported by the Manabrew engine; export remains available for other engines`
             : name
         }
       >

--- a/src/components/editor/DeckValidationPanel.tsx
+++ b/src/components/editor/DeckValidationPanel.tsx
@@ -2,7 +2,7 @@ import { AlertTriangle } from "lucide-react";
 import { useDeckStore } from "@/stores/useDeckStore";
 import { getFormat, validateDeckSections } from "@/lib/formats";
 
-export function DeckValidationPanel({ unsupportedNames }: { unsupportedNames?: Set<string> }) {
+export function DeckValidationPanel() {
   const { currentDeck } = useDeckStore();
 
   const format = getFormat(currentDeck.format ?? "standard");
@@ -16,17 +16,9 @@ export function DeckValidationPanel({ unsupportedNames }: { unsupportedNames?: S
     format,
   );
 
-  const unsupportedList = unsupportedNames ? [...unsupportedNames].sort() : [];
-  const hasUnsupported = unsupportedList.length > 0;
+  if (validation.legal) return null;
 
-  if (validation.legal && !hasUnsupported) return null;
-
-  const unsupportedErrors = hasUnsupported
-    ? [
-        `${unsupportedList.length} card${unsupportedList.length === 1 ? "" : "s"} not implemented by the engine - playable build blocked, save as draft only: ${unsupportedList.join(", ")}`,
-      ]
-    : [];
-  const errors = [...unsupportedErrors, ...validation.errors];
+  const errors = validation.errors;
   const count = errors.length;
 
   return (

--- a/src/components/editor/DeckValidationPanel.tsx
+++ b/src/components/editor/DeckValidationPanel.tsx
@@ -2,7 +2,7 @@ import { AlertTriangle } from "lucide-react";
 import { useDeckStore } from "@/stores/useDeckStore";
 import { getFormat, validateDeckSections } from "@/lib/formats";
 
-export function DeckValidationPanel() {
+export function DeckValidationPanel({ unsupportedNames }: { unsupportedNames?: Set<string> }) {
   const { currentDeck } = useDeckStore();
 
   const format = getFormat(currentDeck.format ?? "standard");
@@ -16,9 +16,16 @@ export function DeckValidationPanel() {
     format,
   );
 
-  if (validation.legal) return null;
+  const unsupportedList = unsupportedNames ? [...unsupportedNames].sort() : [];
+  if (validation.legal && unsupportedList.length === 0) return null;
 
-  const errors = validation.errors;
+  const compatibilityErrors =
+    unsupportedList.length > 0
+      ? [
+          `${unsupportedList.length} card${unsupportedList.length === 1 ? " is" : "s are"} unsupported by the Manabrew engine; export remains available for other engines: ${unsupportedList.join(", ")}`,
+        ]
+      : [];
+  const errors = [...compatibilityErrors, ...validation.errors];
   const count = errors.length;
 
   return (

--- a/src/components/limited/DraftCardTile.tsx
+++ b/src/components/limited/DraftCardTile.tsx
@@ -37,11 +37,23 @@ function DraftCardTileImpl({
       }),
     hide: () => preview?.dismiss(),
   });
-  if (!deckCard) {
+  const hasImage = !deckCard.uris.normal.startsWith("data:");
+  if (!hasImage) {
     return (
-      <div className="relative w-full">
-        <div className="aspect-[5/7] w-full animate-pulse rounded-lg border border-border/50 bg-muted/40" />
-      </div>
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
+        className="relative aspect-[5/7] w-full rounded-lg border border-border/70 bg-card p-2 text-left text-xs font-medium shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        <span className="break-words">{card.name}</span>
+        {card.setCode && (
+          <span className="absolute bottom-2 left-2 font-mono text-[10px] uppercase text-muted-foreground">
+            {card.setCode}
+          </span>
+        )}
+        {overlay}
+      </button>
     );
   }
   return (

--- a/src/components/limited/DraftCardTile.tsx
+++ b/src/components/limited/DraftCardTile.tsx
@@ -17,6 +17,8 @@ interface DraftCardTileProps {
   disabled?: boolean;
   preview?: ReturnType<typeof useCardPreview>;
   overlay?: React.ReactNode;
+  selected?: boolean;
+  pickPending?: boolean;
 }
 
 function DraftCardTileImpl({
@@ -26,6 +28,8 @@ function DraftCardTileImpl({
   disabled,
   preview,
   overlay,
+  selected = false,
+  pickPending = false,
 }: DraftCardTileProps) {
   const deckCard = useDeckCard(card, index);
   const longPress = useLongPressPreview<DeckCard>({
@@ -44,7 +48,11 @@ function DraftCardTileImpl({
         type="button"
         onClick={onClick}
         disabled={disabled}
-        className="relative aspect-[5/7] w-full rounded-lg border border-border/70 bg-card p-2 text-left text-xs font-medium shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
+        className={cn(
+          "relative aspect-[5/7] w-full rounded-lg border border-border/70 bg-card p-2 text-left text-xs font-medium shadow-sm disabled:cursor-not-allowed disabled:opacity-60",
+          selected && "ring-2 ring-primary",
+          selected && pickPending && "animate-draft-card-pick",
+        )}
       >
         <span className="break-words">{card.name}</span>
         {card.setCode && (
@@ -69,6 +77,8 @@ function DraftCardTileImpl({
       className={cn(
         "group relative w-full text-left transition hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-60",
         card.foil && "draft-tile-foil",
+        selected && "z-10 ring-2 ring-primary",
+        selected && pickPending && "animate-draft-card-pick",
       )}
     >
       <CardThumbnail card={deckCard} />

--- a/src/components/limited/DraftPodButton.tsx
+++ b/src/components/limited/DraftPodButton.tsx
@@ -28,12 +28,21 @@ export function DraftPodButton({ seats }: DraftPodButtonProps) {
         </DropdownMenuLabel>
         <ul className="space-y-1 px-2 pb-2 text-sm">
           {seats.map((s) => (
-            <li key={s.seat} className="flex items-center justify-between gap-3">
+            <li
+              key={s.seat}
+              className="flex items-center justify-between gap-3 rounded px-1 py-0.5"
+            >
               <span className={s.isHuman ? "font-semibold" : ""}>
                 {s.seat}. {s.name}
               </span>
-              <span className="shrink-0 text-muted-foreground">
-                {s.picksMade} pick{s.picksMade === 1 ? "" : "s"}
+              <span className="shrink-0 text-right text-[11px] text-muted-foreground">
+                <span className="block">
+                  {s.currentPackSize ?? 0} cards
+                  {(s.packsWaiting ?? 0) > 0 ? ` · ${s.packsWaiting} waiting` : ""}
+                </span>
+                <span className="block">
+                  {s.awaitingPick ? "Picking" : `${s.picksMade} picked`}
+                </span>
               </span>
             </li>
           ))}

--- a/src/components/limited/DraftPoolPanel.tsx
+++ b/src/components/limited/DraftPoolPanel.tsx
@@ -1,0 +1,47 @@
+import { Button } from "@/components/ui/button";
+import { DraftCardTile } from "@/components/limited/DraftCardTile";
+import { LimitedDeckStats } from "@/components/limited/LimitedDeckStats";
+import type { useCardPreview } from "@/hooks/useCardPreview";
+import type { DraftCard } from "@/types/limited";
+
+interface DraftPoolPanelProps {
+  cards: DraftCard[];
+  preview: ReturnType<typeof useCardPreview>;
+  onBuild?: () => void;
+}
+
+export function DraftPoolPanel({ cards, preview, onBuild }: DraftPoolPanelProps) {
+  return (
+    <section className="flex min-h-0 flex-1 flex-col rounded-md border border-border/70 bg-card/20">
+      <div className="flex items-center justify-between border-b border-border/40 px-3 py-2">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Picks ({cards.length})
+        </h2>
+        {onBuild && cards.length > 0 && (
+          <Button size="sm" variant="outline" onClick={onBuild} className="h-7 text-xs">
+            Build
+          </Button>
+        )}
+      </div>
+      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto p-3">
+        <LimitedDeckStats cards={cards} compact />
+        {cards.length === 0 ? (
+          <p className="text-xs text-muted-foreground">
+            Your picks and live deck analysis appear here.
+          </p>
+        ) : (
+          <div className="grid grid-cols-3 gap-1.5 sm:grid-cols-4 lg:grid-cols-3">
+            {cards.map((card, index) => (
+              <DraftCardTile
+                key={`${card.name}:${card.setCode}:${card.cardNumber}:${index}`}
+                card={card}
+                index={index}
+                preview={preview}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/limited/DraftPreviewPanel.tsx
+++ b/src/components/limited/DraftPreviewPanel.tsx
@@ -1,0 +1,55 @@
+import { ChevronDown, ChevronUp, Image as ImageIcon } from "lucide-react";
+
+interface DraftPreviewPanelProps {
+  setSlot: (element: HTMLDivElement | null) => void;
+  collapsed: boolean;
+  onCollapse: () => void;
+}
+
+export function DraftPreviewPanel({ setSlot, collapsed, onCollapse }: DraftPreviewPanelProps) {
+  if (collapsed) {
+    return (
+      <button
+        type="button"
+        className="flex h-9 shrink-0 items-center justify-between rounded-md border border-border/70 bg-card/20 px-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground transition-colors hover:bg-muted/40"
+        onClick={onCollapse}
+        title="Show card preview"
+      >
+        Preview
+        <ChevronUp className="h-3.5 w-3.5" />
+      </button>
+    );
+  }
+
+  return (
+    <section className="flex h-[372px] shrink-0 flex-col overflow-hidden rounded-md border border-border/70 bg-card/20">
+      <div className="flex h-9 shrink-0 items-center justify-between border-b border-border/40 px-3">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Preview
+        </h2>
+        <button
+          type="button"
+          className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted"
+          onClick={onCollapse}
+          title="Hide card preview"
+        >
+          <ChevronDown className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      <div
+        ref={setSlot}
+        className="relative flex min-h-0 flex-1 items-start justify-center overflow-hidden p-2 [&:has([data-card-preview])_[data-preview-skeleton]]:opacity-0"
+      >
+        <div
+          data-preview-skeleton
+          className="pointer-events-none absolute inset-2 flex flex-col items-center justify-center gap-3 text-muted-foreground/70 transition-opacity"
+        >
+          <div className="flex aspect-[5/7] h-full max-h-[312px] items-center justify-center rounded-xl border-2 border-dashed border-border/60 bg-background/30">
+            <ImageIcon className="h-10 w-10 text-muted-foreground/40" />
+          </div>
+          <span className="text-xs">Hover a card to preview</span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/limited/DraftStatusBar.tsx
+++ b/src/components/limited/DraftStatusBar.tsx
@@ -1,0 +1,95 @@
+import { ArrowLeft, ArrowRight, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { DraftPodButton } from "@/components/limited/DraftPodButton";
+import { LimitedModeToggle, type LimitedDraftMode } from "@/components/limited/LimitedModeToggle";
+import type { DraftState } from "@/types/limited";
+
+interface DraftStatusBarProps {
+  draft: DraftState;
+  mode?: LimitedDraftMode;
+  onModeChange?: (mode: LimitedDraftMode) => void;
+  onUndo?: () => void;
+  canBuild?: boolean;
+  seatLabel?: string;
+  isHost?: boolean;
+  waitingLabel?: string;
+  viewerSeat?: number;
+}
+
+export function DraftStatusBar({
+  draft,
+  mode,
+  onModeChange,
+  onUndo,
+  canBuild = false,
+  seatLabel,
+  isHost = false,
+  waitingLabel = "AI thinking…",
+  viewerSeat = 0,
+}: DraftStatusBarProps) {
+  const PassIcon = draft.passDirection === "right" ? ArrowRight : ArrowLeft;
+  const packsWaiting =
+    draft.seatSummaries.find((seat) => seat.seat === viewerSeat)?.packsWaiting ?? 0;
+
+  return (
+    <header className="z-10 flex shrink-0 flex-wrap items-center justify-between gap-2 rounded-md border border-border/70 bg-background/95 px-3 py-2 shadow-sm backdrop-blur">
+      <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+        <span className="font-medium text-foreground">
+          Round {draft.round}/{draft.totalRounds} · Pick {draft.pickNumber}
+        </span>
+        <span className="inline-flex items-center gap-1 rounded bg-muted/60 px-1.5 py-0.5 text-[11px]">
+          <PassIcon className="h-3 w-3" /> Pass {draft.passDirection ?? "left"}
+        </span>
+        <span className="rounded bg-muted/60 px-1.5 py-0.5 text-[11px]">
+          {draft.currentPack.length} in pack
+        </span>
+        {packsWaiting > 0 && (
+          <span className="rounded bg-muted/60 px-1.5 py-0.5 text-[11px]">
+            {packsWaiting} waiting
+          </span>
+        )}
+        {seatLabel && (
+          <span className="rounded bg-muted/60 px-1.5 py-0.5 text-[11px]">{seatLabel}</span>
+        )}
+        {isHost && (
+          <span className="rounded bg-primary/15 px-1.5 py-0.5 text-[11px] font-medium text-primary">
+            Host
+          </span>
+        )}
+        {draft.isComplete ? (
+          <span className="rounded bg-primary/15 px-1.5 py-0.5 text-[11px] font-medium text-primary">
+            Draft complete
+          </span>
+        ) : draft.awaitingHuman ? (
+          <span className="rounded bg-primary/15 px-1.5 py-0.5 text-[11px] font-medium text-primary">
+            {draft.picksPerPass > 1 && draft.picksRemainingInPack > 0
+              ? `Your pick · ${draft.picksRemainingInPack} remaining`
+              : "Your pick"}
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-1.5 rounded bg-muted/60 px-1.5 py-0.5 text-[11px] font-medium">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            {waitingLabel}
+          </span>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <DraftPodButton seats={draft.seatSummaries} />
+        {canBuild && onUndo && (
+          <Button size="sm" variant="ghost" onClick={onUndo} className="h-8 px-2 text-xs">
+            Undo pick
+          </Button>
+        )}
+        {canBuild && mode && onModeChange && (
+          <LimitedModeToggle
+            mode={mode}
+            onChange={onModeChange}
+            disableDrafting={draft.isComplete}
+          />
+        )}
+      </div>
+    </header>
+  );
+}

--- a/src/components/limited/DraftWorkspace.tsx
+++ b/src/components/limited/DraftWorkspace.tsx
@@ -1,0 +1,152 @@
+import { useState } from "react";
+
+import { HoverCardPreview } from "@/components/game/HoverCardPreview";
+import { PreviewRail } from "@/components/editor/PreviewRail";
+import { DraftCardTile } from "@/components/limited/DraftCardTile";
+import { DraftPoolPanel } from "@/components/limited/DraftPoolPanel";
+import { LimitedHoverPreviewPane } from "@/components/limited/LimitedHoverPreviewPane";
+import {
+  LimitedWorkspaceTabs,
+  type LimitedWorkspaceTab,
+} from "@/components/limited/LimitedWorkspaceTabs";
+import { RaritySetBadge } from "@/components/limited/RaritySetBadge";
+import { useCardPreview } from "@/hooks/useCardPreview";
+import { cn } from "@/lib/utils";
+import type { ConspiracyHook, DraftCard, DraftState } from "@/types/limited";
+
+interface DraftWorkspaceProps {
+  draft: DraftState;
+  onPick: (card: DraftCard) => void | Promise<void>;
+  onBuild?: () => void;
+  pickPending?: boolean;
+  conspiracyHooks?: ConspiracyHook[];
+}
+
+function cardKey(card: DraftCard, index: number): string {
+  return `${card.name}:${card.setCode}:${card.cardNumber}:${index}`;
+}
+
+export function DraftWorkspace({
+  draft,
+  onPick,
+  onBuild,
+  pickPending = false,
+  conspiracyHooks = [],
+}: DraftWorkspaceProps) {
+  const preview = useCardPreview([draft.round, draft.pickNumber]);
+  const [mobileTab, setMobileTab] = useState<LimitedWorkspaceTab>("pack");
+  const [selectedCardKey, setSelectedCardKey] = useState<string | null>(null);
+  const [previewSlot, setPreviewSlot] = useState<HTMLDivElement | null>(null);
+  const [previewCollapsed, setPreviewCollapsed] = useState(true);
+  const packKey = `${draft.round}:${draft.pickNumber}:${draft.currentPack.length}`;
+  const selectedStillVisible = draft.currentPack.some(
+    (card, index) => cardKey(card, index) === selectedCardKey,
+  );
+  const visibleSelectedKey = selectedStillVisible ? selectedCardKey : null;
+
+  const submitPick = (card: DraftCard, index: number) => {
+    if (!draft.awaitingHuman || pickPending) return;
+    setSelectedCardKey(cardKey(card, index));
+    void Promise.resolve(onPick(card)).catch(() => setSelectedCardKey(null));
+  };
+
+  const packPanel = (
+    <section className="flex min-h-0 flex-1 flex-col rounded-md border border-border/70 bg-card/20">
+      <div className="flex items-center justify-between border-b border-border/40 px-3 py-2">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Current pack ({draft.currentPack.length})
+        </h2>
+        <span className="text-[11px] text-muted-foreground">
+          {draft.awaitingHuman ? "Choose a card" : "Waiting for the next pack"}
+        </span>
+      </div>
+      <div
+        key={packKey}
+        className="min-h-0 flex-1 overflow-y-auto p-3 motion-safe:animate-draft-pack-arrive"
+      >
+        {draft.currentPack.length === 0 ? (
+          <div className="flex h-full min-h-48 items-center justify-center text-sm text-muted-foreground">
+            Waiting for a pack…
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
+            {draft.currentPack.map((card, index) => {
+              const key = cardKey(card, index);
+              return (
+                <DraftCardTile
+                  key={key}
+                  card={card}
+                  index={index}
+                  onClick={() => submitPick(card, index)}
+                  disabled={!draft.awaitingHuman || pickPending}
+                  preview={preview}
+                  selected={visibleSelectedKey === key}
+                  pickPending={pickPending}
+                  overlay={<RaritySetBadge card={card} />}
+                />
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+
+  const poolPanel = (
+    <div className="flex min-h-0 flex-1 flex-col gap-3">
+      {draft.humanConspiracies && draft.humanConspiracies.length > 0 && (
+        <section className="shrink-0 rounded-md border border-primary/40 bg-primary/5 p-3 text-xs">
+          <h2 className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-primary">
+            Conspiracies ({draft.humanConspiracies.length})
+          </h2>
+          <ul className="space-y-1">
+            {draft.humanConspiracies.map((name) => {
+              const hook = conspiracyHooks.find((candidate) => candidate.cardName === name);
+              return (
+                <li key={name}>
+                  <span className="font-medium">{name}</span>
+                  {hook && <span className="ml-1 text-muted-foreground">· {hook.description}</span>}
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      )}
+      <DraftPoolPanel cards={draft.pickedPile} preview={preview} onBuild={onBuild} />
+    </div>
+  );
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden">
+      <LimitedWorkspaceTabs value={mobileTab} onChange={setMobileTab} />
+
+      <div className="hidden min-h-0 flex-1 gap-3 overflow-hidden lg:flex">
+        <div className="flex min-w-0 flex-[2]">{packPanel}</div>
+        <aside className="flex w-[320px] min-h-0 shrink-0 xl:w-[360px]">{poolPanel}</aside>
+        <div className="hidden min-h-0 overflow-hidden 2xl:flex">
+          <PreviewRail
+            setSlot={setPreviewSlot}
+            collapsed={previewCollapsed}
+            onCollapse={() => setPreviewCollapsed((value) => !value)}
+            defaultWidth={300}
+          />
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-hidden lg:hidden">
+        <div className={cn("h-full", mobileTab !== "pack" && "hidden")}>{packPanel}</div>
+        <div className={cn("flex h-full", mobileTab !== "picks" && "hidden")}>{poolPanel}</div>
+        <div className={cn("h-full", mobileTab !== "preview" && "hidden")}>
+          <LimitedHoverPreviewPane preview={preview} className="h-full" />
+        </div>
+      </div>
+
+      <HoverCardPreview
+        preview={preview}
+        slot={previewSlot}
+        pinned={Boolean(previewSlot)}
+        imageSize="normal"
+      />
+    </div>
+  );
+}

--- a/src/components/limited/DraftWorkspace.tsx
+++ b/src/components/limited/DraftWorkspace.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
 
 import { HoverCardPreview } from "@/components/game/HoverCardPreview";
-import { PreviewRail } from "@/components/editor/PreviewRail";
 import { DraftCardTile } from "@/components/limited/DraftCardTile";
 import { DraftPoolPanel } from "@/components/limited/DraftPoolPanel";
+import { DraftPreviewPanel } from "@/components/limited/DraftPreviewPanel";
 import { LimitedHoverPreviewPane } from "@/components/limited/LimitedHoverPreviewPane";
 import {
   LimitedWorkspaceTabs,
@@ -37,7 +37,11 @@ export function DraftWorkspace({
   const [mobileTab, setMobileTab] = useState<LimitedWorkspaceTab>("pack");
   const [selectedCardKey, setSelectedCardKey] = useState<string | null>(null);
   const [previewSlot, setPreviewSlot] = useState<HTMLDivElement | null>(null);
-  const [previewCollapsed, setPreviewCollapsed] = useState(true);
+  const [previewCollapsed, setPreviewCollapsed] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.localStorage.getItem("draft.previewPanelCollapsed") === "true",
+  );
   const packKey = `${draft.round}:${draft.pickNumber}:${draft.currentPack.length}`;
   const selectedStillVisible = draft.currentPack.some(
     (card, index) => cardKey(card, index) === selectedCardKey,
@@ -48,6 +52,14 @@ export function DraftWorkspace({
     if (!draft.awaitingHuman || pickPending) return;
     setSelectedCardKey(cardKey(card, index));
     void Promise.resolve(onPick(card)).catch(() => setSelectedCardKey(null));
+  };
+
+  const togglePreview = () => {
+    setPreviewCollapsed((value) => {
+      const next = !value;
+      window.localStorage.setItem("draft.previewPanelCollapsed", String(next));
+      return next;
+    });
   };
 
   const packPanel = (
@@ -122,15 +134,14 @@ export function DraftWorkspace({
 
       <div className="hidden min-h-0 flex-1 gap-3 overflow-hidden lg:flex">
         <div className="flex min-w-0 flex-[2]">{packPanel}</div>
-        <aside className="flex w-[320px] min-h-0 shrink-0 xl:w-[360px]">{poolPanel}</aside>
-        <div className="hidden min-h-0 overflow-hidden 2xl:flex">
-          <PreviewRail
+        <aside className="flex min-h-0 w-[320px] shrink-0 flex-col gap-3 xl:w-[360px]">
+          {poolPanel}
+          <DraftPreviewPanel
             setSlot={setPreviewSlot}
             collapsed={previewCollapsed}
-            onCollapse={() => setPreviewCollapsed((value) => !value)}
-            defaultWidth={300}
+            onCollapse={togglePreview}
           />
-        </div>
+        </aside>
       </div>
 
       <div className="min-h-0 flex-1 overflow-hidden lg:hidden">

--- a/src/components/limited/LimitedDeckBuilder.tsx
+++ b/src/components/limited/LimitedDeckBuilder.tsx
@@ -25,6 +25,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { CardThumbnail } from "@/components/editor/deckEditor.primitives";
+import { exportToArena } from "@/components/editor/deckBuilder.utils";
 import { ManaSymbols } from "@/components/game/ManaSymbols";
 import { DraftCardTile } from "@/components/limited/DraftCardTile";
 import { LimitedCompareDialog } from "@/components/limited/LimitedCompareDialog";
@@ -411,6 +412,26 @@ export default function LimitedDeckBuilder({
     }
   };
 
+  const handleExport = async () => {
+    try {
+      const mainCards = main.map((i) => fullPool[i]).filter(Boolean);
+      const sideboardCards = sideboard.map((i) => fullPool[i]).filter(Boolean);
+      const leftoverCards = unused
+        .map((i) => fullPool[i])
+        .filter((c): c is DraftCard => Boolean(c) && !isSynthBasic(c));
+      const [resolvedMain, resolvedSide] = await Promise.all([
+        resolveDeckCards(mainCards),
+        resolveDeckCards([...sideboardCards, ...leftoverCards]),
+      ]);
+      await navigator.clipboard.writeText(
+        exportToArena({ name: defaultDeckName, cards: resolvedMain, sideboard: resolvedSide }),
+      );
+      toast.success("Deck copied to clipboard.");
+    } catch {
+      toast.error("Couldn't copy the deck. Try again.");
+    }
+  };
+
   return (
     <DndContext
       sensors={sensors}
@@ -437,6 +458,7 @@ export default function LimitedDeckBuilder({
           confirmLabel={confirmLabel}
           onConfirm={onConfirm ? handleConfirm : undefined}
           onSaveToMyDecks={openSaveDialog}
+          onExport={handleExport}
         />
 
         <div className="grid flex-1 grid-cols-1 gap-3 overflow-hidden md:grid-cols-2 md:grid-rows-2 lg:grid-cols-[1.4fr_1fr_0.7fr_minmax(0,326px)] lg:grid-rows-1">
@@ -590,6 +612,7 @@ interface ToolbarProps {
   confirmLabel: string;
   onConfirm?: () => void;
   onSaveToMyDecks: () => void;
+  onExport: () => void;
 }
 
 function Toolbar({
@@ -609,6 +632,7 @@ function Toolbar({
   confirmLabel,
   onConfirm,
   onSaveToMyDecks,
+  onExport,
 }: ToolbarProps) {
   const mainShortBy = targetMainSize - mainCount;
   const filterActive = colorFilter.size > 0;
@@ -718,6 +742,9 @@ function Toolbar({
         )}
         <Button size="sm" variant="outline" onClick={onSaveToMyDecks}>
           Save to My Decks
+        </Button>
+        <Button size="sm" variant="outline" onClick={onExport}>
+          Copy decklist
         </Button>
         {onConfirm && (
           <Button onClick={onConfirm} disabled={mainCount < targetMainSize}>

--- a/src/components/limited/LimitedDeckStats.tsx
+++ b/src/components/limited/LimitedDeckStats.tsx
@@ -9,12 +9,13 @@ import type { DraftCard } from "@/types/limited";
 interface Props {
   cards: DraftCard[];
   className?: string;
+  compact?: boolean;
 }
 
 const COLOR_KEYS = ["W", "U", "B", "R", "G"] as const;
 type ColorKey = (typeof COLOR_KEYS)[number];
 
-export function LimitedDeckStats({ cards, className }: Props) {
+export function LimitedDeckStats({ cards, className, compact = false }: Props) {
   const cacheBucket = useScryfallStore((s) => s.cards);
 
   const stats = useMemo(() => {
@@ -72,6 +73,7 @@ export function LimitedDeckStats({ cards, className }: Props) {
     <div
       className={cn(
         "grid grid-cols-1 gap-3 rounded-md border border-border/70 bg-card/40 p-3 text-xs lg:grid-cols-3",
+        compact && "gap-2 p-2 lg:grid-cols-1",
         className,
       )}
     >

--- a/src/components/limited/LimitedWorkspaceTabs.tsx
+++ b/src/components/limited/LimitedWorkspaceTabs.tsx
@@ -1,0 +1,41 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type LimitedWorkspaceTab = "pack" | "picks" | "preview";
+
+interface LimitedWorkspaceTabsProps {
+  value: LimitedWorkspaceTab;
+  onChange: (value: LimitedWorkspaceTab) => void;
+  packLabel?: string;
+}
+
+export function LimitedWorkspaceTabs({
+  value,
+  onChange,
+  packLabel = "Pack",
+}: LimitedWorkspaceTabsProps) {
+  const tabs: Array<{ value: LimitedWorkspaceTab; label: string }> = [
+    { value: "pack", label: packLabel },
+    { value: "picks", label: "Picks" },
+    { value: "preview", label: "Preview" },
+  ];
+
+  return (
+    <div className="grid shrink-0 grid-cols-3 rounded-md border border-border/70 bg-card/40 p-1 lg:hidden">
+      {tabs.map((tab) => (
+        <Button
+          key={tab.value}
+          size="sm"
+          variant="ghost"
+          onClick={() => onChange(tab.value)}
+          className={cn(
+            "h-8 text-xs",
+            value === tab.value && "bg-secondary text-secondary-foreground",
+          )}
+        >
+          {tab.label}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/lobby/CreateRoomDialog.tsx
+++ b/src/components/lobby/CreateRoomDialog.tsx
@@ -797,7 +797,7 @@ export function CreateRoomDialog({ open, onOpenChange }: CreateRoomDialogProps) 
                     Loaded: <span className="text-foreground/90">{importedCube.name}</span> —{" "}
                     {importedCube.cardCount} cards
                     {importedCube.rejectedCardCount > 0 &&
-                      ` · ${importedCube.rejectedCardCount} unsupported`}
+                      ` · ${importedCube.rejectedCardCount} without local engine data`}
                   </p>
                 )}
                 {cubeImportError && !importedCube && !importingCube && (

--- a/src/game/draftHost.ts
+++ b/src/game/draftHost.ts
@@ -118,6 +118,7 @@ export async function startDraftAsHost(args: {
         rounds: config.rounds,
         pool,
         picksPerPass: config.picksPerPass,
+        customPool: Boolean(config.cubeId),
         seed: config.seed,
       },
       humans: seats.filter((s) => s.isHuman).map((s) => ({ seat: s.seat, name: s.displayName })),

--- a/src/game/draftHost.ts
+++ b/src/game/draftHost.ts
@@ -167,7 +167,7 @@ export async function startDraftAsHost(args: {
 
 function enqueuePick(
   seat: number,
-  cardName: string,
+  card: DraftCard,
   round?: number,
   pickNumber?: number,
 ): Promise<void> {
@@ -176,17 +176,17 @@ function enqueuePick(
     .catch((err) => {
       console.error("[draftHost] pick chain swallowed error:", err);
     })
-    .then(() => applyPick(seat, cardName, round, pickNumber));
+    .then(() => applyPick(seat, card, round, pickNumber));
   active.pendingChain = next;
   return next;
 }
 
-export async function submitHostPick(cardName: string): Promise<void> {
+export async function submitHostPick(card: DraftCard): Promise<void> {
   if (!active) return;
   const store = useMultiplayerDraftStore.getState();
   if (store.pickPending) return;
   store.setPickPending(true);
-  await enqueuePick(active.mySeat, cardName, store.state?.round, store.state?.pickNumber);
+  await enqueuePick(active.mySeat, card, store.state?.round, store.state?.pickNumber);
 }
 
 async function onRelay(payload: { from_player: string; state: RoomRelayEnvelope }): Promise<void> {
@@ -201,12 +201,22 @@ async function onRelay(payload: { from_player: string; state: RoomRelayEnvelope 
     console.warn("[draftHost] pick from unknown player", payload.from_player);
     return;
   }
-  await enqueuePick(seat.seat, pick.cardName, pick.round, pick.pickNumber);
+  await enqueuePick(
+    seat.seat,
+    {
+      id: "",
+      name: pick.cardName,
+      setCode: pick.setCode ?? "",
+      cardNumber: pick.cardNumber ?? "",
+    },
+    pick.round,
+    pick.pickNumber,
+  );
 }
 
 async function applyPick(
   seat: number,
-  cardName: string,
+  card: DraftCard,
   round?: number,
   pickNumber?: number,
 ): Promise<void> {
@@ -217,7 +227,7 @@ async function applyPick(
     const current = await fetchSeatState(session.sessionId, seat);
     if (current && (current.round !== round || current.pickNumber !== pickNumber)) {
       console.warn(
-        `[draftHost] dropping stale pick "${cardName}" from seat ${seat} — sent at round ${round} pick ${pickNumber}, seat is now at round ${current.round} pick ${current.pickNumber}`,
+        `[draftHost] dropping stale pick "${card.name}" from seat ${seat} — sent at round ${round} pick ${pickNumber}, seat is now at round ${current.round} pick ${current.pickNumber}`,
       );
       if (seat === session.mySeat) useMultiplayerDraftStore.getState().setPickPending(false);
       return;
@@ -228,7 +238,9 @@ async function applyPick(
     nextState = await platform.invoke<DraftState>("limited_submit_pick", {
       sessionId: session.sessionId,
       seatIdx: seat,
-      cardName,
+      cardName: card.name,
+      setCode: card.setCode,
+      cardNumber: card.cardNumber,
     });
   } catch (err) {
     useMultiplayerDraftStore.getState().setError(`pick failed: ${String(err)}`);

--- a/src/game/draftPeer.ts
+++ b/src/game/draftPeer.ts
@@ -8,6 +8,7 @@ import {
 import { getPlatform } from "@/platform";
 import { useMultiplayerDraftStore } from "@/stores/useMultiplayerDraftStore";
 import { useServerStore } from "@/stores/useServerStore";
+import type { DraftCard } from "@/types/limited";
 import type { RoomRelayEnvelope } from "@/types/server";
 
 let active: { unsubscribe: () => void; myPlayerSlot: string } | null = null;
@@ -117,7 +118,7 @@ function handleStateUpdate(msg: DraftStateBroadcastMessage): void {
   store.setLocalState(msg.state);
 }
 
-export async function submitPeerPick(cardName: string): Promise<void> {
+export async function submitPeerPick(card: DraftCard): Promise<void> {
   const store = useMultiplayerDraftStore.getState();
   if (!store.sessionId || store.mySeat == null || store.amHost) return;
   if (store.pickPending) return;
@@ -132,7 +133,9 @@ export async function submitPeerPick(cardName: string): Promise<void> {
   const msg: DraftPickMessage = {
     type: "pick",
     sessionId: store.sessionId,
-    cardName,
+    cardName: card.name,
+    setCode: card.setCode,
+    cardNumber: card.cardNumber,
     round: store.state?.round,
     pickNumber: store.state?.pickNumber,
   };

--- a/src/game/draftRelay.ts
+++ b/src/game/draftRelay.ts
@@ -39,6 +39,8 @@ export interface DraftPickMessage {
   type: "pick";
   sessionId: string;
   cardName: string;
+  setCode?: string;
+  cardNumber?: string;
   round?: number;
   pickNumber?: number;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -151,6 +151,30 @@
   --animate-preview-in: preview-in 220ms cubic-bezier(0.16, 1, 0.3, 1) both;
   --animate-preview-out: preview-out 130ms ease-in both;
   --animate-preview-fade-in: preview-fade-in 150ms ease-out both;
+  --animate-draft-pack-arrive: draft-pack-arrive 220ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  --animate-draft-card-pick: draft-card-pick 280ms cubic-bezier(0.4, 0, 0.2, 1) both;
+
+  @keyframes draft-pack-arrive {
+    from {
+      opacity: 0;
+      transform: translateY(10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes draft-card-pick {
+    0% {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+    100% {
+      opacity: 0.45;
+      transform: translateY(14px) scale(0.94);
+    }
+  }
 
   @keyframes hourglass-flip {
     0%,
@@ -390,7 +414,9 @@
   .animate-dice-roll,
   .animate-password-pip,
   .animate-preview-in,
-  .animate-preview-out {
+  .animate-preview-out,
+  .animate-draft-pack-arrive,
+  .animate-draft-card-pick {
     animation: none !important;
   }
 }

--- a/src/lib/limited.utils.ts
+++ b/src/lib/limited.utils.ts
@@ -138,8 +138,8 @@ export function refToDeckCard(
     identity: {
       id: `pool-${idx}-${ref.setCode}-${ref.cardNumber}`,
       name: frontFaceName(ref.name),
-      setCode: ref.setCode,
-      cardNumber: ref.cardNumber,
+      setCode: info?.set ?? ref.setCode,
+      cardNumber: info?.collector_number ?? ref.cardNumber,
       oracleId: info?.oracle_id,
       foil: ref.foil,
     },
@@ -176,13 +176,13 @@ export async function resolveDeckCards(refs: DraftCard[]): Promise<DeckCard[]> {
   );
 }
 
-export function useDeckCard(ref: DraftCard, idx: number): DeckCard | null {
+export function useDeckCard(ref: DraftCard, idx: number): DeckCard {
   const entry = useCard({
     name: ref.name,
     setCode: ref.setCode,
     cardNumber: ref.cardNumber,
   });
-  return useMemo(() => (entry ? refToDeckCard(ref, entry, idx) : null), [entry, ref, idx]);
+  return useMemo(() => refToDeckCard(ref, entry, idx), [entry, ref, idx]);
 }
 
 export function indexPool(pool: DraftCard[]): PoolEntry[] {

--- a/src/stores/useLimitedStore.ts
+++ b/src/stores/useLimitedStore.ts
@@ -38,7 +38,7 @@ interface LimitedStore {
   fetchSealedTemplates: () => Promise<void>;
 
   startBoosterDraft: (setup: BoosterDraftSetup) => Promise<DraftState>;
-  pickDraftCard: (sessionId: string, cardName: string) => Promise<DraftState>;
+  pickDraftCard: (sessionId: string, card: DraftCard) => Promise<DraftState>;
   undoDraftPick: (sessionId: string) => Promise<DraftState>;
   refreshDraftState: (sessionId: string) => Promise<void>;
 
@@ -135,11 +135,13 @@ export const useLimitedStore = create<LimitedStore>((set) => ({
     }
   },
 
-  pickDraftCard: async (sessionId, cardName) => {
+  pickDraftCard: async (sessionId, card) => {
     try {
       const state = await invoke<DraftState>("limited_pick_card", {
         sessionId,
-        cardName,
+        cardName: card.name,
+        setCode: card.setCode,
+        cardNumber: card.cardNumber,
       });
       set({ activeDraft: state, lastError: null });
       return state;

--- a/src/stores/useScryfallStore.ts
+++ b/src/stores/useScryfallStore.ts
@@ -118,7 +118,14 @@ async function fetchScryfallCard(lookup: ScryfallCardLookup): Promise<ScryfallCa
   if (!lookup.name) {
     throw new Error("Scryfall lookup requires a name or id");
   }
-  return getCardByName(lookup.name, lookup.setCode);
+  if (lookup.setCode) {
+    try {
+      return await getCardByName(lookup.name, lookup.setCode);
+    } catch {
+      return getCardByName(lookup.name);
+    }
+  }
+  return getCardByName(lookup.name);
 }
 
 function normalizeTokenId(id: string): string {
@@ -350,7 +357,14 @@ export const useScryfallStore = create<ScryfallState>()(
         set((state) => {
           state.cards[key] = { pendingPromise };
         });
-        return pendingPromise;
+        try {
+          return await pendingPromise;
+        } catch (error) {
+          set((state) => {
+            if (state.cards[key]?.pendingPromise === pendingPromise) delete state.cards[key];
+          });
+          throw error;
+        }
       },
       getCardTexture: async (deckCard, variant = "full", faceIndex = 0) => {
         const pick = (u: ScryfallImageUris | undefined) =>

--- a/src/types/limited.ts
+++ b/src/types/limited.ts
@@ -57,6 +57,9 @@ export interface DraftSeat {
   isHuman: boolean;
   picksMade: number;
   lastPickName: string | null;
+  currentPackSize?: number;
+  packsWaiting?: number;
+  awaitingPick?: boolean;
 }
 
 export interface DraftState {
@@ -74,6 +77,7 @@ export interface DraftState {
   humanConspiracies?: string[];
   picksPerPass: number;
   picksRemainingInPack: number;
+  passDirection?: "left" | "right";
 }
 
 export interface BoosterDraftSetup {

--- a/src/types/limited.ts
+++ b/src/types/limited.ts
@@ -83,6 +83,7 @@ export interface BoosterDraftSetup {
   variant?: string;
   seed?: number;
   picksPerPass?: number;
+  customPool?: boolean;
 }
 
 export interface WinstonSetup {
@@ -90,6 +91,7 @@ export interface WinstonSetup {
   pool: DraftCard[];
   variant?: string;
   seed?: number;
+  customPool?: boolean;
 }
 
 export interface WinstonState {

--- a/src/views/Draft.tsx
+++ b/src/views/Draft.tsx
@@ -1,26 +1,14 @@
 import { useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
-import { Loader2 } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
-import { LandscapeGate } from "@/components/LandscapeGate";
 import LimitedDeckBuilder from "@/components/limited/LimitedDeckBuilder";
-import { DraftCardTile } from "@/components/limited/DraftCardTile";
-import { DraftPodButton } from "@/components/limited/DraftPodButton";
-import { HoverCardPreview } from "@/components/game/HoverCardPreview";
-import { PreviewRail } from "@/components/editor/PreviewRail";
-import { LimitedModeToggle, type LimitedDraftMode } from "@/components/limited/LimitedModeToggle";
-import { RaritySetBadge } from "@/components/limited/RaritySetBadge";
-import { useCardPreview } from "@/hooks/useCardPreview";
+import { DraftStatusBar } from "@/components/limited/DraftStatusBar";
+import { DraftWorkspace } from "@/components/limited/DraftWorkspace";
+import type { LimitedDraftMode } from "@/components/limited/LimitedModeToggle";
 import { useLimitedStore } from "@/stores/useLimitedStore";
 import type { DraftCard } from "@/types/limited";
 
 type DraftMode = LimitedDraftMode;
-
-const RAIL_DEFAULT_WIDTH = 360;
-const RAIL_COMPACT_WIDTH = 300;
-const RAIL_FITS_AT_ROW_WIDTH = 880;
-const RAIL_WIDE_AT_ROW_WIDTH = 1120;
 
 export default function Draft() {
   const { draftId } = useParams<{ draftId: string }>();
@@ -93,51 +81,13 @@ export default function Draft() {
 
   return (
     <div className="flex h-full flex-col gap-4 px-4 py-6 sm:px-6 lg:px-8">
-      <LandscapeGate />
-      <header className="flex flex-wrap items-center justify-between gap-2">
-        <p className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-          <span>
-            Round {activeDraft.round} / {activeDraft.totalRounds} · Pick {activeDraft.pickNumber}
-          </span>
-          {activeDraft.isComplete ? (
-            <span className="rounded bg-primary/15 px-1.5 py-0.5 text-[11px] font-medium text-primary">
-              Complete
-            </span>
-          ) : activeDraft.awaitingHuman ? (
-            <span className="rounded bg-primary/15 px-1.5 py-0.5 text-[11px] font-medium text-primary">
-              {activeDraft.picksPerPass > 1 && activeDraft.picksRemainingInPack > 0
-                ? `Your pick (${activeDraft.picksRemainingInPack} of ${activeDraft.picksPerPass})`
-                : "Your pick"}
-            </span>
-          ) : (
-            <span className="inline-flex items-center gap-1.5 rounded bg-muted/60 px-1.5 py-0.5 text-[11px] font-medium">
-              <Loader2 className="h-3 w-3 animate-spin" />
-              AI thinking…
-            </span>
-          )}
-        </p>
-        <div className="flex items-center gap-2">
-          <DraftPodButton seats={activeDraft.seatSummaries} />
-          {canBuild && !activeDraft.isComplete && (
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={handleUndo}
-              className="h-8 px-2 text-xs"
-              title="Undo your last pick"
-            >
-              Undo pick
-            </Button>
-          )}
-          {canBuild && (
-            <LimitedModeToggle
-              mode={mode}
-              onChange={setUserMode}
-              disableDrafting={activeDraft.isComplete}
-            />
-          )}
-        </div>
-      </header>
+      <DraftStatusBar
+        draft={activeDraft}
+        mode={mode}
+        onModeChange={setUserMode}
+        onUndo={!activeDraft.isComplete ? handleUndo : undefined}
+        canBuild={canBuild}
+      />
 
       {mode === "building" ? (
         <div className="min-h-0 flex-1">
@@ -148,11 +98,10 @@ export default function Draft() {
           />
         </div>
       ) : (
-        <DraftingView
-          activeDraft={activeDraft}
+        <DraftWorkspace
+          draft={activeDraft}
           onPick={handlePick}
-          onJumpToBuild={() => setUserMode("building")}
-          canBuild={canBuild}
+          onBuild={canBuild ? () => setUserMode("building") : undefined}
           conspiracyHooks={conspiracyHooks}
           pickPending={picking}
         />
@@ -162,157 +111,6 @@ export default function Draft() {
         <p className="rounded border border-destructive/70 bg-destructive/10 p-3 text-sm text-destructive">
           {lastError}
         </p>
-      )}
-    </div>
-  );
-}
-
-export interface DraftingViewProps {
-  activeDraft: import("@/types/limited").DraftState;
-  onPick: (card: DraftCard) => void;
-  onJumpToBuild?: () => void;
-  canBuild?: boolean;
-  conspiracyHooks: ReturnType<typeof useLimitedStore.getState>["conspiracyHooks"];
-  pickPending?: boolean;
-}
-
-export function DraftingView({
-  activeDraft,
-  onPick,
-  onJumpToBuild,
-  canBuild = false,
-  conspiracyHooks,
-  pickPending = false,
-}: DraftingViewProps) {
-  const preview = useCardPreview([activeDraft.round, activeDraft.pickNumber]);
-  const [previewSlot, setPreviewSlot] = useState<HTMLDivElement | null>(null);
-  const [previewCollapsed, setPreviewCollapsed] = useState<boolean>(
-    () =>
-      typeof window !== "undefined" &&
-      window.localStorage.getItem("draft.previewRailCollapsed") === "true",
-  );
-  function togglePreview() {
-    setPreviewCollapsed((v) => {
-      const next = !v;
-      if (typeof window !== "undefined") {
-        window.localStorage.setItem("draft.previewRailCollapsed", String(next));
-      }
-      return next;
-    });
-  }
-  const rowRef = useRef<HTMLDivElement | null>(null);
-  const [rowWidth, setRowWidth] = useState(0);
-  useEffect(() => {
-    const el = rowRef.current;
-    if (!el) return;
-    const observer = new ResizeObserver(() => {
-      setRowWidth(el.clientWidth);
-    });
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
-  const railFits = rowWidth >= RAIL_FITS_AT_ROW_WIDTH;
-  return (
-    <div ref={rowRef} className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden md:flex-row">
-      <div className="min-h-0 flex-1 overflow-y-auto rounded-md border border-border/70 p-4">
-        <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-          Current Pack ({activeDraft.currentPack.length})
-        </h2>
-        {activeDraft.currentPack.length === 0 ? (
-          <p className="text-sm text-muted-foreground">Pack empty.</p>
-        ) : (
-          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5">
-            {activeDraft.currentPack.map((c, i) => (
-              <DraftCardTile
-                key={`${c.setCode}:${c.cardNumber}:${c.name}:${i}`}
-                card={c}
-                index={i}
-                onClick={() => onPick(c)}
-                disabled={!activeDraft.awaitingHuman || pickPending}
-                preview={preview}
-                overlay={<RaritySetBadge card={c} />}
-              />
-            ))}
-          </div>
-        )}
-      </div>
-
-      <aside className="flex min-h-0 flex-col gap-4 md:w-[280px] md:shrink-0 lg:w-[380px]">
-        {activeDraft.humanConspiracies && activeDraft.humanConspiracies.length > 0 && (
-          <section className="rounded-md border border-purple-500/40 bg-purple-500/10 p-3 text-xs">
-            <h2 className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-purple-200">
-              Conspiracies armed ({activeDraft.humanConspiracies.length})
-            </h2>
-            <ul className="space-y-1">
-              {activeDraft.humanConspiracies.map((name) => {
-                const hook = conspiracyHooks.find((h) => h.cardName === name);
-                return (
-                  <li key={name} className="rounded bg-purple-400/15 px-2 py-1.5 text-purple-100">
-                    <div className="font-medium">{name}</div>
-                    {hook && (
-                      <div className="text-[10px] text-purple-200/80">{hook.description}</div>
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
-          </section>
-        )}
-        <section className="flex min-h-0 flex-1 flex-col rounded-md border border-border/70">
-          <div className="flex items-center justify-between border-b border-border/40 px-4 py-2">
-            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-              Your Pile ({activeDraft.pickedPile.length})
-            </h2>
-            {canBuild && (
-              <Button size="sm" variant="outline" onClick={onJumpToBuild} className="h-7 text-xs">
-                Build
-              </Button>
-            )}
-          </div>
-          <div className="flex-1 overflow-y-auto p-4">
-            {activeDraft.pickedPile.length === 0 ? (
-              <p className="text-xs text-muted-foreground">No picks yet.</p>
-            ) : (
-              <div className="grid grid-cols-3 gap-1.5">
-                {activeDraft.pickedPile.map((c, i) => (
-                  <DraftCardTile
-                    key={`picked-${i}`}
-                    card={c}
-                    index={i}
-                    preview={preview}
-                    overlay={
-                      <span
-                        className="pointer-events-none absolute right-1 top-1 rounded-full border border-white/20 bg-black/70 px-1.5 py-0.5 text-[9px] font-bold text-white/90"
-                        title={`Pick #${i + 1}`}
-                      >
-                        #{i + 1}
-                      </span>
-                    }
-                  />
-                ))}
-              </div>
-            )}
-          </div>
-        </section>
-      </aside>
-
-      {railFits && (
-        <div className="flex min-h-0 overflow-hidden rounded-md">
-          <PreviewRail
-            setSlot={setPreviewSlot}
-            collapsed={previewCollapsed}
-            onCollapse={togglePreview}
-            defaultWidth={
-              rowWidth >= RAIL_WIDE_AT_ROW_WIDTH ? RAIL_DEFAULT_WIDTH : RAIL_COMPACT_WIDTH
-            }
-          />
-        </div>
-      )}
-
-      {railFits ? (
-        <HoverCardPreview preview={preview} slot={previewSlot} pinned imageSize="normal" />
-      ) : (
-        <HoverCardPreview preview={preview} />
       )}
     </div>
   );

--- a/src/views/Draft.tsx
+++ b/src/views/Draft.tsx
@@ -59,7 +59,7 @@ export default function Draft() {
     pickingRef.current = true;
     setPicking(true);
     try {
-      await pick(draftId, card.name);
+      await pick(draftId, card);
     } catch {
       /* surfaced via lastError */
     } finally {

--- a/src/views/Limited.tsx
+++ b/src/views/Limited.tsx
@@ -310,7 +310,7 @@ export default function Limited() {
                   Loaded: <span className="text-foreground/90">{lastImportedCube.name}</span> —{" "}
                   {lastImportedCube.cardCount} cards
                   {lastImportedCube.rejectedCardCount > 0 &&
-                    ` · ${lastImportedCube.rejectedCardCount} unsupported`}
+                    ` · ${lastImportedCube.rejectedCardCount} without local engine data`}
                 </>
               ) : null
             }
@@ -369,6 +369,7 @@ export default function Limited() {
                 pool: lastImportedCube.pool!,
                 seed: seedOpt,
                 picksPerPass,
+                customPool: true,
               });
               navigate(`/draft/${state.sessionId}`);
             } catch {
@@ -381,6 +382,7 @@ export default function Limited() {
                 poolPacks: winstonPacks,
                 pool: lastImportedCube.pool!,
                 seed: seedOpt,
+                customPool: true,
               });
               navigate(`/winston/${state.sessionId}`);
             } catch {
@@ -902,8 +904,8 @@ function CubeStartActions({
             cards · {cube.numPacks} packs/player{" "}
             {cube.singleton && <span className="text-muted-foreground">· singleton</span>}
             {cube.rejectedCardCount > 0 && (
-              <span className="ml-2 text-destructive">
-                {cube.playableCardCount} playable · {cube.rejectedCardCount} unsupported
+              <span className="ml-2 text-muted-foreground">
+                {cube.playableCardCount} locally recognized · {cube.rejectedCardCount} name-only
               </span>
             )}
             {seed !== undefined && (

--- a/src/views/MultiplayerDraft.tsx
+++ b/src/views/MultiplayerDraft.tsx
@@ -74,9 +74,9 @@ export default function MultiplayerDraft() {
   const handlePick = async (card: DraftCard) => {
     if (!state?.awaitingHuman || pickPending) return;
     if (amHost) {
-      await submitHostPick(card.name);
+      await submitHostPick(card);
     } else {
-      await submitPeerPick(card.name);
+      await submitPeerPick(card);
     }
   };
 

--- a/src/views/MultiplayerDraft.tsx
+++ b/src/views/MultiplayerDraft.tsx
@@ -4,10 +4,9 @@ import { Loader2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { useTopBarOverride } from "@/components/layout/TopBarOverride";
-import { LandscapeGate } from "@/components/LandscapeGate";
 import LimitedDeckBuilder from "@/components/limited/LimitedDeckBuilder";
-import { DraftPodButton } from "@/components/limited/DraftPodButton";
-import { DraftingView } from "@/views/Draft";
+import { DraftStatusBar } from "@/components/limited/DraftStatusBar";
+import { DraftWorkspace } from "@/components/limited/DraftWorkspace";
 import { submitHostPick, teardownHost } from "@/game/draftHost";
 import { submitPeerPick } from "@/game/draftPeer";
 import { useLimitedStore } from "@/stores/useLimitedStore";
@@ -109,44 +108,20 @@ export default function MultiplayerDraft() {
 
   return (
     <div className="flex h-full flex-col gap-4 px-4 py-6 sm:px-6 lg:px-8">
-      <LandscapeGate />
-      <header className="flex flex-wrap items-center justify-between gap-2">
-        <p className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-          <span>
-            Round {state.round} / {state.totalRounds} · Pick {state.pickNumber}
-          </span>
-          {mySeatAssignment && (
-            <span className="rounded bg-muted/60 px-1.5 py-0.5 text-[11px]">
-              Seat {mySeatAssignment.seat} · {mySeatAssignment.displayName}
-            </span>
-          )}
-          {amHost && (
-            <span className="rounded bg-primary/15 px-1.5 py-0.5 text-[11px] font-medium text-primary">
-              Host
-            </span>
-          )}
-          {state.isComplete ? (
-            <span className="rounded bg-primary/15 px-1.5 py-0.5 text-[11px] font-medium text-primary">
-              Complete
-            </span>
-          ) : state.awaitingHuman ? (
-            <span className="rounded bg-primary/15 px-1.5 py-0.5 text-[11px] font-medium text-primary">
-              Your pick
-            </span>
-          ) : (
-            <span className="inline-flex items-center gap-1.5 rounded bg-muted/60 px-1.5 py-0.5 text-[11px] font-medium">
-              <Loader2 className="h-3 w-3 animate-spin" />
-              Waiting…
-            </span>
-          )}
-        </p>
-        <div className="flex items-center gap-2">
-          <DraftPodButton seats={state.seatSummaries} />
-        </div>
-      </header>
+      <DraftStatusBar
+        draft={state}
+        seatLabel={
+          mySeatAssignment
+            ? `Seat ${mySeatAssignment.seat} · ${mySeatAssignment.displayName}`
+            : undefined
+        }
+        isHost={amHost}
+        waitingLabel="Waiting for the pod…"
+        viewerSeat={mySeat ?? undefined}
+      />
 
-      <DraftingView
-        activeDraft={state}
+      <DraftWorkspace
+        draft={state}
         onPick={handlePick}
         conspiracyHooks={conspiracyHooks}
         pickPending={pickPending}
@@ -170,7 +145,6 @@ interface CompletionViewProps {
 function CompletionView({ pools, myPool, onExit }: CompletionViewProps) {
   return (
     <div className="flex h-full flex-col gap-4 px-4 py-6 sm:px-6 lg:px-8">
-      <LandscapeGate />
       <header className="flex items-center justify-between gap-3">
         <div className="max-w-3xl">
           <p className="text-sm text-muted-foreground">

--- a/src/views/Winston.tsx
+++ b/src/views/Winston.tsx
@@ -13,9 +13,14 @@ import {
 } from "@/components/ui/dialog";
 import { CARD_BACK_IMAGE_URL } from "@/components/game/game.constants";
 import { DraftCardTile } from "@/components/limited/DraftCardTile";
+import { DraftPoolPanel } from "@/components/limited/DraftPoolPanel";
 import LimitedDeckBuilder from "@/components/limited/LimitedDeckBuilder";
 import { LimitedHoverPreviewPane } from "@/components/limited/LimitedHoverPreviewPane";
 import { LimitedModeToggle, type LimitedDraftMode } from "@/components/limited/LimitedModeToggle";
+import {
+  LimitedWorkspaceTabs,
+  type LimitedWorkspaceTab,
+} from "@/components/limited/LimitedWorkspaceTabs";
 import { useCardPreview } from "@/hooks/useCardPreview";
 import { cn } from "@/lib/utils";
 import { useLimitedStore } from "@/stores/useLimitedStore";
@@ -89,9 +94,12 @@ export default function Winston() {
 
   return (
     <div className="flex h-full flex-col gap-4 px-4 py-6 sm:px-6 lg:px-8">
-      <header className="flex flex-wrap items-center justify-between gap-2">
+      <header className="z-10 flex shrink-0 flex-wrap items-center justify-between gap-2 rounded-md border border-border/70 bg-background/95 px-3 py-2 shadow-sm backdrop-blur">
         <p className="flex items-center gap-2 text-sm text-muted-foreground">
           <span>Deck: {activeWinston.deckSize} cards left</span>
+          <span className="rounded bg-muted/60 px-1.5 py-0.5 text-[11px]">
+            AI: {activeWinston.aiPickCount} picks
+          </span>
           {activeWinston.isComplete ? (
             <span className="rounded bg-primary/15 px-1.5 py-0.5 text-[11px] font-medium text-primary">
               Complete
@@ -189,118 +197,117 @@ function DraftingView({
   onJumpToBuild,
 }: DraftingViewProps) {
   const preview = useCardPreview();
+  const [mobileTab, setMobileTab] = useState<LimitedWorkspaceTab>("pack");
   const activePileEmpty =
     activeWinston.piles.length === 0 || activeWinston.piles[activeIdx].length === 0;
+  const activePile = activeWinston.piles[activeIdx] ?? [];
+
+  const activePilePanel = (
+    <section className="flex min-h-0 flex-1 flex-col rounded-md border border-primary/50 bg-primary/5 motion-safe:animate-draft-pack-arrive">
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border/40 px-3 py-2">
+        <div>
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-primary">
+            Active pile {activeIdx + 1}
+          </h2>
+          <p className="text-[11px] text-muted-foreground">
+            {activePile.length} card{activePile.length === 1 ? "" : "s"}
+          </p>
+        </div>
+        {activeWinston.awaitingHuman && (
+          <div className="flex gap-2">
+            <Button onClick={onTake} disabled={activePileEmpty} size="sm">
+              Take pile
+            </Button>
+            <Button variant="outline" onClick={onPass} size="sm">
+              Pass
+            </Button>
+          </div>
+        )}
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto p-4">
+        {activePile.length === 0 ? (
+          <div className="flex h-full min-h-48 items-center justify-center text-sm text-muted-foreground">
+            This pile is empty.
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-4">
+            {activePile.map((card, index) => (
+              <DraftCardTile
+                key={`${card.name}:${card.setCode}:${card.cardNumber}:${index}`}
+                card={card}
+                index={index}
+                preview={preview}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+
+  const inactivePiles = (
+    <section className="flex min-h-0 flex-col rounded-md border border-border/70 bg-card/20 p-3">
+      <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        Other piles
+      </h2>
+      <div className="grid grid-cols-2 gap-2 lg:grid-cols-1">
+        {activeWinston.piles.map((pile, index) =>
+          index === activeIdx ? null : (
+            <div key={index} className="rounded border border-border/40 bg-card/40 p-2">
+              <div className="mb-1 text-[11px] font-medium text-muted-foreground">
+                Pile {index + 1} · {pile.length}
+              </div>
+              <FaceDownStack count={pile.length} compact />
+            </div>
+          ),
+        )}
+      </div>
+    </section>
+  );
 
   return (
-    <div className="grid flex-1 grid-cols-1 gap-4 overflow-hidden lg:grid-cols-[1fr_minmax(0,340px)]">
-      <div className="flex min-h-0 flex-col rounded-md border border-border/70 p-4">
-        <div className="mb-2 flex items-center justify-between">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-            Piles
-          </h2>
-          {activeWinston.awaitingHuman && (
-            <div className="flex gap-2">
-              <Button onClick={onTake} disabled={activePileEmpty} size="sm">
-                Take Pile {activeIdx + 1}
-              </Button>
-              <Button variant="outline" onClick={onPass} size="sm">
-                Pass
-              </Button>
-            </div>
-          )}
-        </div>
-        <div className="grid flex-1 grid-cols-3 gap-3 overflow-y-auto">
-          {activeWinston.piles.map((pile, i) => {
-            const isActive = i === activeIdx && activeWinston.awaitingHuman;
-            return (
-              <div
-                key={i}
-                className={cn(
-                  "flex flex-col gap-2 rounded border p-2",
-                  isActive ? "border-primary bg-primary/5" : "border-border/40 bg-card/40",
-                )}
-              >
-                <h3 className="text-xs font-semibold uppercase text-muted-foreground">
-                  Pile {i + 1} ({pile.length})
-                </h3>
-                {isActive ? (
-                  pile.length === 0 ? (
-                    <p className="text-xs text-muted-foreground">(empty)</p>
-                  ) : (
-                    <div className="grid grid-cols-1 gap-1.5">
-                      {pile.map((c, j) => (
-                        <DraftCardTile
-                          key={`pile-${i}-${j}`}
-                          card={c}
-                          index={j}
-                          preview={preview}
-                        />
-                      ))}
-                    </div>
-                  )
-                ) : (
-                  <FaceDownStack count={pile.length} />
-                )}
-              </div>
-            );
-          })}
-        </div>
+    <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden">
+      <LimitedWorkspaceTabs value={mobileTab} onChange={setMobileTab} packLabel="Piles" />
+
+      <div className="hidden min-h-0 flex-1 grid-cols-[minmax(0,1fr)_180px_340px] gap-3 overflow-hidden lg:grid">
+        {activePilePanel}
+        {inactivePiles}
+        <aside className="flex min-h-0 flex-col gap-3">
+          <LimitedHoverPreviewPane preview={preview} />
+          <DraftPoolPanel
+            cards={activeWinston.pickedPile}
+            preview={preview}
+            onBuild={canBuild ? onJumpToBuild : undefined}
+          />
+        </aside>
       </div>
 
-      <aside className="flex min-h-0 flex-col gap-4">
-        <LimitedHoverPreviewPane preview={preview} className="hidden lg:block" />
-        <section className="flex min-h-0 flex-1 flex-col rounded-md border border-border/70">
-          <div className="flex items-center justify-between border-b border-border/40 px-4 py-2">
-            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-              Your Pile ({activeWinston.pickedPile.length})
-            </h2>
-            {canBuild && (
-              <Button size="sm" variant="outline" onClick={onJumpToBuild} className="h-7 text-xs">
-                Build
-              </Button>
-            )}
-          </div>
-          <div className="flex-1 overflow-y-auto p-4">
-            {activeWinston.pickedPile.length === 0 ? (
-              <p className="text-xs text-muted-foreground">No picks yet.</p>
-            ) : (
-              <div className="grid grid-cols-3 gap-1.5">
-                {activeWinston.pickedPile.map((c, i) => (
-                  <DraftCardTile
-                    key={`picked-${i}`}
-                    card={c}
-                    index={i}
-                    preview={preview}
-                    overlay={
-                      <span
-                        className="pointer-events-none absolute right-1 top-1 rounded-full border border-white/20 bg-black/70 px-1.5 py-0.5 text-[9px] font-bold text-white/90"
-                        title={`Pick #${i + 1}`}
-                      >
-                        #{i + 1}
-                      </span>
-                    }
-                  />
-                ))}
-              </div>
-            )}
-          </div>
-        </section>
-
-        <section className="shrink-0 rounded-md border border-border/70 p-4 text-sm">
-          <p className="text-muted-foreground">AI picks: {activeWinston.aiPickCount}</p>
-        </section>
-      </aside>
+      <div className="min-h-0 flex-1 overflow-hidden lg:hidden">
+        <div className={cn("flex h-full flex-col gap-3", mobileTab !== "pack" && "hidden")}>
+          {activePilePanel}
+          {inactivePiles}
+        </div>
+        <div className={cn("flex h-full", mobileTab !== "picks" && "hidden")}>
+          <DraftPoolPanel
+            cards={activeWinston.pickedPile}
+            preview={preview}
+            onBuild={canBuild ? onJumpToBuild : undefined}
+          />
+        </div>
+        <div className={cn("h-full", mobileTab !== "preview" && "hidden")}>
+          <LimitedHoverPreviewPane preview={preview} className="h-full" />
+        </div>
+      </div>
     </div>
   );
 }
 
-function FaceDownStack({ count }: { count: number }) {
+function FaceDownStack({ count, compact = false }: { count: number; compact?: boolean }) {
   if (count === 0) {
     return <p className="text-xs text-muted-foreground">(empty)</p>;
   }
   return (
-    <div className="relative aspect-[5/7] w-full">
+    <div className={cn("relative aspect-[5/7] w-full", compact && "mx-auto max-w-24")}>
       <ScryfallImg
         src={CARD_BACK_IMAGE_URL}
         alt={`Face-down pile of ${count} card${count === 1 ? "" : "s"}`}

--- a/src/workers/game-engine.worker.ts
+++ b/src/workers/game-engine.worker.ts
@@ -493,12 +493,19 @@ async function handleCommand(command: string, args?: Record<string, unknown>): P
     case "limited_start_multiplayer_draft":
       return limited_start_multiplayer_draft(args?.setup as object, args?.humans as object);
     case "limited_pick_card":
-      return limited_pick_card(args?.sessionId as string, args?.cardName as string);
+      return limited_pick_card(
+        args?.sessionId as string,
+        args?.cardName as string,
+        args?.setCode as string,
+        args?.cardNumber as string,
+      );
     case "limited_submit_pick":
       return limited_submit_pick(
         args?.sessionId as string,
         args?.seatIdx as number,
         args?.cardName as string,
+        args?.setCode as string,
+        args?.cardNumber as string,
       );
     case "limited_get_seat_state":
       return limited_get_seat_state(args?.sessionId as string, args?.seatIdx as number);


### PR DESCRIPTION
## Summary

- preserve imported CubeCobra cards through booster draft and Winston setup
- deal singleton cubes from one finite shared pool, matching Forge custom-draft behavior
- reject cube configurations that cannot supply every requested pack
- identify picks by card name, set, and collector number in offline and multiplayer drafts
- resolve imported card metadata through Scryfall with a playable fallback for unsupported printings
- expose per-seat pack state and pass direction from the draft engine
- redesign booster and multiplayer drafts around a persistent status bar, dominant pack, compact drafted-pool panel, and embedded card preview
- add responsive Pack, Picks, and Preview tabs for narrow screens
- redesign Winston so the active pile is prominent and inactive piles stay compact
- keep deck export engine-agnostic while accurately labeling cards unsupported by Manabrew

## Why

CubeCobra imports were usable for sealed because sealed consumed the imported pool directly, but draft setup reconstructed packs in a way that could discard unresolved imported cards. That produced a valid-looking draft session with an empty current pack. Cube drafts must also consume their finite card list instead of sampling it repeatedly, and cards that share a name must retain the printing the player selected.

The draft screens also gave equal visual weight to the pack, pool, and preview, which obscured the primary pick flow and did not adapt well to portrait layouts.

## Test plan

- `cargo test -p forge-foundation -p forge-limited`
- `yarn lint:all`
- `yarn build:wasm`
- `yarn build:web`
- `cargo check -p forge-foundation -p forge-limited -p wasm`
- `git diff --check`
- start a local booster draft and confirm the first pack is populated
- verify the shared draft workspace at desktop and narrow breakpoints
- verify Winston keeps the active pile prominent and preserves forced-draw confirmation

## Demo

The draft workspace now keeps round, pick, pass direction, pack queue, pod state, and build controls in a stable top bar. The current pack is the primary surface. The right column stacks drafted cards and deck stats above a collapsible hover preview, remembers the player's collapsed preference, and avoids consuming a third desktop column. Preview remains available as a dedicated tab on narrow screens. Winston uses the same hierarchy with one large active pile and compact face-down inactive piles.
