### PR TITLE
feat(node): export the engine JVM's GC pauses and live set

### DIFF
--- a/manabrew-rs/crates/self-hosted-node/src/engine_backend/java_backend.rs
+++ b/manabrew-rs/crates/self-hosted-node/src/engine_backend/java_backend.rs
@@ -2270,6 +2270,9 @@ impl SubprocessBridge {
         cmd.arg("-Dsun.stdout.encoding=UTF-8");
         cmd.arg("-Dsun.stderr.encoding=UTF-8");
         cmd.arg("-Djava.awt.headless=true");
+        // The fleet ships no logs, so the GC log exists only to be turned into
+        // metrics by the stderr pump. One line per collection.
+        cmd.arg("-Xlog:gc:stderr");
         cmd.arg("-jar").arg(&config.harness_jar);
         cmd.arg("--interactive-server");
         cmd.arg("--forge-home")
@@ -2308,6 +2311,13 @@ impl SubprocessBridge {
             if let Some(stderr) = stderr {
                 let reader = BufReader::new(stderr);
                 for line in reader.lines().map_while(Result::ok) {
+                    if let Some(pause) = parse_gc_pause(&line) {
+                        crate::metrics::record_jvm_gc(
+                            pause.kind,
+                            Duration::from_secs_f64(pause.millis / 1000.0),
+                            pause.heap_after_mb,
+                        );
+                    }
                     if line.contains("Exception") || line.contains("ERROR") {
                         warn!(target: "self_hosted_node::java", "[java] {line}");
                     } else {
@@ -2621,5 +2631,69 @@ fn require_file(path: &Path, label: &str) -> Result<(), String> {
         Ok(())
     } else {
         Err(format!("{label} does not exist: {}", path.display()))
+    }
+}
+
+/// One `Pause` line from the JVM's unified GC log.
+struct GcPause {
+    kind: &'static str,
+    millis: f64,
+    heap_after_mb: Option<u64>,
+}
+
+/// Parse a unified-log GC pause, e.g.
+/// `[12.3s][info][gc] GC(7) Pause Full (Allocation Failure) 240M->171M(247M) 226.856ms`
+fn parse_gc_pause(line: &str) -> Option<GcPause> {
+    let kind = if line.contains("Pause Full") {
+        "full"
+    } else if line.contains("Pause Young") {
+        "young"
+    } else {
+        return None;
+    };
+    let millis = line
+        .rsplit(' ')
+        .find_map(|token| token.strip_suffix("ms")?.parse::<f64>().ok())?;
+    // "240M->171M(247M)": the figure after the arrow is what survived.
+    let heap_after_mb = line.split_once("->").and_then(|(_, rest)| {
+        let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
+        digits.parse::<u64>().ok()
+    });
+    Some(GcPause {
+        kind,
+        millis,
+        heap_after_mb,
+    })
+}
+
+#[cfg(test)]
+mod gc_log_tests {
+    use super::parse_gc_pause;
+
+    #[test]
+    fn reads_a_full_collection() {
+        let pause = parse_gc_pause(
+            "[117.6s][info][gc] GC(21) Pause Full (Allocation Failure) 240M->171M(247M) 226.856ms",
+        )
+        .expect("parsed");
+        assert_eq!(pause.kind, "full");
+        assert_eq!(pause.heap_after_mb, Some(171));
+        assert!((pause.millis - 226.856).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn reads_a_young_collection() {
+        let pause = parse_gc_pause(
+            "[3.1s][info][gc] GC(2) Pause Young (Allocation Failure) 216M->91M(494M) 17.254ms",
+        )
+        .expect("parsed");
+        assert_eq!(pause.kind, "young");
+        assert_eq!(pause.heap_after_mb, Some(91));
+    }
+
+    #[test]
+    fn ignores_other_output() {
+        assert!(parse_gc_pause("[java] LOGGER ERROR: something").is_none());
+        assert!(parse_gc_pause("[1.0s][info][gc,init] CardTable entry size: 512").is_none());
     }
 }

--- a/manabrew-rs/crates/self-hosted-node/src/metrics.rs
+++ b/manabrew-rs/crates/self-hosted-node/src/metrics.rs
@@ -10,8 +10,12 @@ const GAME_DURATION_SECONDS: &str = "manabrew_node_game_duration_seconds";
 const ENGINE_ERRORS: &str = "manabrew_node_engine_errors_total";
 const RELAY_RECONNECTS: &str = "manabrew_node_relay_reconnects_total";
 const BUILD_INFO: &str = "manabrew_node_build_info";
+const JVM_GC_PAUSE_SECONDS: &str = "manabrew_node_jvm_gc_pause_seconds";
+const JVM_GC_TOTAL: &str = "manabrew_node_jvm_gc_total";
+const JVM_HEAP_AFTER_GC_BYTES: &str = "manabrew_node_jvm_heap_after_gc_bytes";
 
 const LABEL_POOL: &str = "pool";
+const LABEL_KIND: &str = "kind";
 const LABEL_CLEAN: &str = "clean";
 const LABEL_PLAYERS: &str = "players";
 const LABEL_SIGNATURE: &str = "signature";
@@ -125,6 +129,16 @@ impl RoomHostedGuard {
 impl Drop for RoomHostedGuard {
     fn drop(&mut self) {
         gauge!(ROOMS_HOSTED, LABEL_POOL => self.pool.as_str()).decrement(1.0);
+    }
+}
+
+/// Pause and retained heap reported by the engine JVM's own GC log. The fleet
+/// ships no logs, so without this a stalled JVM is invisible from off-box.
+pub fn record_jvm_gc(kind: &'static str, pause: Duration, heap_after_mb: Option<u64>) {
+    histogram!(JVM_GC_PAUSE_SECONDS, LABEL_KIND => kind).record(pause.as_secs_f64());
+    counter!(JVM_GC_TOTAL, LABEL_KIND => kind).increment(1);
+    if let Some(megabytes) = heap_after_mb {
+        gauge!(JVM_HEAP_AFTER_GC_BYTES, LABEL_KIND => kind).set((megabytes * 1024 * 1024) as f64);
     }
 }
 


### PR DESCRIPTION
## Summary

- Ask the engine JVM for a GC log (`-Xlog:gc:stderr`, one line per collection) and parse it in the stderr pump the node already runs.
- Export `manabrew_node_jvm_gc_pause_seconds`, `manabrew_node_jvm_gc_total` and `manabrew_node_jvm_heap_after_gc_bytes`, labelled `kind=young|full`.

## Why

The fleet pushes metrics and ships no logs. Alloy discovers containers on the relay host, and the nodes do not run there, so nothing they write reaches Loki. Today a node reports that a game happened and how long it took. When one freezes for two minutes it reports nothing at all.

That gap is why #684 took as long as it did. The stalls are inside the engine JVM (the node's 30s heartbeats stayed exactly on schedule right through a 134s stall, so the transport and the Rust loop were both healthy), and the leading explanation is Serial GC full collections, whose cost measures 1.328 ms per MB of live set. Confirming or killing that needs one number, the live set, which nothing currently reports.

`manabrew_node_jvm_heap_after_gc_bytes` is that number.

Nothing here depends on log shipping, and the push path is already proven: all 32 nodes are pushing on time, `last_push_successful=true`, no gaps.

## Test plan

- Parser unit tests for a full collection, a young collection, and non-GC output.
- End to end against a local push sink, with a real Forge game under the fleet's own JVM settings (`-Xmx512m -XX:+UseSerialGC`). The push body contained:

```
manabrew_node_jvm_gc_total{kind="young"} 14
manabrew_node_jvm_heap_after_gc_bytes{kind="young"} 207618048
manabrew_node_jvm_gc_pause_seconds{kind="young",quantile="0.9"} 0.039
```

198MB retained, which matches what the JVM's own log reported for that game.

- `cargo clippy --all-targets --features java-forge -- -D warnings` clean.

## Notes for review

`-Xlog:gc:stderr` is added unconditionally. It is one line per collection, roughly a hundred over a long game, and the pump already reads the stream. #691 introduces a configurable `gc_log` that emits `-Xlog:gc*`; when it lands, that flag supersedes this line and this one should be dropped to avoid double logging.

Deliberately no JMX and no `jcmd`. The GC log is already there, the pump already reads it, and this adds no new dependency or port.
