### PR TITLE
feat(deckhub): enable deck hub browse on desktop builds

### DIFF
--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -12,15 +12,19 @@ export const featureFlags = {
   // in via Settings (`ironsmithRuntimeEnabled`) — the experimental engine ships
   // dark in prod by default.
   ironsmithRuntime: true,
-  // Deck Hub (browse/publish shared decks + top decks). Ships dark until the
-  // api.manabrew.app service is deployed and the flow has had a manual pass.
-  deckHub: false,
-  // Hub accounts (OAuth + email sign-in, deck ownership). Ships dark until the
-  // prod OAuth apps and the Resend domain are registered. Hub publishing
-  // requires a session once the hub enforces auth, so flip this before deckHub.
+  // Deck Hub (browse/publish shared decks + top decks). Public browse, play and
+  // copy need no session, so this stands alone; publishing and favorites stay
+  // gated behind `accounts` below.
+  deckHub: true,
+  // Hub accounts (OAuth + email sign-in, deck ownership). Still dark at compile
+  // time because both sign-in flows hand off to `WEB_APP_URL` and there is no
+  // route back into a desktop window: the hub sends OAuth to
+  // `{public_url}/api/auth/callback/{provider}` then on to `web_app_url`
+  // (`auth/oauth.rs`), and magic links to `{web_app_url}/auth/callback`
+  // (`auth/email.rs`). The web image turns this on at runtime, where that
+  // handoff lands back on the same origin.
   accounts: false,
-  // Email (magic-link) sign-in inside the accounts dialog. Hidden until the
-  // Resend domain is registered; OAuth sign-in is unaffected.
+  // Email (magic-link) sign-in inside the accounts dialog. Gated by `accounts`.
   emailSignIn: false,
 } as const;
 


### PR DESCRIPTION
## Summary

- Flip `deckHub` to `true` so desktop builds get Deck Hub browse, play and copy.
- Leave `accounts` and `emailSignIn` dark, with the reason recorded next to them.

## Why

Desktop has no runtime switch. `window.__MANABREW_RUNTIME__.featureFlags` is written by `ops/web-entrypoint.sh` in the web Docker image; desktop ships `public/config.js` as an empty object, and the dev opt-in inside `isFeatureEnabled` explicitly excludes Tauri. So the compile-time flag is the only lever a packaged build has, and Deck Hub has been invisible on desktop since it shipped.

Public Deck Hub reads need no session. Checked against production with no credentials:

```
GET /api/deckhub/entries  -> 200 (20 entries)
GET /api/deckhub/tags     -> 200
GET /api/decks            -> 401
```

The route table matches: the `deckhub` GETs are unguarded, while create, unpublish and favorite are session-gated, so a signed-out desktop user gets browse, play and copy and nothing else.

## Why accounts stays off

Both sign-in flows hand off to `WEB_APP_URL` and there is no route back into a desktop window. OAuth returns to `{public_url}/api/auth/callback/{provider}` and then on to `web_app_url` (`auth/oauth.rs:118`); magic links point at `{web_app_url}/auth/callback` (`auth/email.rs:83`). On desktop that strands the user in the browser on play.manabrew.app, signed in there and not in the app they started from. Turning the flag on without fixing that ships a sign-in button that cannot succeed.

The fix is a separate change and mostly already in place: the app serves a fixed loopback origin at `http://localhost:9527` with an SPA fallback, so `/auth/callback` resolves, and that origin is already allowed through CORS. What is missing is a caller-supplied return target on the Hub, validated against an allowlist. The OAuth apps themselves need no change, since the provider redirect stays pointed at the Hub.

## Test plan

`yarn typecheck`, `eslint` and `prettier` clean. The endpoint checks above ran against production unauthenticated.

Manual: open a desktop build and confirm Community browse lists entries, a deck opens and copies, and no sign-in affordance appears.
