### PR TITLE
fix(hub): allow the desktop asset-server origin through cors

### DIFF
--- a/manabrew-rs/crates/manabrew-hub/src/routes.rs
+++ b/manabrew-rs/crates/manabrew-hub/src/routes.rs
@@ -50,11 +50,14 @@ pub struct AppState {
 }
 
 // The Tauri shells load from fixed webview origins; the web app origin comes
-// from WEB_APP_URL per environment.
+// from WEB_APP_URL per environment. Keep the asset-server origin in sync with
+// ASSET_SERVER_PORT in src-tauri/src/asset_server.rs — macOS and Linux packaged
+// builds serve the frontend from there, not from a tauri:// scheme.
 fn cors_origins(web_app_url: &str) -> AllowOrigin {
     let mut origins = vec![
         HeaderValue::from_static("tauri://localhost"),
         HeaderValue::from_static("http://tauri.localhost"),
+        HeaderValue::from_static("http://localhost:9527"),
     ];
     if let Some(origin) = reqwest::Url::parse(web_app_url)
         .ok()

--- a/src-tauri/src/asset_server.rs
+++ b/src-tauri/src/asset_server.rs
@@ -19,6 +19,8 @@
 // `dist/` left by an earlier `vite build` would otherwise hijack `tauri dev`
 // and silently serve that old bundle instead of vite. The port is fixed
 // so capabilities/default.json can list an exact `http://localhost:9527` origin.
+// Also listed in manabrew-hub's `cors_origins` — the Hub rejects the app
+// without it. Keep both in sync.
 const ASSET_SERVER_PORT: u16 = 9527;
 
 #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
## Summary

- Add `http://localhost:9527` to the Hub CORS allowlist.
- Note the cross-crate constraint on both sides, since the origin and `ASSET_SERVER_PORT` have to move together.

## Why

macOS and Linux packaged builds serve the frontend from `http://localhost:9527` (`src-tauri/src/asset_server.rs`), not from a `tauri://` scheme, because the custom scheme cannot be cross-origin isolated. The Hub allowlist only carried `tauri://localhost`, `http://tauri.localhost`, and `WEB_APP_URL`, so a request from those builds is rejected before it reaches a handler.

Confirmed against production:

```
$ curl -sD- -o/dev/null -H "Origin: <origin>" https://api.manabrew.app/api/health

http://localhost:9527      -> no access-control-allow-origin   (blocked)
tauri://localhost          -> access-control-allow-origin: tauri://localhost
http://tauri.localhost     -> access-control-allow-origin: http://tauri.localhost
https://play.manabrew.app  -> access-control-allow-origin: https://play.manabrew.app
```

**This is latent, not currently breaking anything.** `accounts` and `deckHub` ship `false` in `src/featureFlags.ts`, and the only runtime opt-in is `window.__MANABREW_RUNTIME__.featureFlags`, written by `ops/web-entrypoint.sh` in the web Docker image. Desktop ships `public/config.js` as an empty object, and the dev escape hatch in `isFeatureEnabled` explicitly excludes Tauri. Verified at the `v3.9.7` tag: both flags are still off. So no desktop build calls the Hub today, and the blocked origin bites the moment desktop is wired for accounts or Deck Hub.

Windows would be unaffected either way, it keeps `http://tauri.localhost`. Web is unaffected.

`tauri://localhost` stays in the list. Mobile still uses it, and it is also where the desktop window lands if the asset server fails to bind its port.

Fixes #668.

## Test plan

Ran the Hub locally against a throwaway database and checked the header per origin. The desktop origin is now allowed and an unrelated origin is still refused, so the allowlist has not been loosened:

```
http://localhost:9527      -> access-control-allow-origin: http://localhost:9527
tauri://localhost          -> access-control-allow-origin: tauri://localhost
http://tauri.localhost     -> access-control-allow-origin: http://tauri.localhost
https://play.manabrew.app  -> access-control-allow-origin: https://play.manabrew.app
https://evil.example.com   -> blocked
```

`cargo test -p manabrew-hub` passes, 19 tests. `yarn lint` and `yarn lint:rust` clean.
