### PR TITLE
fix(node): silence too_many_arguments on the hosted game inner fn

### DIFF
--- a/manabrew-rs/crates/self-hosted-node/src/engine_backend/java_backend.rs
+++ b/manabrew-rs/crates/self-hosted-node/src/engine_backend/java_backend.rs
@@ -1142,6 +1142,7 @@ pub fn run_hosted_engine_game(
 }
 
 #[cfg(forge_backend)]
+#[allow(clippy::too_many_arguments)]
 fn run_hosted_engine_game_inner(
     game_id: String,
     player_names: Vec<String>,


### PR DESCRIPTION
## Summary

Adds the `#[allow(clippy::too_many_arguments)]` that `run_hosted_engine_game_inner` was missing.

## Why

`cargo clippy -p self-hosted-node --features graal-forge -- -D warnings` fails:

```
error: this function has too many arguments (13/7)
  --> manabrew-rs/crates/self-hosted-node/src/engine_backend/java_backend.rs:1145:1
```

Its public wrapper `run_hosted_engine_game` already carries that allow for the identical 13-argument signature — the private `_inner` it delegates to was simply never annotated. So this is a missed annotation rather than a design issue, and matching the wrapper is the smallest correct fix. Bundling the arguments into a params struct would mean reshaping the public API and `rust_backend`'s mirrored signature for no behavioural gain, which the crate guidance argues against.

It goes unnoticed because `yarn lint:rust` runs `clippy.mjs`'s no-Forge overlay, so nothing lints this feature combination — the one the Tauri desktop build actually uses.

Secondary effect, stated plainly: `main` currently has no unreleased crate changes, so `cargo xtask release` cuts no tag and `publish.yml` (tag-triggered only) cannot run. #659's harness fix is build-time and bumps nothing, so the desktop installers cannot rebuild until some crate moves. This patch bumps `self-hosted-node`, which releases a tag carrying that fix. It was picked because it is a genuine defect worth fixing on its own, not a placeholder commit.

## Test plan

- `cargo clippy -p self-hosted-node --features graal-forge -- -D warnings` — exit 0 (was `error: this function has too many arguments`).
- `cargo fmt --check -p self-hosted-node` clean.
- One line, no behaviour change.
