### PR TITLE
fix(tauri): allow manabrew hosts through the http plugin scope

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -21,6 +21,8 @@
     {
       "identifier": "http:default",
       "allow": [
+        { "url": "https://api.manabrew.app/*" },
+        { "url": "https://play.manabrew.app/*" },
         { "url": "https://archidekt.com/*" },
         { "url": "https://api2.moxfield.com/*" },
         { "url": "https://backend.commanderspellbook.com/*" },


### PR DESCRIPTION
## Summary

- Add `https://api.manabrew.app/*` and `https://play.manabrew.app/*` to the `http:default` scope in `capabilities/default.json`.

## Why

On desktop, `platformFetch` does not use the WebView's `fetch`. It calls `tauriFetch` from `tauri-plugin-http` (`src/lib/platformFetch.ts:13-15`), which runs in Rust and only reaches hosts listed in the capability's `allow` list. That list had Scryfall, Archidekt, Moxfield, CommanderSpellbook and CubeCobra, but neither of our own hosts.

So every call the app makes to its own backend was refused by the plugin before any request left the machine:

- `api/hub.ts` and `api/auth.ts` both go through `platformFetch`, so accounts and Deck Hub fail to connect
- `useStatusBanner` does too (`hooks/useStatusBanner.ts:36`), which is why the status banner disappeared

One missing scope, all three symptoms. This surfaced now because v3.10.0 and v3.11.0 turned on `deckHub` and `accounts` for desktop, which made the app start calling those hosts for the first time.

Worth recording, since it sent me the wrong way at first: this is not a CORS problem. Requests through the plugin do not go through the WebView, so the browser never applies CORS to them. I confirmed separately that COEP `require-corp` does not block a CORS-passing cross-origin fetch in WebKit either, so neither the Hub allowlist nor the asset server's COEP headers were ever the cause here.

## Test plan

`cargo check -p manabrew` clean, capability JSON parses, prettier clean.

Manual, on a packaged desktop build: open Community and confirm entries load, sign in with GitHub or Discord and confirm the code exchange completes, and confirm the status banner renders again.
