### PR TITLE
feat(accounts): enable hub accounts on desktop builds

### DIFF
--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -13,19 +13,15 @@ export const featureFlags = {
   // dark in prod by default.
   ironsmithRuntime: true,
   // Deck Hub (browse/publish shared decks + top decks). Public browse, play and
-  // copy need no session, so this stands alone; publishing and favorites stay
-  // gated behind `accounts` below.
+  // copy need no session; publishing and favorites also need `accounts`.
   deckHub: true,
-  // Hub accounts (OAuth + email sign-in, deck ownership). Still dark at compile
-  // time because both sign-in flows hand off to `WEB_APP_URL` and there is no
-  // route back into a desktop window: the hub sends OAuth to
-  // `{public_url}/api/auth/callback/{provider}` then on to `web_app_url`
-  // (`auth/oauth.rs`), and magic links to `{web_app_url}/auth/callback`
-  // (`auth/email.rs`). The web image turns this on at runtime, where that
-  // handoff lands back on the same origin.
-  accounts: false,
-  // Email (magic-link) sign-in inside the accounts dialog. Gated by `accounts`.
-  emailSignIn: false,
+  // Hub accounts (OAuth + email sign-in, deck ownership). Desktop never uses the
+  // `WEB_APP_URL` redirect: an OAuth start with `client: "desktop"` ends on the
+  // hub's own code page and the app exchanges the pasted code at
+  // `/api/auth/exchange`, and the login email carries a code alongside its link.
+  accounts: true,
+  // Email sign-in inside the accounts dialog. Code entry, so desktop-safe.
+  emailSignIn: true,
 } as const;
 
 export type FeatureFlag = keyof typeof featureFlags;


### PR DESCRIPTION
## Summary

- Flip `accounts` and `emailSignIn` to `true` so desktop builds get sign-in and account decks.
- Correct the note left on `accounts` in #671.

## Why

#671 held these dark on the grounds that both sign-in flows hand off to `WEB_APP_URL` with no route back into a desktop window. That reasoning was wrong: desktop does not use the redirect at all, and the flow it does use is already implemented end to end on main.

Server side:

- `oauth_start` accepts `client: "desktop"` (`auth/oauth.rs:105`)
- the callback ends on the hub's own page instead of redirecting, `desktop_code_page` (`auth/oauth.rs:184`, `445`)
- desktop auth codes get their own TTL (`mint_auth_code`, `auth/oauth.rs:34`)
- `/api/auth/exchange` trades the code for a session (`routes.rs:138`, covered by tests)

Client side:

- `SignInDialog` detects Tauri, starts OAuth as `desktop`, opens the browser and shows a `desktop-code` step (`SignInDialog.tsx:106-110`, `281-288`)
- `exchangeCode` posts to `/api/auth/exchange` (`api/auth.ts:68`)

Email is the same shape. `send_login_email` is given a code as well as a link (`auth/email.rs:83-88`), and the dialog verifies via `verifyEmailCode`, so nothing depends on the link resolving to the desktop origin.

So the only thing keeping desktop signed out was the compile-time flag, which is the sole lever a packaged build has: `window.__MANABREW_RUNTIME__.featureFlags` comes from `ops/web-entrypoint.sh` in the web image, and desktop ships `public/config.js` empty.

## Test plan

`yarn typecheck` and `prettier` clean.

Manual, on a packaged desktop build: sign in with GitHub or Discord, confirm the browser lands on the hub code page, paste the code, and confirm the session lands in the app and account decks load. Repeat with email sign-in using the emailed code. Both need the CORS fix from #670, which is already released.
