### PR TITLE
feat(node): smoke the graal native library in ci

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -619,6 +619,14 @@ jobs:
         run: ./forge-harness/build-native.ps1
         shell: pwsh
 
+      # Proves the library actually runs, not merely that it exists: a cache hit
+      # restores forge-harness/native/build without anything else exercising it.
+      - name: Smoke the Forge native library
+        env:
+          SELF_HOSTED_NODE_GRAAL_SMOKE: "1"
+          RUST_LOG: self_hosted_node=info
+        run: cargo run -p self-hosted-node --features graal-forge
+
       - name: Stub frontend dist for tauri context macro
         shell: bash
         run: |
@@ -699,6 +707,14 @@ jobs:
       - name: Build native Forge library (GraalVM native-image)
         if: steps.forge-native-cache.outputs.cache-hit != 'true'
         run: ./forge-harness/build-native.sh
+
+      # Proves the library actually runs, not merely that it exists: a cache hit
+      # restores forge-harness/native/build without anything else exercising it.
+      - name: Smoke the Forge native library
+        env:
+          SELF_HOSTED_NODE_GRAAL_SMOKE: "1"
+          RUST_LOG: self_hosted_node=info
+        run: cargo run -p self-hosted-node --features graal-forge
 
       # `cargo build` of the tauri crate runs `generate_context!`, which embeds
       # `frontendDist` (../dist). Stub it so the link test doesn't drag in the

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -360,6 +360,14 @@ jobs:
         if: steps.forge-native-cache.outputs.cache-hit != 'true'
         run: ./forge-harness/build-native.sh
 
+      # Proves the library actually runs, not merely that it exists: a cache hit
+      # restores forge-harness/native/build without anything else exercising it.
+      - name: Smoke the Forge native library
+        env:
+          SELF_HOSTED_NODE_GRAAL_SMOKE: "1"
+          RUST_LOG: self_hosted_node=info
+        run: cargo run -p self-hosted-node --features graal-forge
+
       - name: Stub frontend dist for tauri context macro
         run: |
           mkdir -p dist
@@ -469,6 +477,14 @@ jobs:
         if: steps.forge-native-cache.outputs.cache-hit != 'true'
         run: ./forge-harness/build-native.ps1
         shell: pwsh
+
+      # Proves the library actually runs, not merely that it exists: a cache hit
+      # restores forge-harness/native/build without anything else exercising it.
+      - name: Smoke the Forge native library
+        env:
+          SELF_HOSTED_NODE_GRAAL_SMOKE: "1"
+          RUST_LOG: self_hosted_node=info
+        run: cargo run -p self-hosted-node --features graal-forge
 
       - name: Stub frontend dist for tauri context macro
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -147,6 +147,14 @@ jobs:
         if: steps.forge-native-cache.outputs.cache-hit != 'true'
         run: ./forge-harness/build-native.sh
 
+      # Proves the library actually runs, not merely that it exists: a cache hit
+      # restores forge-harness/native/build without anything else exercising it.
+      - name: Smoke the Forge native library
+        env:
+          SELF_HOSTED_NODE_GRAAL_SMOKE: "1"
+          RUST_LOG: self_hosted_node=info
+        run: cargo run -p self-hosted-node --features graal-forge
+
       - name: Tauri build (macOS)
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f
         env:
@@ -301,6 +309,14 @@ jobs:
         if: steps.forge-native-cache.outputs.cache-hit != 'true'
         run: ./forge-harness/build-native.ps1
         shell: pwsh
+
+      # Proves the library actually runs, not merely that it exists: a cache hit
+      # restores forge-harness/native/build without anything else exercising it.
+      - name: Smoke the Forge native library
+        env:
+          SELF_HOSTED_NODE_GRAAL_SMOKE: "1"
+          RUST_LOG: self_hosted_node=info
+        run: cargo run -p self-hosted-node --features graal-forge
 
       - name: Tauri build (Windows)
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f

--- a/manabrew-rs/crates/self-hosted-node/src/engine_backend/java_backend.rs
+++ b/manabrew-rs/crates/self-hosted-node/src/engine_backend/java_backend.rs
@@ -121,6 +121,43 @@ pub fn run_smoke_game(_max_prompts: usize) -> Result<(), String> {
     )
 }
 
+// Unlike run_smoke_game, which spawns the JAR in a subprocess, this drives the
+// GraalVM native library in-process: isolate creation, forge_initialize (which
+// loads the card database) and a real game start. CI runs it after restoring
+// forge-harness/native/build from cache, where nothing else would notice a
+// stale or broken libforgeharness.
+#[cfg(feature = "graal-forge")]
+pub fn run_graal_smoke() -> Result<(), String> {
+    let config = JavaRuntimeConfig::from_env();
+    let engine = GraalEngineHandle::create(&config.assets_dir)?;
+
+    let deck_a = smoke_deck("Mountain", "Lightning Bolt");
+    let deck_b = smoke_deck("Forest", "Grizzly Bears");
+    let request = StartGameRequest::new(
+        "self-hosted-graal-smoke".to_string(),
+        String::new(),
+        20,
+        42,
+        vec![
+            PlayerConfig::new("Smoke A".to_string(), &deck_a, Vec::new()),
+            PlayerConfig::new("Smoke B".to_string(), &deck_b, Vec::new()),
+        ],
+    );
+
+    let session_id = engine.start_game(&request.to_json().map_err(|err| err.to_string())?)?;
+    info!(session_id, "graal-forge smoke session started");
+    engine.end_game(&session_id)?;
+    Ok(())
+}
+
+#[cfg(not(feature = "graal-forge"))]
+pub fn run_graal_smoke() -> Result<(), String> {
+    Err(
+        "graal-forge smoke requires building self-hosted-node with --features graal-forge"
+            .to_string(),
+    )
+}
+
 #[cfg(feature = "java-forge")]
 pub fn run_scenario(name: &str, max_prompts: usize) -> Result<(), String> {
     let scenario = JavaScenario::from_name(name)?;
@@ -1506,7 +1543,7 @@ fn commander_names_for_java(deck: &Deck, fallback: Option<&str>) -> Vec<String> 
         .unwrap_or_default()
 }
 
-#[cfg(feature = "java-forge")]
+#[cfg(forge_backend)]
 fn smoke_deck(land_name: &str, spell_name: &str) -> Vec<DeckCardIdentity> {
     (0..24)
         .map(|_| DeckCardIdentity {

--- a/manabrew-rs/crates/self-hosted-node/src/host.rs
+++ b/manabrew-rs/crates/self-hosted-node/src/host.rs
@@ -164,6 +164,14 @@ pub async fn cli_entry() {
         info!(max_prompts, "java-forge smoke completed");
         return;
     }
+    if std::env::var("SELF_HOSTED_NODE_GRAAL_SMOKE").is_ok() {
+        if let Err(error) = java_backend::run_graal_smoke() {
+            error!(%error, "graal-forge smoke failed");
+            std::process::exit(1);
+        }
+        info!("graal-forge smoke completed");
+        return;
+    }
     if std::env::var("SELF_HOSTED_NODE_JAVA_CONCEDE_SMOKE").is_ok() {
         if let Err(error) = java_backend::run_concede_smoke() {
             error!(%error, "java-forge concede smoke failed");


### PR DESCRIPTION
> Stacked on #649. Base is `khaliostr/harness-native-cache`, not `main` — it edits the same GraalVM job blocks, so branching off main would guarantee a conflict. Retarget to main once #649 lands.

## Summary

Adds `run_graal_smoke`, which drives the GraalVM native library in-process, and runs it in the six GraalVM jobs immediately after the native library step.

## Why

#649 caches `forge-harness/native/build` and skips `native-image` on a hit. Nothing revalidates the restored artifact — the cache key is the only guard, which is the one gap that PR calls out. A key missing an input would ship a stale `libforgeharness` in a release build.

Placing the smoke after the native step covers both paths: a fresh build and a cache hit.

The existing `run_smoke_game` could not be reused — it spawns the JAR in a subprocess via `SubprocessBridge`, so it exercises the wrong artifact entirely. `run_graal_smoke` goes through `GraalEngineHandle`: isolate creation, `forge_initialize` (which loads the card database) and a real game start, then `end_game`. It is gated behind `SELF_HOSTED_NODE_GRAAL_SMOKE`, mirroring the four env-gated smokes already in `cli_entry`.

`smoke_deck` moves from `feature = "java-forge"` to `forge_backend` so both backends can build the same decks.

Deliberately scoped: this does not replay the prompt loop like `run_smoke_game`. The graal handle has a different session API, and mirroring it would mean ~50 lines duplicated in an already heavily `cfg`'d file. Stale or broken libraries fail at isolate creation or card-DB load, which this covers.

## Test plan

Ran locally against a freshly built library (`FORGE_NATIVE_LIB_DIR` pointed at a clean `native-image` output):

```
INFO graal-forge smoke session started session_id="self-hosted-graal-smoke"
INFO graal-forge smoke completed
exit 0
```

It loads the real card database (32K cards, 824 token files) before starting the game, so this is not a stub path.

Independently, a C program compiled against the emitted `forgeharness.h` confirmed the same FFI contract end to end: `graal_create_isolate` → `forge_initialize` → `{"ok":true,"result":""}` → `forge_free_string`.

Feature-matrix check, since the file is heavily `cfg`'d and a stub mismatch is the likely break:

| Features | `cargo check` |
| --- | --- |
| none | ok |
| `graal-forge` | ok |
| `java-forge` | ok |
| both | ok |

`cargo fmt --check` clean; `prettier --check` clean on all workflows; every smoke step verified to sit directly after a `build-native` step in all six jobs.

One pre-existing failure worth flagging: `cargo clippy -p self-hosted-node --features graal-forge -- -D warnings` errors on `run_hosted_engine_game_inner` (13 args, max 7). It reproduces on the base branch with my changes stashed, and only under `graal-forge`, which `yarn lint:rust` does not use (it runs the no-Forge overlay). Untouched here.
