### PR TITLE
fix(ui): load deck cover art through ScryfallImg on desktop

### DIFF
--- a/src/components/deck/DeckHubEntryCard.tsx
+++ b/src/components/deck/DeckHubEntryCard.tsx
@@ -6,6 +6,7 @@ import { FormatBadge } from "@/components/game/FormatBadge";
 import { ManaSymbols } from "@/components/game/ManaSymbols";
 import { cn } from "@/lib/utils";
 import type { DeckHubEntrySummary } from "@/api/hubTypes";
+import { ScryfallImg } from "@/components/ScryfallImg";
 
 interface DeckHubEntryCardProps {
   entry: DeckHubEntrySummary;
@@ -134,7 +135,7 @@ export function DeckHubEntryCard({
       variant={variant}
       cover={
         entry.coverImageUrl ? (
-          <img
+          <ScryfallImg
             src={entry.coverImageUrl}
             alt=""
             loading="lazy"

--- a/src/components/lobby/DeckSelectionCard.tsx
+++ b/src/components/lobby/DeckSelectionCard.tsx
@@ -12,6 +12,7 @@ import { ManaSymbols } from "@/components/game/ManaSymbols";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import type { DeckCard, DeckLabel } from "@/protocol/deck";
+import { ScryfallImg } from "@/components/ScryfallImg";
 
 interface DeckSelectionCardProps {
   name: string;
@@ -147,7 +148,7 @@ export function DeckSelectionCard({
       supportingText={!isLegal ? validationError : !dense ? breakdown : undefined}
       cover={
         coverImageUrl ? (
-          <img
+          <ScryfallImg
             src={coverImageUrl}
             alt=""
             loading="lazy"


### PR DESCRIPTION
## Summary

- Render deck cover art through `ScryfallImg` instead of a raw `<img>` in `DeckHubEntryCard` and `DeckSelectionCard`.

## Why

Community deck covers are blank on desktop. `DeckHubEntryCard` rendered `entry.coverImageUrl` as a plain `<img>` with no `crossOrigin`, and the Hub serves those as `cards.scryfall.io` URLs.

The desktop asset server sets COEP `require-corp` (needed for `SharedArrayBuffer`), and under that a no-cors cross-origin subresource must carry `Cross-Origin-Resource-Policy`. `cards.scryfall.io` sends `access-control-allow-origin: *` but no CORP, so the image is refused.

Measured in a browser under `require-corp` against the real CDN URL:

```
plain <img> (no crossOrigin)   -> BLOCKED
<img crossOrigin="anonymous">  -> LOADED
fetch cors                     -> OK 200
```

Web is unaffected either way, because it is served COEP `credentialless`, which still allows no-cors subresources. This is the same web/desktop split behind the recent HTTP-scope fix.

`ScryfallImg` is the existing answer for this: on Tauri it resolves through `loadScryfallImage`, which fetches via `platformFetch` (the Tauri HTTP plugin, so no CORS dependency at all — `cards.scryfall.io` is already in the capability) and hands back a `blob:` URL that COEP does not police. Off Tauri it passes the URL straight through, so web rendering is byte-for-byte unchanged.

`DeckSelectionCard` had the same raw `<img>` on the same kind of URL and is fixed alongside it.

Adding `crossOrigin="anonymous"` would also work today, but the codebase deliberately stopped depending on that CDN's CORS headers after they went missing on 2026-07-15 (see the note in `api/scryfall.ts`). The blob path does not depend on them.

## Test plan

`yarn lint` clean (eslint, prettier, tsc).

Manual, on a packaged desktop build: open the play home and confirm Community deck covers render, then open the lobby deck picker and confirm those covers render. On web, confirm the covers are unchanged.
