### PR TITLE
fix(tauri): forward reconnect timeout to the forge room host

### DIFF
--- a/manabrew-rs/crates/self-hosted-node/src/config.rs
+++ b/manabrew-rs/crates/self-hosted-node/src/config.rs
@@ -142,6 +142,7 @@ impl Config {
         format: GameFormat,
         max_players: u8,
         room_password: Option<String>,
+        reconnect_timeout_s: Option<u32>,
     ) -> Self {
         let username = format!("forge-host-{}", uuid::Uuid::new_v4());
         let bot_username = format!("{username}-bot");
@@ -163,7 +164,7 @@ impl Config {
             bot_enabled: false,
             bot_username,
             forge_ai: false,
-            reconnect_timeout_s: None,
+            reconnect_timeout_s,
             host_deck: synthetic_deck("forge-host", None),
             bot_deck: synthetic_deck("forge-bot", None),
         }

--- a/src-tauri/src/forge_room.rs
+++ b/src-tauri/src/forge_room.rs
@@ -43,6 +43,7 @@ pub async fn start_forge_host(
     format: GameFormat,
     max_players: u8,
     password: Option<String>,
+    reconnect_timeout_s: Option<u32>,
 ) -> Result<String, String> {
     #[cfg(not(feature = "forge-room"))]
     {
@@ -55,6 +56,7 @@ pub async fn start_forge_host(
             format,
             max_players,
             password,
+            reconnect_timeout_s,
         );
         Err("this desktop build was not compiled with the forge-room feature".to_string())
     }
@@ -74,6 +76,7 @@ pub async fn start_forge_host(
             format,
             max_players,
             password.filter(|value| !value.is_empty()),
+            reconnect_timeout_s,
         );
 
         let cancel: Arc<Notify> = Arc::new(Notify::new());

--- a/src/platform/tauri.ts
+++ b/src/platform/tauri.ts
@@ -60,6 +60,7 @@ class TauriServerApi implements IServerApi {
         format: params.format,
         maxPlayers: params.maxPlayers,
         password: params.password ?? null,
+        reconnectTimeoutS: params.reconnectTimeoutS ?? null,
       });
     }
     return this.inner.createRoom(params);


### PR DESCRIPTION
## Summary

- Forward the host's reconnect timeout choice through the desktop Forge host path: `tauri.ts` → `start_forge_host` → `Config::for_hosted_room`.
- `for_hosted_room` takes `reconnect_timeout_s` instead of hardcoding `None`.

## Why

The lobby offers 30/60/90s, but the desktop Forge branch of `createRoom` never passed the value to `start_forge_host`, and `for_hosted_room` hardcoded `None`. The relay then substituted its own default, so every Forge-hosted room ran at 60s no matter what the host picked.

Prod logs confirm it. In room `57b58636` a seat was forfeited 65.003s after the disconnect, and `schedule_seat_forfeit` sleeps `reconnect_timeout_s + 5s`, so the room was running at 60. Across 7 days: 21 of 22 seat forfeits fired at exactly 65.0s, both host-resume aborts likewise, and not one at 95s or 35s in 66 rooms.

Reported on Discord by rustydawwwg, whose group hosts Forge from the desktop app.

The param is `Option<u32>`, so a desktop build that predates this change still sends nothing and still gets the 60s default. No protocol change, no relay change.

This does not address the second half of that report, a request for an unlimited timeout. That needs a design decision: `MAX_RECONNECT_TIMEOUT_S` is 90 to stay under the engine's 120s auto-pass, so an unbounded room would wait while the engine passes the absent player's turns.

## Test plan

- `cargo check -p self-hosted-node`
- `cargo check -p manabrew --features forge-room` — the default build cfgs the affected branch out, so this needs the feature flag explicitly
- `yarn lint` and `yarn lint:rust` (clippy clean)

Manual: host a Forge room from the desktop app with the timeout set to 90, drop a player, and confirm the relay logs the forfeit at ~95s instead of ~65s.
