### PR TITLE
fix(ui): keep rendering while the window is unfocused

### DIFF
--- a/src/components/BreweryBackdrop.tsx
+++ b/src/components/BreweryBackdrop.tsx
@@ -5,11 +5,31 @@ interface BreweryBackdropProps {
   className?: string;
 }
 
+/**
+ * A soft radial fade, used in place of `blur-3xl` on the two glow discs.
+ *
+ * A CSS `filter: blur()` on a disc this large (60vw) is a real Gaussian pass
+ * over millions of pixels, and WebKit runs it on the CPU (vImage) once the
+ * surface is big enough. A mask is a compositing operation instead, and reads
+ * near-identically for a shape whose only job is to fade out at the edges.
+ */
+const GLOW_MASK =
+  "radial-gradient(closest-side, #000 0%, rgba(0,0,0,0.72) 34%, " +
+  "rgba(0,0,0,0.32) 60%, rgba(0,0,0,0.08) 82%, transparent 100%)";
+
 export function BreweryBackdrop({ variant = "hero", className }: BreweryBackdropProps) {
   return (
     <div
       aria-hidden
-      className={cn("pointer-events-none absolute inset-0 overflow-hidden", className)}
+      className={cn(
+        "pointer-events-none absolute inset-0 overflow-hidden",
+        // Promote to its own compositing layer. The backdrop never changes, but
+        // it shares a layer with animated siblings (the init gate's shimmer, the
+        // app's transitions), so every one of their frames was re-rasterising
+        // the blurred artwork below. Isolated, it rasterises once.
+        "transform-gpu",
+        className,
+      )}
     >
       <div
         className={cn(
@@ -19,15 +39,17 @@ export function BreweryBackdrop({ variant = "hero", className }: BreweryBackdrop
         )}
       />
       <div
+        style={{ maskImage: GLOW_MASK, WebkitMaskImage: GLOW_MASK }}
         className={cn(
-          "pointer-events-none absolute left-1/2 top-[28%] size-[60vw] -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary/10 blur-3xl",
+          "pointer-events-none absolute left-1/2 top-[28%] size-[60vw] -translate-x-1/2 -translate-y-1/2 bg-primary/10",
           variant === "ambient" && "opacity-60",
           variant === "subtle" && "opacity-30",
         )}
       />
       <div
+        style={{ maskImage: GLOW_MASK, WebkitMaskImage: GLOW_MASK }}
         className={cn(
-          "pointer-events-none absolute left-1/2 top-[60%] size-[45vw] -translate-x-1/2 rounded-full bg-primary/5 blur-3xl",
+          "pointer-events-none absolute left-1/2 top-[60%] size-[45vw] -translate-x-1/2 bg-primary/5",
           variant === "ambient" && "opacity-60",
           variant === "subtle" && "opacity-30",
         )}

--- a/src/pixi/visibility.test.ts
+++ b/src/pixi/visibility.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import type { Application } from "pixi.js";
+
+type Listener = () => void;
+
+/**
+ * `visibility` keeps module-level state (installed listeners, current paused
+ * flag), so every case re-imports it against a freshly stubbed document.
+ */
+async function loadVisibility(initial: { hidden: boolean; focused: boolean }) {
+  const listeners = new Map<string, Listener[]>();
+  const state = { ...initial };
+
+  const addListener = (type: string, fn: Listener) => {
+    const existing = listeners.get(type) ?? [];
+    existing.push(fn);
+    listeners.set(type, existing);
+  };
+
+  vi.stubGlobal("document", {
+    get hidden() {
+      return state.hidden;
+    },
+    hasFocus: () => state.focused,
+    addEventListener: addListener,
+  });
+  vi.stubGlobal("window", { addEventListener: addListener });
+
+  vi.resetModules();
+  const { registerPixiApp } = await import("./visibility");
+
+  return {
+    registerPixiApp,
+    listenerTypes: () => [...listeners.keys()],
+    setHidden(hidden: boolean) {
+      state.hidden = hidden;
+      for (const fn of listeners.get("visibilitychange") ?? []) fn();
+    },
+    setFocused(focused: boolean) {
+      state.focused = focused;
+      for (const fn of listeners.get(focused ? "focus" : "blur") ?? []) fn();
+    },
+  };
+}
+
+function fakeApp() {
+  const ticker = { stop: vi.fn(), start: vi.fn() };
+  return { app: { ticker } as unknown as Application, ticker };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("pixi visibility", () => {
+  it("keeps rendering when the window is merely unfocused", async () => {
+    const v = await loadVisibility({ hidden: false, focused: true });
+    const { app, ticker } = fakeApp();
+    v.registerPixiApp(app);
+
+    v.setFocused(false);
+
+    // A window sitting visible on a second monitor must keep drawing, or the
+    // board freezes mid-game until it is clicked again (#618).
+    expect(ticker.stop).not.toHaveBeenCalled();
+  });
+
+  it("does not subscribe to focus changes at all", async () => {
+    const v = await loadVisibility({ hidden: false, focused: true });
+    v.registerPixiApp(fakeApp().app);
+
+    expect(v.listenerTypes()).toEqual(["visibilitychange"]);
+  });
+
+  it("pauses while hidden and resumes when shown", async () => {
+    const v = await loadVisibility({ hidden: false, focused: true });
+    const { app, ticker } = fakeApp();
+    v.registerPixiApp(app);
+
+    v.setHidden(true);
+    expect(ticker.stop).toHaveBeenCalledTimes(1);
+
+    v.setHidden(false);
+    expect(ticker.start).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts an app paused when it registers while hidden", async () => {
+    const v = await loadVisibility({ hidden: true, focused: false });
+    const { app, ticker } = fakeApp();
+    v.registerPixiApp(app);
+
+    expect(ticker.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops tracking an app once unregistered", async () => {
+    const v = await loadVisibility({ hidden: false, focused: true });
+    const { app, ticker } = fakeApp();
+    const unregister = v.registerPixiApp(app);
+
+    unregister();
+    v.setHidden(true);
+
+    expect(ticker.stop).not.toHaveBeenCalled();
+  });
+});

--- a/src/pixi/visibility.ts
+++ b/src/pixi/visibility.ts
@@ -4,8 +4,17 @@ const apps = new Set<Application>();
 let installed = false;
 let paused = false;
 
+/**
+ * Pause only when the page is genuinely hidden — minimised, occluded, or on a
+ * background tab — where the browser stops servicing rAF anyway.
+ *
+ * Deliberately NOT keyed on `document.hasFocus()`. A window that sits visible
+ * on a second monitor while the user works elsewhere is unfocused but still on
+ * screen, and stopping the ticker there froze the board mid-game: opponents'
+ * plays only appeared once the window regained focus (#618).
+ */
 function shouldPause(): boolean {
-  return document.hidden || !document.hasFocus();
+  return document.hidden;
 }
 
 function sync(): void {
@@ -23,8 +32,6 @@ function install(): void {
   if (installed) return;
   installed = true;
   document.addEventListener("visibilitychange", sync);
-  window.addEventListener("blur", sync);
-  window.addEventListener("focus", sync);
   paused = shouldPause();
 }
 


### PR DESCRIPTION
## Summary

- Pause the Pixi ticker only when the page is actually hidden, not when it merely loses focus.
- Drop the two large CPU Gaussian blurs from `BreweryBackdrop` and give it its own compositing layer.

## Why

**Rendering.** `visibility.ts` paused on `!document.hasFocus()`, so a window sitting visible on a second monitor froze mid-game and only caught up once it was clicked again. The notification area kept updating because it is DOM, not the canvas, which is exactly what the report describes. Forge games are affected the same way, since both engines draw through the same `BoardScene` ticker. `document.hidden` is the right signal: minimised, occluded or backgrounded, where the browser stops servicing rAF anyway.

**Blurs.** At `hero` the backdrop stacked three live CSS filters, two `blur-3xl` discs at 60vw and 45vw plus a full-viewport blurred image. WebKit runs those on the CPU (`FEGaussianBlurSoftwareApplier` into `vImageBoxConvolve_ARGB8888`) once the surface is big enough, and box-blur cost scales with area, so it works out around 14M pixels per rasterisation. They are static and should rasterise once, but they shared a layer with the init gate's infinite shimmer, so every shimmer frame redid all of them.

Found this on a desktop app left open against an unreachable server. The gate has no timeout, so it sat on "Connecting" for 36 hours with the WebKit GPU process pegged above 100%, which dragged WindowServer to 50-60% and tripped its CPU watchdog. `AppShell` renders the same backdrop, so the cost was there during normal play too.

Fixes #618

## Test plan

- `yarn lint` and `yarn vitest run` green, 65 tests.
- New `src/pixi/visibility.test.ts`, 5 cases. Verified they are real regression tests: the two new-behaviour cases fail against the old file and pass against the new one, while the three existing invariants (pause when hidden, register while hidden, unregister) pass on both.
- Backdrop change is visual only. The mask uses shaped stops rather than a linear fade so the falloff still reads like a blur.

## Follow-ups, not in this PR

- The hero `<img>` still carries `blur-md`. It is now isolated on its own layer so it should rasterise once, but it is the largest single filtered surface. A pre-blurred asset would remove it outright.
- `src/platform/web.ts` drives the SAB engine pump off `requestAnimationFrame` (two loops). When the window is genuinely hidden, rAF throttles to about 1Hz, so local WASM-engine games stall on prompts and autopass. Forge and relay games go over WebSockets and are unaffected. `Atomics.waitAsync` is the fix; the wasm side already calls `Atomics.notify`.
- `AppInitGate` has no timeout and no error state. That is why a machine ended up animating for 36 hours.