### PR TITLE
feat(ui): restore the update callout on the play home

### DIFF
--- a/src/components/layout/UpdateCallout.tsx
+++ b/src/components/layout/UpdateCallout.tsx
@@ -1,0 +1,58 @@
+import { ArrowDownToLine, Loader2, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { installDesktopUpdate } from "@/hooks/useDesktopUpdater";
+import { useDesktopUpdateStore } from "@/stores/useDesktopUpdateStore";
+
+export function UpdateCallout() {
+  const phase = useDesktopUpdateStore((s) => s.phase);
+  const version = useDesktopUpdateStore((s) => s.version);
+  const progress = useDesktopUpdateStore((s) => s.progress);
+  const calloutDismissed = useDesktopUpdateStore((s) => s.calloutDismissed);
+  const dismissCallout = useDesktopUpdateStore((s) => s.dismissCallout);
+
+  if (phase === "idle" || !version || calloutDismissed) return null;
+
+  const downloading = phase === "downloading";
+  const downloadLabel = progress == null ? "Downloading…" : `Downloading… ${progress}%`;
+
+  return (
+    <div className="rounded-lg border border-primary/50 bg-primary/10 p-3 motion-safe:animate-update-glow sm:flex sm:items-center sm:gap-4 sm:p-4">
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <ArrowDownToLine className="h-4 w-4 shrink-0 text-primary" />
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold">Update available</p>
+          <p className="text-xs text-muted-foreground">Manabrew {version} is ready to install.</p>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="-mr-1 h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground sm:hidden"
+          onClick={dismissCallout}
+          aria-label="Dismiss update"
+        >
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      <div className="mt-2 flex items-center gap-1 sm:mt-0 sm:shrink-0">
+        <Button
+          size="sm"
+          className="w-full sm:w-auto"
+          disabled={downloading}
+          onClick={() => void installDesktopUpdate()}
+        >
+          {downloading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          {downloading ? downloadLabel : "Install & restart"}
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="hidden h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground sm:inline-flex"
+          onClick={dismissCallout}
+          aria-label="Dismiss update"
+        >
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/play/PlayHome.tsx
+++ b/src/components/play/PlayHome.tsx
@@ -1,5 +1,6 @@
 import { LibraryBig, Swords, Users } from "lucide-react";
 import { useEffect, useState } from "react";
+import { UpdateCallout } from "@/components/layout/UpdateCallout";
 import { FeatureTile } from "@/components/play/FeatureTile";
 import { PlayDeckShelf } from "@/components/play/PlayDeckShelf";
 import { PlayHomeLinks } from "@/components/play/PlayHomeLinks";
@@ -92,6 +93,8 @@ export function PlayHome() {
               Start a match your way, or open a deck from your collection.
             </p>
           </header>
+
+          <UpdateCallout />
 
           {resumeSession && (
             <RejoinMatchCard session={resumeSession} onAbandoned={() => setResumeSession(null)} />

--- a/src/stores/useDesktopUpdateStore.ts
+++ b/src/stores/useDesktopUpdateStore.ts
@@ -7,9 +7,11 @@ interface DesktopUpdateState {
   phase: DesktopUpdatePhase;
   version: string | null;
   progress: number | null;
+  calloutDismissed: boolean;
   setAvailable: (version: string) => void;
   setDownloading: (progress: number | null) => void;
   setFailed: () => void;
+  dismissCallout: () => void;
 }
 
 export const useDesktopUpdateStore = create<DesktopUpdateState>()(
@@ -18,9 +20,11 @@ export const useDesktopUpdateStore = create<DesktopUpdateState>()(
       phase: "idle",
       version: null,
       progress: null,
+      calloutDismissed: false,
       setAvailable: (version) => set({ phase: "available", version, progress: null }),
       setDownloading: (progress) => set({ phase: "downloading", progress }),
       setFailed: () => set({ phase: "available", progress: null }),
+      dismissCallout: () => set({ calloutDismissed: true }),
     }),
     { name: "desktopUpdate", enabled: import.meta.env.DEV },
   ),


### PR DESCRIPTION
## Summary

- Restore `UpdateCallout` and render it on the play home, under the header.
- Bring back `calloutDismissed` / `dismissCallout` on the update store so it can be dismissed for the session.

## Why

The unified play home (#494) dropped the old links panel, and `UpdateCallout` went with it. Since then the only update affordance has been the top-bar chip, which is easy to miss and collapses to an icon under 400px. `useDesktopUpdater` still tells people to "retry from the home page" on a failed install, and there was nothing there to retry from.

Dismiss is session-only, matching the previous behaviour: the store is not persisted, and `checkForDesktopUpdate` guards on `pendingUpdate`, so `setAvailable` fires once per run. Dismissing hides the callout while the top-bar chip stays available.

The old component had a second collapsed variant for the sidebar that no longer exists, so this renders nothing once dismissed rather than duplicating the top-bar affordance.

## Test plan

`yarn lint` clean (eslint, prettier, tsc).

Verified by forcing the store into `available` locally and loading the play home.

## Demo

![Update callout on the play home](https://raw.githubusercontent.com/witchesofthehill/manabrew/pr-assets/home-update-callout/675/update-callout-home.jpg)

![Close-up](https://raw.githubusercontent.com/witchesofthehill/manabrew/pr-assets/home-update-callout/675/update-callout-closeup.png)
