### PR TITLE
chore: bump app to 3.15.3 for the hub migration fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "manabrew"
-version = "3.15.2"
+version = "3.15.3"
 dependencies = [
  "forge-carddb",
  "forge-cardset-archive",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "manabrew",
   "private": true,
-  "version": "3.15.2",
+  "version": "3.15.3",
   "type": "module",
   "license": "AGPL-3.0-or-later",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manabrew"
-version = "3.15.2"
+version = "3.15.3"
 edition = "2021"
 publish = false
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Manabrew",
-  "version": "3.15.2",
+  "version": "3.15.3",
   "identifier": "com.manabrew.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- Hand-bump the app to 3.15.3 so the release pipeline cuts a `v3.15.3` tag

## Why

#709 fixed the hub migration that took prod down, but `cargo xtask release` scored it as a crate-level change: it bumped `manabrew-hub` 0.8.0 to 0.8.1 and tagged `manabrew-hub-v0.8.1`. Nothing depends on the hub crate, so the app never bumped, and `docker-images.yml` only triggers on `v*`. There is no fixed hub image in GHCR and no deploy will ever pick the fix up on its own.

`plan::next_version` releases a hand-set version as-is when Cargo.toml is ahead of the last tag, so bumping the app is the sanctioned way to force a release with no app-facing change.

Prod is currently serving with its hub rolled back to the v3.15.0 image, which predates `15_orphan_decks.sql`. That image is missing the account export and delete endpoints from #656, which the deployed v3.15.2 web calls. Cutting v3.15.3 puts the fixed hub on prod and closes that gap.

## Test plan

- `cargo update -p manabrew --offline` keeps `Cargo.lock` in sync
- The four touched files are what a `chore(release)` commit rewrites anyway, so `xtask apply` is a no-op over them
- Verification is the pipeline itself: the merge should produce a `v3.15.3` tag, a docker-images run, and a publish run whose deploy rolls the hub

Note for whoever merges: the commit subject deliberately avoids the `chore(release):` prefix, which the Release workflow's loop guard skips.
