### PR TITLE
fix(auth): open the desktop oauth page in the system browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@tailwindcss/vite": "^4.2.0",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-http": "^2.5.9",
+    "@tauri-apps/plugin-opener": "^2.5.4",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",
     "class-variance-authority": "^0.7.1",

--- a/src/components/auth/SignInDialog.tsx
+++ b/src/components/auth/SignInDialog.tsx
@@ -28,6 +28,7 @@ import { useSignInDialog } from "@/stores/useSignInDialogStore";
 import { getPlatformType } from "@/platform";
 import { clearAuthReturnIntent, storeAuthReturnIntent } from "@/lib/authReturn";
 import type { AuthProviders, AuthSessionResponse } from "@/api/authTypes";
+import { openExternal } from "@/lib/openExternal";
 
 type Step = "start" | "email-code" | "desktop-code" | "handle";
 
@@ -106,7 +107,7 @@ export function SignInDialog() {
       const desktop = getPlatformType() === "tauri";
       const url = await startOAuth(provider, "signin", desktop ? "desktop" : "web");
       if (desktop) {
-        window.open(url, "_blank", "noopener");
+        await openExternal(url);
         setStep("desktop-code");
       } else {
         storeAuthReturnIntent(prefill ?? undefined);

--- a/src/components/settings/AccountSection.tsx
+++ b/src/components/settings/AccountSection.tsx
@@ -9,6 +9,7 @@ import { useSignInDialog } from "@/stores/useSignInDialogStore";
 import { startOAuth, unlinkIdentity, AuthRequestError, type OAuthProvider } from "@/api/auth";
 import { useAuthStore } from "@/stores/useAuthStore";
 import { getPlatformType } from "@/platform";
+import { openExternal } from "@/lib/openExternal";
 
 const PROVIDER_LABELS: Record<string, string> = {
   github: "GitHub",
@@ -57,7 +58,7 @@ export function AccountSection() {
       const desktop = getPlatformType() === "tauri";
       const url = await startOAuth(provider, "link", desktop ? "desktop" : "web", token);
       if (desktop) {
-        window.open(url, "_blank", "noopener");
+        await openExternal(url);
         const onFocus = () => {
           window.removeEventListener("focus", onFocus);
           void refresh();

--- a/src/lib/openExternal.ts
+++ b/src/lib/openExternal.ts
@@ -1,0 +1,13 @@
+import { getPlatformType } from "@/platform";
+
+// `window.open` does not reach the system browser from the desktop webview, so
+// anything that hands the user off to an external page must go through the
+// opener plugin there.
+export async function openExternal(url: string): Promise<void> {
+  if (getPlatformType() === "tauri") {
+    const { openUrl } = await import("@tauri-apps/plugin-opener");
+    await openUrl(url);
+    return;
+  }
+  window.open(url, "_blank", "noopener");
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1693,6 +1693,13 @@
   dependencies:
     "@tauri-apps/api" "^2.11.0"
 
+"@tauri-apps/plugin-opener@^2.5.4":
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/@tauri-apps/plugin-opener/-/plugin-opener-2.5.4.tgz#b37883e4d36125b8c5a0c74f683395958a65bd7d"
+  integrity sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==
+  dependencies:
+    "@tauri-apps/api" "^2.11.0"
+
 "@tauri-apps/plugin-process@^2.3.1":
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz#fff77aa7550c9c5347689c859d581f88287bf7ae"


### PR DESCRIPTION
## Summary

- Add `@tauri-apps/plugin-opener` and a small `openExternal` helper.
- Use it for both OAuth hand-offs: the sign-in dialog and identity linking in Settings.

## Why

Desktop OAuth sign-in cannot be completed. Picking GitHub or Discord moves the dialog to the "enter code" step, but no browser ever opens, so there is no code to enter. Email sign-in is unaffected, since that code arrives by email.

`SignInDialog.tsx:109` called `window.open(url, "_blank", "noopener")`, which does not reach the system browser from the Tauri webview. `AccountSection.tsx:60` did the same for linking an identity.

The desktop side was already set up for this and only the JS half was missing: `tauri-plugin-opener` is in `src-tauri/Cargo.toml`, `.plugin(tauri_plugin_opener::init())` runs in `lib.rs:43`, and `opener:default` is granted in the capability. But `@tauri-apps/plugin-opener` was not a dependency at all, so nothing could call it. The other three plugins in use (`plugin-http`, `plugin-process`, `plugin-updater`) are all installed JS-side; this one was missed.

No capability change is needed. `opener:default` pulls in `allow-default-urls`, whose scope already allows `https://*`, `http://*`, `mailto:*` and `tel:*`. That is worth stating explicitly given the HTTP plugin's scope gap in #674 — this plugin's default is permissive, that one's was not.

Once the browser opens, the rest of the flow already works: the hub renders its code page after the callback (`auth/oauth.rs:184`), and the dialog exchanges the pasted code at `/api/auth/exchange`.

## Test plan

`yarn lint` clean (eslint, prettier, tsc).

Manual, on a packaged desktop build: open sign-in, pick Discord, confirm the system browser opens the provider flow, authorize, confirm the hub shows the code page, paste the code and confirm the session lands in the app. Repeat from Settings for linking an identity. On web, confirm sign-in still redirects in place.

## Follow-up, not in this PR

External links elsewhere are plain `<a target="_blank">` (the Discord, GitHub and Website buttons in `PlayHomeLinks`, and the links in `StatusBanner` and `ComboDetailModal`). Those may have the same problem on desktop. I have not verified whether they work, so they are left alone here rather than changed on a guess.
