### PR TITLE
fix(ui): unify live card art resolution

### DIFF
--- a/src/components/game/Card.tsx
+++ b/src/components/game/Card.tsx
@@ -12,11 +12,9 @@ import { isCreature, isLethalDamage, type ScryfallImageSize } from "./game.utils
 import { CARD_BADGES, CARD_BACK_IMAGE_URL } from "./game.constants";
 import { isFacelessCard } from "@/lib/gameCard";
 import { CARD_BANNER_CONTAINER, CARD_BANNER_TEXT } from "./game.styles";
-import { useGameStore } from "@/stores/useGameStore";
 import { deriveCardRailState } from "@/components/game/cardRailState";
-import { asDeckCard } from "@/lib/decks";
 import { ScryfallImg } from "@/components/ScryfallImg";
-import { useCardFaces } from "@/hooks/useCardFaces";
+import { useResolvedGameCard } from "@/hooks/useResolvedGameCard";
 import { isHorizontalGameCard } from "@/lib/horizontalGameCard";
 
 const TOKEN_LABELS: Record<string, string> = {
@@ -66,18 +64,11 @@ function CardComponent({
   resolution = "border_crop",
 }: CardProps) {
   const [hasError, setHasError] = useState(false);
-  const deck = useGameStore((s) => s.gameDecks[card.ownerId]);
-  const deckCard = asDeckCard(deck, card);
-  const cardFaces = useCardFaces({
-    name: card.identity.name,
-    setCode: card.identity.setCode || undefined,
-    cardNumber: card.identity.cardNumber || undefined,
-  });
+  const { deckCard, imageUrl: resolveImageUrl } = useResolvedGameCard(card);
   const faceIndex = showBackFace ? 1 : 0;
-  const faceImageUrl = cardFaces.faces[faceIndex]?.imageUris?.[resolution];
 
   const faceless = isFacelessCard(card);
-  const imageUrl = faceless ? CARD_BACK_IMAGE_URL : (faceImageUrl ?? deckCard.uris[resolution]);
+  const imageUrl = faceless ? CARD_BACK_IMAGE_URL : resolveImageUrl(faceIndex, resolution);
   const displayName = faceless ? "Face-down card" : card.identity.name;
   const themeColors = useTheme().gameTheme;
 

--- a/src/components/game/CardPreview.tsx
+++ b/src/components/game/CardPreview.tsx
@@ -22,11 +22,9 @@ import { PREVIEW_TIMING } from "@/lib/cardPreview";
 import type { HandActionOption } from "@/stores/useGameUIStore";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { CSSProperties } from "react";
-import { useGameStore } from "@/stores/useGameStore";
 import { DEBUG_KEYWORD_CARD_ID, useGameDevStore } from "@/stores/useGameDevStore";
-import { asDeckCard } from "@/lib/decks";
 import { ScryfallImg } from "@/components/ScryfallImg";
-import { useCardFaces } from "@/hooks/useCardFaces";
+import { useResolvedGameCard } from "@/hooks/useResolvedGameCard";
 import { useKeybindings } from "@/hooks/useKeybindings";
 import { deriveCardRailEffects, deriveCardRailState } from "@/components/game/cardRailState";
 
@@ -172,24 +170,16 @@ export function CardPreview({
       : [];
   const hasMainActions = mainActions.length > 0;
   const showSidePanel = hasMainActions || Boolean(rail || extraClassActions.length);
-  const deck = useGameStore((s) => s.gameDecks[card.ownerId]);
   const isDebugCard = card.id === DEBUG_KEYWORD_CARD_ID;
+  const resolvedGameCard = useResolvedGameCard(card);
   const deckCard: DeckCard = isDebugCard
     ? ({
         identity: { id: "", name: card.identity.name, setCode: "", cardNumber: "" },
         uris: {},
       } as DeckCard)
-    : asDeckCard(deck, card);
-  const { setCode, cardNumber } = deckCard.identity;
-  const cardFaces = useCardFaces(
-    isDebugCard
-      ? { name: card.identity.name }
-      : {
-          name: card.identity.name,
-          setCode: setCode || undefined,
-          cardNumber: cardNumber || undefined,
-        },
-  );
+    : resolvedGameCard.deckCard;
+  const cardFaces = resolvedGameCard.cardFaces;
+  const resolveImageUrl = resolvedGameCard.imageUrl;
   const front = cardFaces.faces[0];
   const back = cardFaces.faces[1];
   const railEffects = rail ? deriveCardRailEffects(card, rail) : [];
@@ -230,17 +220,16 @@ export function CardPreview({
   }, [showSidePanel, card.id]);
 
   const faceless = isFacelessCard(card);
-  const imageUrl = faceless
-    ? CARD_BACK_IMAGE_URL
-    : deckCard.uris[imageSize] || front?.imageUris?.[imageSize];
-  const hasFlippableFaces =
-    cardFaces.isFlippable && !!front?.imageUris?.[imageSize] && !!back?.imageUris?.[imageSize];
+  const imageUrl = faceless ? CARD_BACK_IMAGE_URL : resolveImageUrl(0, imageSize);
+  const frontImageUrl = resolveImageUrl(0, imageSize);
+  const backImageUrl = resolveImageUrl(1, imageSize);
+  const hasFlippableFaces = cardFaces.isFlippable && !!frontImageUrl && !!backImageUrl;
   const doubleFacedData = hasFlippableFaces
     ? {
-        frontImageUrl: front!.imageUris![imageSize],
-        backImageUrl: back!.imageUris![imageSize],
-        frontImageUrlLow: front!.imageUris!.normal,
-        backImageUrlLow: back!.imageUris!.normal,
+        frontImageUrl: frontImageUrl!,
+        backImageUrl: backImageUrl!,
+        frontImageUrlLow: resolveImageUrl(0, "normal")!,
+        backImageUrlLow: resolveImageUrl(1, "normal")!,
         frontName: front!.name,
         backName: back!.name,
       }
@@ -354,7 +343,7 @@ export function CardPreview({
         ? showBackFace
           ? doubleFacedData.backImageUrlLow
           : doubleFacedData.frontImageUrlLow
-        : deckCard.uris.normal;
+        : resolveImageUrl(0, "normal");
   const cardLookupPending = !isDebugCard && cardFaces.faces.length === 0;
 
   return createPortal(

--- a/src/hooks/useResolvedGameCard.ts
+++ b/src/hooks/useResolvedGameCard.ts
@@ -1,0 +1,21 @@
+import { useCardFaces } from "@/hooks/useCardFaces";
+import { asDeckCard } from "@/lib/decks";
+import { useGameStore } from "@/stores/useGameStore";
+import type { CardDto } from "@/protocol/game";
+import type { ScryfallImageSize } from "@/components/game/game.utils";
+
+export function useResolvedGameCard(card: CardDto) {
+  const deck = useGameStore((state) => state.gameDecks[card.ownerId]);
+  const deckCard = asDeckCard(deck, card);
+  const cardFaces = useCardFaces({
+    name: deckCard.identity.name || card.identity.name,
+    setCode: deckCard.identity.setCode || undefined,
+    cardNumber: deckCard.identity.cardNumber || undefined,
+  });
+  const imageUrl = (faceIndex: number, size: ScryfallImageSize) =>
+    faceIndex === 0
+      ? (deckCard.uris[size] ?? cardFaces.faces[0]?.imageUris?.[size])
+      : (cardFaces.faces[faceIndex]?.imageUris?.[size] ?? deckCard.uris[size]);
+
+  return { deckCard, cardFaces, imageUrl };
+}


### PR DESCRIPTION
## Summary

- route live game card renderers through the shared `asDeckCard` resolver
- preserve token-script-selected front art in dialogs, zone cards, and hover previews
- keep face-specific Scryfall art resolution for genuine card backs

## Why

The token-script identity fix correctly selected token printings on the game board, but DOM card surfaces could perform a second Scryfall lookup from the raw game identity and replace the resolved art with an ambiguous or broken printing.

## Test plan

- `yarn lint:all`
- `git diff --check`
- audited live `CardDto` image consumers and prompt source-card resolution

## Demo

Not recorded; this corrects which existing card image is selected without changing layout or styling.