### PR TITLE
fix(ci): run the wasm cache key step under bash

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -160,6 +160,7 @@ jobs:
       # changes). The forge gitlink stands in for the card-data dirs.
       - name: Compute wasm output key
         id: wasm-key
+        shell: bash
         run: echo "key=wasm-output-$(git rev-parse HEAD:forge)-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'manabrew-rs/**/*.rs', 'manabrew-rs/**/Cargo.toml', 'scripts/build-wasm.mjs') }}" >> "$GITHUB_OUTPUT"
 
       - name: Wasm output cache
@@ -423,6 +424,7 @@ jobs:
       # changes). The forge gitlink stands in for the card-data dirs.
       - name: Compute wasm output key
         id: wasm-key
+        shell: bash
         run: echo "key=wasm-output-$(git rev-parse HEAD:forge)-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'manabrew-rs/**/*.rs', 'manabrew-rs/**/Cargo.toml', 'scripts/build-wasm.mjs') }}" >> "$GITHUB_OUTPUT"
 
       - name: Wasm output cache
@@ -495,6 +497,7 @@ jobs:
       # changes). The forge gitlink stands in for the card-data dirs.
       - name: Compute wasm output key
         id: wasm-key
+        shell: bash
         run: echo "key=wasm-output-$(git rev-parse HEAD:forge)-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'manabrew-rs/**/*.rs', 'manabrew-rs/**/Cargo.toml', 'scripts/build-wasm.mjs') }}" >> "$GITHUB_OUTPUT"
 
       - name: Wasm output cache

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -242,6 +242,7 @@ jobs:
       # PR runs hit the cache warmed here.
       - name: Compute wasm output key
         id: wasm-key
+        shell: bash
         run: echo "key=wasm-output-$(git rev-parse HEAD:forge)-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'manabrew-rs/**/*.rs', 'manabrew-rs/**/Cargo.toml', 'scripts/build-wasm.mjs') }}" >> "$GITHUB_OUTPUT"
 
       - name: Wasm output cache
@@ -309,6 +310,7 @@ jobs:
       # changes). The forge gitlink stands in for the card-data dirs.
       - name: Compute wasm output key
         id: wasm-key
+        shell: bash
         run: echo "key=wasm-output-$(git rev-parse HEAD:forge)-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'manabrew-rs/**/*.rs', 'manabrew-rs/**/Cargo.toml', 'scripts/build-wasm.mjs') }}" >> "$GITHUB_OUTPUT"
 
       - name: Wasm output cache
@@ -426,6 +428,7 @@ jobs:
       # changes). The forge gitlink stands in for the card-data dirs.
       - name: Compute wasm output key
         id: wasm-key
+        shell: bash
         run: echo "key=wasm-output-$(git rev-parse HEAD:forge)-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'manabrew-rs/**/*.rs', 'manabrew-rs/**/Cargo.toml', 'scripts/build-wasm.mjs') }}" >> "$GITHUB_OUTPUT"
 
       - name: Wasm output cache
@@ -538,6 +541,7 @@ jobs:
       # changes). The forge gitlink stands in for the card-data dirs.
       - name: Compute wasm output key
         id: wasm-key
+        shell: bash
         run: echo "key=wasm-output-$(git rev-parse HEAD:forge)-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'manabrew-rs/**/*.rs', 'manabrew-rs/**/Cargo.toml', 'scripts/build-wasm.mjs') }}" >> "$GITHUB_OUTPUT"
 
       - name: Wasm output cache
@@ -609,6 +613,7 @@ jobs:
       # changes). The forge gitlink stands in for the card-data dirs.
       - name: Compute wasm output key
         id: wasm-key
+        shell: bash
         run: echo "key=wasm-output-$(git rev-parse HEAD:forge)-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'manabrew-rs/**/*.rs', 'manabrew-rs/**/Cargo.toml', 'scripts/build-wasm.mjs') }}" >> "$GITHUB_OUTPUT"
 
       - name: Wasm output cache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,7 @@ jobs:
       # changes). The forge gitlink stands in for the card-data dirs.
       - name: Compute wasm output key
         id: wasm-key
+        shell: bash
         run: echo "key=wasm-output-$(git rev-parse HEAD:forge)-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'manabrew-rs/**/*.rs', 'manabrew-rs/**/Cargo.toml', 'scripts/build-wasm.mjs') }}" >> "$GITHUB_OUTPUT"
 
       - name: Wasm output cache
@@ -258,6 +259,7 @@ jobs:
       # changes). The forge gitlink stands in for the card-data dirs.
       - name: Compute wasm output key
         id: wasm-key
+        shell: bash
         run: echo "key=wasm-output-$(git rev-parse HEAD:forge)-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'manabrew-rs/**/*.rs', 'manabrew-rs/**/Cargo.toml', 'scripts/build-wasm.mjs') }}" >> "$GITHUB_OUTPUT"
 
       - name: Wasm output cache
@@ -419,6 +421,7 @@ jobs:
       # changes). The forge gitlink stands in for the card-data dirs.
       - name: Compute wasm output key
         id: wasm-key
+        shell: bash
         run: echo "key=wasm-output-$(git rev-parse HEAD:forge)-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'manabrew-rs/**/*.rs', 'manabrew-rs/**/Cargo.toml', 'scripts/build-wasm.mjs') }}" >> "$GITHUB_OUTPUT"
 
       - name: Wasm output cache
@@ -507,6 +510,7 @@ jobs:
       # changes). The forge gitlink stands in for the card-data dirs.
       - name: Compute wasm output key
         id: wasm-key
+        shell: bash
         run: echo "key=wasm-output-$(git rev-parse HEAD:forge)-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'manabrew-rs/**/*.rs', 'manabrew-rs/**/Cargo.toml', 'scripts/build-wasm.mjs') }}" >> "$GITHUB_OUTPUT"
 
       - name: Wasm output cache


### PR DESCRIPTION
## Summary

Pins `Compute wasm output key` to `shell: bash` in all 12 places.

## Why

`Build Windows .exe` failed on `v3.9.3` with:

```
##[error]Input required and not supplied: key
```

The step writes `>> "$GITHUB_OUTPUT"`. That is bash syntax — PowerShell has no `$GITHUB_OUTPUT`, it uses `$env:GITHUB_OUTPUT` — so on Windows the redirect target expanded to nothing, the key output was never set, and `actions/cache` failed on an empty key. Every later step in the job was skipped, so no installer was produced.

My mistake in #649: that block was copied verbatim from Linux-only jobs into the Windows ones. I set `shell: bash` on the `Harness cache keys` step I wrote from scratch, but not on the one I copied.

It slipped through the PR verification because `build-checks`' Windows GraalVM job does not build wasm — only `publish.yml` and `cache-warm.yml`'s Windows tauri jobs do, and neither runs on a PR.

Pinning the shell rather than rewriting for pwsh keeps one code path across all three platforms.

## Test plan

- All 12 `wasm-key` steps now carry `shell: bash`, asserted by parsing each workflow; the `harness-keys` steps already had it.
- `prettier --check` clean on all workflows.
- Real check is the next `publish` run: `Build Windows .exe` must get past `Wasm output cache` to `Tauri build (Windows)`.
