### PR TITLE
fix(harness): drop the profiling left in the action space, and apply the hold

### DIFF
--- a/forge-harness/src/main/java/forge/harness/common/ActionSpace.java
+++ b/forge-harness/src/main/java/forge/harness/common/ActionSpace.java
@@ -45,12 +45,6 @@ public final class ActionSpace {
             "Spend only colored mana on X. No more than one mana of each color may be spent this way.";
 
 
-    public static final java.util.concurrent.atomic.AtomicLong T_MANA = new java.util.concurrent.atomic.AtomicLong();
-    public static final java.util.concurrent.atomic.AtomicLong T_TGT = new java.util.concurrent.atomic.AtomicLong();
-    public static final java.util.concurrent.atomic.AtomicLong T_RESTR = new java.util.concurrent.atomic.AtomicLong();
-    public static final java.util.concurrent.atomic.AtomicLong T_ABIL = new java.util.concurrent.atomic.AtomicLong();
-    public static final java.util.concurrent.atomic.AtomicLong N_ABIL = new java.util.concurrent.atomic.AtomicLong();
-    public static final java.util.concurrent.atomic.AtomicLong N_SCAN = new java.util.concurrent.atomic.AtomicLong();
 
     private ActionSpace() {}
 
@@ -137,25 +131,25 @@ public final class ActionSpace {
 
         final List<SpellAbility> actions = new ArrayList<>();
         final Map<Integer, Card> restrictionHosts = new HashMap<>();
+        // GameActionUtil.getAlternativeCosts runs the whole CR 613 layer pass twice for
+        // every ability with an alternate host (MDFC, adventure, split, bestow), and an
+        // enumeration hits that once per candidate. Game state cannot change while we
+        // enumerate, so hold the pass and restore once at the end.
+        game.getAction().setHoldCheckingStaticAbilities(true);
+        try {
         for (final Card c : candidates) {
-            final long ta0 = System.nanoTime();
-            final java.util.List<SpellAbility> abils = c.getAllPossibleAbilities(player, true);
-            T_ABIL.addAndGet(System.nanoTime() - ta0);
-            for (final SpellAbility sa : abils) {
-                N_ABIL.incrementAndGet();
+            for (final SpellAbility sa : c.getAllPossibleAbilities(player, true)) {
                 sa.setActivatingPlayer(player);
                 final Cost payCosts = sa.getPayCosts();
                 if (payCosts != null && payCosts.hasManaCost()) {
                     // SpellAbility.canPlay() uses Cost.canPay(), and CostPartMana.canPay()
                     // is permissive in engine core. Add an explicit mana-feasibility check.
                     final Set<Card> reservedSacrifices = getFixedReservedSacrifices(sa);
-                    final long tm0 = System.nanoTime();
                     final boolean canPayMana = lifePaymentFallback
                             ? canPayManaCostWithLifeFallback(sa, player, reservedSacrifices)
                             : (reservedSacrifices.isEmpty()
                             ? ComputerUtilMana.canPayManaCost(sa, player, 0, false)
                             : canPayManaCostWithReservedSacrifices(sa, player, reservedSacrifices));
-                    T_MANA.addAndGet(System.nanoTime() - tm0);
                     if (!canPayMana) {
                         continue;
                     }
@@ -165,28 +159,18 @@ public final class ActionSpace {
                 }
                 // Target enumeration scans every card in the target zones, so it stays behind
                 // the payability guards: most candidates are unpayable late in a game.
-                final long tt0 = System.nanoTime();
-                final boolean vt = hasValidTargets(sa);
-                T_TGT.addAndGet(System.nanoTime() - tt0);
-                if (!vt) {
+                if (!hasValidTargets(sa)) {
                     continue;
                 }
-                final long tr0 = System.nanoTime();
-                final boolean okr = sa.checkRestrictions(restrictionHost(sa, game, restrictionHosts), player);
-                T_RESTR.addAndGet(System.nanoTime() - tr0);
-                if (!okr) {
+                if (!sa.checkRestrictions(restrictionHost(sa, game, restrictionHosts), player)) {
                     continue;
                 }
                 actions.add(sa);
             }
         }
-        if (N_SCAN.incrementAndGet() % 100 == 0) {
-            System.err.printf("ERROR-SPLIT scans=%d abil=%d mana=%dms tgt=%dms restr=%dms getabil=%dms statics=%d staticms=%d nstat=%d%n",
-                    N_SCAN.get(), N_ABIL.get(), T_MANA.get()/1000000, T_TGT.get()/1000000,
-                    T_RESTR.get()/1000000, T_ABIL.get()/1000000,
-                    forge.game.GameAction.STATIC_CALLS.get(),
-                    forge.game.GameAction.STATIC_NANOS.get()/1000000,
-                    forge.game.GameAction.STATIC_COUNT.get());
+        } finally {
+            game.getAction().setHoldCheckingStaticAbilities(false);
+            game.getAction().checkStaticAbilities(false);
         }
         return actions;
     }


### PR DESCRIPTION
## Summary

- Remove the profiling counters #691 left in `ActionSpace`: six `AtomicLong`s, the `System.nanoTime()` calls around every stage, and a `System.err.printf` firing every hundred scans.
- Remove the matching counters from the forge fork, where `checkStaticAbilities` was doing an atomic increment and two `nanoTime()` calls on every invocation.
- Apply `setHoldCheckingStaticAbilities` around the enumeration, which is the change #691 was named for and did not contain.

## Why

#691 merged the scaffolding from the #684 investigation instead of the fix.

`ActionSpace` on main carries `T_MANA`, `T_TGT`, `T_RESTR`, `T_ABIL`, `N_ABIL` and `N_SCAN`, times four stages per candidate ability, and writes a line to stderr every hundred scans. The forge fork counts and times every `checkStaticAbilities` call, which is the hottest path in the engine. Meanwhile `setHoldCheckingStaticAbilities` appears nowhere in the harness, so the pass it was meant to hold still runs per candidate.

The fork's net change against upstream is now the two things it should always have been: the visibility widening, and replacing a quadratic `removeAll` with a filtering pass.

This also caused the build failure on #711. #691's submodule commit lived only on a feature branch when it merged, and `.gitmodules` pins `branch = manabrew` with `shallow = true`, so CI fetched a branch tip that did not contain it. Both `manabrew` and `manabrew-staging` now carry the cleanup commit, so the pinned commit is reachable.

## Test plan

Parity, harness rebuilt on each side, identical commands and seeds. Same pass counts and the same failing seeds throughout, so nothing here changes behaviour:

| suite | main | this branch |
| --- | --- | --- |
| `staticability` | 13 PASS / 7 FAIL (47, 48, 49, 51, 53, 58, 61) | 13 PASS / 7 FAIL (same seeds) |
| `phyrexian_mana` | 12 PASS / 0 FAIL | 12 PASS / 0 FAIL |
| `keyword_advanced` | 2 PASS / 8 FAIL (42-47, 50, 51) | 2 PASS / 8 FAIL (same seeds) |

`phyrexian_mana` is the meaningful one: alternate costs are what `getAlternativeCosts` drives and what the hold brackets, and it is clean on both sides.

## Note on those pre-existing failures

`keyword_advanced` sits at 20% on main and `staticability` at 65%, and the divergences are `library_top` mismatches, the two engines holding entirely different library orders. That looks like RNG or shuffle drift upstream of anything here. Unrelated to this PR, but it is not visible in CI for these crates and is worth someone's attention.
