### PR TITLE
fix(node): gate the Instant import on forge_backend

### DIFF
--- a/manabrew-rs/crates/self-hosted-node/src/engine_backend/java_backend.rs
+++ b/manabrew-rs/crates/self-hosted-node/src/engine_backend/java_backend.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 #[cfg(forge_backend)]
 use std::time::Duration;
-#[cfg(feature = "java-forge")]
+#[cfg(forge_backend)]
 use std::time::Instant;
 
 use manabrew_protocol::deck_dto::{Deck, DeckCardIdentity};


### PR DESCRIPTION
`main` does not build with `--features graal-forge`. Six `cannot find type Instant` errors in `java_backend.rs`.

The timing calls added by #691 sit in `run_hosted_engine_game_inner`, which is `cfg(forge_backend)`. The import stayed gated on `java-forge`, so the graal-only build has no `Instant` in scope.

#697 branched before #691 widened the gate. Its stale copy of the line won the merge, so both PRs were green on their own branches and `main` broke on the merge itself.

Fallout:
- `manabrew-node` image build failed on the v3.17.1 release run, so that tag shipped without a node image.
- `GraalVM node (Linux)` is red on every open PR, e.g. #722.

Checked clean locally with `graal-forge`, `java-forge`, and no features.