### PR TITLE
fix(relay): answer the client keepalive so dead sockets are caught

### DIFF
--- a/manabrew-rs/crates/manabrew-relay-protocol/src/lib.rs
+++ b/manabrew-rs/crates/manabrew-relay-protocol/src/lib.rs
@@ -150,6 +150,8 @@ pub enum ClientMessage {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum ServerMessage {
+    Pong,
+
     AuthResult {
         success: bool,
         player_id: Option<String>,

--- a/manabrew-rs/crates/manabrew-server/src/connection.rs
+++ b/manabrew-rs/crates/manabrew-server/src/connection.rs
@@ -680,7 +680,7 @@ fn handle_client_message(
             );
         }
 
-        ClientMessage::Ping => {}
+        ClientMessage::Ping => send_msg(sender, &ServerMessage::Pong),
 
         ClientMessage::ListRooms => {
             let rooms: Vec<_> = state
@@ -1287,6 +1287,7 @@ fn get_username(state: &Arc<ServerState>, player_id: &str) -> String {
 
 fn msg_type_of(msg: &ServerMessage) -> &'static str {
     match msg {
+        ServerMessage::Pong => "Pong",
         ServerMessage::AuthResult { .. } => "AuthResult",
         ServerMessage::SessionTakenOver => "SessionTakenOver",
         ServerMessage::RoomList { .. } => "RoomList",

--- a/src/platform/web.ts
+++ b/src/platform/web.ts
@@ -683,6 +683,10 @@ interface BotEntry {
 }
 
 const RECONNECT_BACKOFF_MS = [1000, 2000, 4000, 8000, 16000, 30000];
+const KEEPALIVE_INTERVAL_MS = 4_000;
+// A half-open socket (peer reset seen only by the relay) stays writable here, so
+// silence is the only signal the connection is gone. The relay answers every Ping.
+const KEEPALIVE_SILENCE_MS = 10_000;
 
 class WebServerApi implements IServerApi {
   private ws: WebSocket | null = null;
@@ -692,6 +696,8 @@ class WebServerApi implements IServerApi {
   private bots = new Map<string, BotEntry>();
   private wasmReady: Promise<typeof import("@/wasm/wasm")> | null = null;
   private keepaliveTimer: ReturnType<typeof setInterval> | null = null;
+  private lastInboundAt = 0;
+  private lastKeepaliveTickAt = 0;
   private connectParams: ServerConnectParams | null = null;
   private connectedAt: number | null = null;
   private manualDisconnect = false;
@@ -790,6 +796,7 @@ class WebServerApi implements IServerApi {
       };
 
       this.ws.onmessage = (e: MessageEvent) => {
+        this.lastInboundAt = Date.now();
         if (typeof e.data !== "string") return;
         try {
           const msg = JSON.parse(e.data);
@@ -801,7 +808,7 @@ class WebServerApi implements IServerApi {
     });
   }
 
-  private handleSocketClose(event: CloseEvent): void {
+  private handleSocketClose(event: { code: number; reason: string; wasClean: boolean }): void {
     const connectedForS =
       this.connectedAt !== null ? Math.round((Date.now() - this.connectedAt) / 1000) : null;
     const shutdownPending = this.serverShutdownPending;
@@ -883,9 +890,33 @@ class WebServerApi implements IServerApi {
 
   private startKeepalive(): void {
     this.stopKeepalive();
+    this.lastInboundAt = Date.now();
+    this.lastKeepaliveTickAt = Date.now();
     this.keepaliveTimer = setInterval(() => {
-      if (this.ws?.readyState === WebSocket.OPEN) this.send({ type: "Ping" });
-    }, 30_000);
+      const now = Date.now();
+      const sinceTick = now - this.lastKeepaliveTickAt;
+      this.lastKeepaliveTickAt = now;
+      if (this.ws?.readyState !== WebSocket.OPEN) return;
+      // A background tab throttles timers to roughly once a minute, so a late tick
+      // says nothing about the socket. Re-baseline instead of reading it as death.
+      if (sinceTick > KEEPALIVE_INTERVAL_MS * 2) {
+        this.lastInboundAt = now;
+      } else if (now - this.lastInboundAt > KEEPALIVE_SILENCE_MS) {
+        this.failStaleSocket();
+        return;
+      }
+      this.send({ type: "Ping" });
+    }, KEEPALIVE_INTERVAL_MS);
+  }
+
+  private failStaleSocket(): void {
+    const ws = this.ws;
+    if (ws === null) return;
+    ws.onclose = null;
+    ws.onerror = null;
+    ws.onmessage = null;
+    ws.close();
+    this.handleSocketClose({ code: 4000, reason: "keepalive timeout", wasClean: false });
   }
 
   private stopKeepalive(): void {
@@ -1160,14 +1191,16 @@ class WebServerApi implements IServerApi {
       console.error("[WebServerApi] Not connected");
       return;
     }
-    logComms("send", msg);
+    if (msg.type !== "Ping") logComms("send", msg);
     this.ws.send(JSON.stringify(msg));
   }
 
   private handleServerMessage(msg: Record<string, unknown>): void {
+    const type = msg.type as string;
+    // The heartbeat would evict real traffic from the bug-report ring buffer.
+    if (type === "Pong") return;
     logComms("recv", msg);
     if (DEBUG_TRANSPORT) console.log("[transport←ws] received:", JSON.stringify(msg));
-    const type = msg.type as string;
     if (isPromptLoggingEnabled()) {
       if (type === "AuthResult") {
         console.log(


### PR DESCRIPTION
## Summary

- The relay answers `ClientMessage::Ping` with a new `ServerMessage::Pong` instead of dropping it.
- The web client pings every 4s and fails the socket after 10s of silence, going straight into the existing reconnect path.
- A throttled background tab re-baselines instead of tripping the watchdog.
- The heartbeat is kept out of the comms ring buffer that bug reports dump.

## Why

Relates to #715. Players reported opponents vanishing for long stretches mid game.

The relay logs show the cause. A middlebox on some players' path resets the connection roughly every 5 minutes, and the reset reaches only the relay. The client keeps writing into a socket that is already gone. In one 4 player Forge game the reconnect gaps were 21, 23, 39, 40, 47 and 48 seconds, with zero TCP connection attempts during the gaps. The client was not backing off, it had not noticed. Once a reconnect did start, session resume finished in 370ms.

Nothing on our side could detect this. WebSocket ping and pong frames are answered by the browser and never surface to page JS, so the app level `Ping` was the only usable signal, and the relay never replied to it.

This does not stop the resets. It cuts the time to notice one from 20 to 50 seconds down to about 12.

Additive on the wire. Only the web client sends `Ping`, so only the web client receives `Pong`, and older clients ignore unknown message types.

## Test plan

- Ping and pong round trip against a local `manabrew-server` build over a real WebSocket: `Authenticate` then `Ping` returns `Pong`.
- `WebServerApi` driven with a stub socket and fake timers:
  - 12 answered cycles keep one socket open and send exactly 12 pings.
  - Silence tears the socket down at 12s and opens a replacement.
  - A 60s clock jump delivering a single tick does not trip the watchdog, and the next cycle stays healthy.
- `yarn lint` and `yarn lint:rust` clean.
