### PR TITLE
fix(harness): map transparent newtypes to their primitive

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -32,6 +32,8 @@ Docker images that build the harness directly must perform the same generation s
 
 `gen-harness-prompts.mjs` roots the generated Java graph at every prompt input plus `CardDto` (the manually serialized `AgentPrompt` envelope uses it), then parses the generated TS with a **single-line** regex (`^export type X = …;$`). A `///` doc comment on a `manabrew-protocol` DTO field makes ts-rs emit a multi-line JSDoc block inside that type literal, so prettier wraps the alias across lines and the parser silently **drops the type** (and anything reachable only through it) — the harness then fails to compile with `cannot find symbol: CardDto`. Use a plain `//` comment on protocol DTO fields, never `///`.
 
+A `#[serde(transparent)]` newtype (`pub struct TokenScript(pub String)`) exports as `export type X = string;`. The generator follows those aliases to the underlying primitive instead of emitting a class: a class would have no fields, so it would compile but serialize as `{}` and drop the value on the wire. Keep `isPrimitiveAlias` in step with any new primitive the protocol wraps.
+
 Protocol generators replace their output directories. Do not run `yarn gen:types`, `yarn gen:protocol-docs`, `yarn build:harness`, or commands that invoke them concurrently; one process can delete files while another is exporting them.
 
 ## Lint and format (yarn)

--- a/scripts/gen-harness-prompts.mjs
+++ b/scripts/gen-harness-prompts.mjs
@@ -36,6 +36,8 @@ for (const file of walk(PROTO))
     if (m) aliases.set(m[1], m[2].trim());
   }
 
+const isPrimitiveAlias = (body) => /^(string|number|boolean)$/.test((body ?? "").trim());
+
 // Input type -> its PromptInput tag, e.g. ChooseFromSelectionInput -> "chooseFromSelection".
 const inputTag = new Map();
 for (const m of (aliases.get("PromptInput") ?? "").matchAll(/\{ "type": "(\w+)" \}(?: & (\w+))?/g))
@@ -107,6 +109,11 @@ const javaType = (ts, optional) => {
   if (record) return `java.util.Map<String, ${javaType(record[1], true)}>`;
   const arr = ts.match(/^Array<(.+)>$/);
   if (arr) return `java.util.List<${javaType(arr[1], true)}>`;
+  // A #[serde(transparent)] newtype exports as `export type X = string;`, which
+  // carries no fields. Emitting a class for it would compile to an empty
+  // wrapper that silently drops the value on the wire, so follow the alias to
+  // the primitive the JSON actually contains.
+  if (isPrimitiveAlias(aliases.get(ts))) return javaType(aliases.get(ts), opt);
   switch (ts) {
     case "string":
       return "String";
@@ -194,6 +201,7 @@ for (const name of reachable) {
 
 for (const name of reachable) {
   const body = aliases.get(name);
+  if (isPrimitiveAlias(body)) continue;
   if (unions.has(name)) {
     emit(name, `public interface ${name} {}`);
     for (const v of unions.get(name)) emitClass(v.vName, v.discriminator, v.fields, null);


### PR DESCRIPTION
## Summary

Makes `gen-harness-prompts.mjs` follow `#[serde(transparent)]` newtype aliases to the primitive they wrap, instead of emitting a fieldless Java class for them.

## Why

`main` is red. `Build macOS .dmg`, `Build Windows .exe` and `Build & push manabrew-node` all fail on `v3.9.4` and `v3.9.5` with one error:

```
InteractiveSnapshotExtractor.java:[377,28] incompatible types:
java.lang.String cannot be converted to forge.harness.protocol.TokenScript
```

#651 added `token_script: Option<TokenScript>` to `CardIdentity`. `TokenScript` is `#[serde(transparent)] pub struct TokenScript(pub String)`, which ts-rs exports as `export type TokenScript = string;`. The generator treated that like any other named type and ran `parseFields("string")`, which finds no fields, so it emitted:

```java
public final class TokenScript {
  public TokenScript() {}
}
```

A wrapper with nowhere to put the value. `CardIdentity` then demanded one where the harness passes a `String`.

The tempting fix — `new TokenScript(...)` at the callsite — is wrong twice over: that constructor takes no arguments, and even if it did, the class serializes to `{}`. It would compile and silently drop the token script that #651 exists to preserve. Mapping to `String` also matches the wire format, since a transparent newtype serializes as a bare string.

It reached `main` because nothing on a PR compiles the harness: the GraalVM jobs are label-gated, and the `Forge harness (checkstyle)` gate I added in #647 runs `mvn validate`, which is before compile. A follow-up PR upgrades that gate to compile. It likely passed locally too — the generated `forge.harness.protocol.*` sources are gitignored and persist between local builds, so a stale `CardIdentity` keeps compiling.

## Test plan

- Regenerated: `TokenScript.java` is no longer emitted (59 classes, was 60), and `CardIdentity` now declares `public String tokenScript` with a matching constructor, so the existing harness code compiles untouched.
- `mvn -pl forge-harness -am -DskipTests -Dcheckstyle.skip compile` passes in 9s against the regenerated sources — the exact command shape that fails on `main`.
- `prettier --check` and `eslint` clean.
- `scripts/AGENTS.md` gained a note next to the existing generator quirks, so the next transparent newtype does not repeat this.
