### PR TITLE
fix(ui): keep the last saved deck, not its snapshot

### DIFF
--- a/src/components/editor/DeckBuilder.tsx
+++ b/src/components/editor/DeckBuilder.tsx
@@ -109,7 +109,7 @@ import { useDerivedTokens, mergeDerivedAndCustomized } from "@/hooks/useDerivedT
 import {
   buildDeckSnapshot,
   setUnsavedState,
-  setLastSavedSnapshotRef,
+  setLastSavedDeckRef,
 } from "./deckBuilder.unsavedChanges";
 import { useUnsupportedCards } from "@/hooks/useUnsupportedCards";
 import { CommanderSlots } from "./CommanderSlots";
@@ -275,10 +275,9 @@ export function DeckBuilder({
   const [groupBy, setGroupBy] = useState<GroupByMode>("type");
   const [sortBy, setSortBy] = useState<SortMode>("mana-value");
   const [collectionFilter, setCollectionFilter] = useState<"all" | DeckOwnershipStatus>("all");
-  const [lastSavedSnapshot, setLastSavedSnapshot] = useState(() => {
-    const snap = buildDeckSnapshot(currentDeck);
-    setLastSavedSnapshotRef(snap);
-    return snap;
+  const [lastSavedDeck, setLastSavedDeck] = useState<EditorDeck>(() => {
+    setLastSavedDeckRef(currentDeck);
+    return currentDeck;
   });
   const [confirmClear, setConfirmClear] = useState(false);
   const filterInputRef = useRef<HTMLInputElement>(null);
@@ -428,19 +427,21 @@ export function DeckBuilder({
     ],
   );
   const currentSnapshot = useMemo(() => buildDeckSnapshot(currentDeck), [currentDeck]);
+  const lastSavedSnapshot = useMemo(() => buildDeckSnapshot(lastSavedDeck), [lastSavedDeck]);
   const accountSavedDeck = savedDecks.find((saved) => saved.id === currentDeckId);
   // Read-only presets can't be edited; background Scryfall enrichment mutates the
   // deck after the baseline snapshot, so never treat a preset as dirty.
   const hasUnsavedChanges = !isReadOnly && currentSnapshot !== lastSavedSnapshot;
 
   useEffect(() => {
-    setLastSavedSnapshotRef(lastSavedSnapshot);
+    setLastSavedDeckRef(lastSavedDeck);
     setUnsavedState(lastSavedSnapshot, isReadOnly ? lastSavedSnapshot : currentSnapshot);
-  }, [lastSavedSnapshot, currentSnapshot, isReadOnly]);
+  }, [lastSavedDeck, lastSavedSnapshot, currentSnapshot, isReadOnly]);
 
   useEffect(() => {
-    const snapshot = buildDeckSnapshot(useDeckStore.getState().currentDeck);
-    setLastSavedSnapshot(snapshot);
+    const savedDeck = useDeckStore.getState().currentDeck;
+    const snapshot = buildDeckSnapshot(savedDeck);
+    setLastSavedDeck(savedDeck);
     setSyncState("saved");
     setSaveConflict(null);
     conflictDeckRef.current = null;
@@ -1084,8 +1085,9 @@ export function DeckBuilder({
     try {
       const saved = savedDecks.find((candidate) => candidate.id === currentDeckId);
       saveCurrentDeck();
-      const snapshot = buildDeckSnapshot({ ...deckToSave, draft: undefined });
-      setLastSavedSnapshot(snapshot);
+      const savedDeck = { ...deckToSave, draft: undefined };
+      const snapshot = buildDeckSnapshot(savedDeck);
+      setLastSavedDeck(savedDeck);
       setUnsavedState(snapshot, snapshot);
       if (accountsEnabled && saved?.accountDeckId && saved.accountVersionNo) {
         const detail = await useAccountDecksStore
@@ -1170,8 +1172,9 @@ export function DeckBuilder({
           copy.deck as EditorDeck,
         );
       }
-      const snapshot = buildDeckSnapshot(useDeckStore.getState().currentDeck);
-      setLastSavedSnapshot(snapshot);
+      const savedDeck = useDeckStore.getState().currentDeck;
+      const snapshot = buildDeckSnapshot(savedDeck);
+      setLastSavedDeck(savedDeck);
       setUnsavedState(snapshot, snapshot);
       setSyncState("synced");
       setSaveConflict(null);
@@ -1189,8 +1192,9 @@ export function DeckBuilder({
 
   function handleSaveDraft() {
     saveDraft();
-    const snapshot = buildDeckSnapshot({ ...currentDeck, draft: true });
-    setLastSavedSnapshot(snapshot);
+    const savedDeck = { ...currentDeck, draft: true };
+    const snapshot = buildDeckSnapshot(savedDeck);
+    setLastSavedDeck(savedDeck);
     setUnsavedState(snapshot, snapshot);
     if (hasUnsupportedCards) {
       toast.warning(
@@ -1214,7 +1218,7 @@ export function DeckBuilder({
       clearDeck();
       resetDeckHistory();
       setConfirmClear(false);
-      const snapshot = buildDeckSnapshot({
+      const savedDeck: EditorDeck = {
         format: "standard",
         cards: [],
         sideboard: [],
@@ -1224,8 +1228,9 @@ export function DeckBuilder({
         schemes: [],
         planes: [],
         name: DEFAULT_DECK_NAME,
-      });
-      setLastSavedSnapshot(snapshot);
+      };
+      const snapshot = buildDeckSnapshot(savedDeck);
+      setLastSavedDeck(savedDeck);
       setUnsavedState(snapshot, snapshot);
       toast.success("Deck deleted");
       onDeckDeleted?.();
@@ -1819,7 +1824,7 @@ export function DeckBuilder({
             )}
 
             {!isReadOnly && (
-              <DeckChangeSummary currentDeck={currentDeck} savedSnapshot={lastSavedSnapshot} />
+              <DeckChangeSummary currentDeck={currentDeck} savedDeck={lastSavedDeck} />
             )}
 
             {isReadOnly ? (

--- a/src/components/editor/DeckChangeSummary.tsx
+++ b/src/components/editor/DeckChangeSummary.tsx
@@ -69,15 +69,14 @@ function printingKeys(deck: EditorDeck): Map<string, string> {
 
 export function DeckChangeSummary({
   currentDeck,
-  savedSnapshot,
+  savedDeck,
 }: {
   currentDeck: EditorDeck;
-  savedSnapshot: string;
+  savedDeck: EditorDeck;
 }) {
   const [open, setOpen] = useState(false);
   const quantities = useCollectionStore((state) => state.quantities);
   const changes = useMemo(() => {
-    const savedDeck = JSON.parse(savedSnapshot) as EditorDeck;
     const before = cardCounts(savedDeck);
     const after = cardCounts(currentDeck);
     const quantityChanges = [...new Set([...before.keys(), ...after.keys()])]
@@ -103,7 +102,7 @@ export function DeckChangeSummary({
       coverageDelta:
         coverageShortage(currentDeck, quantities) - coverageShortage(savedDeck, quantities),
     };
-  }, [currentDeck, quantities, savedSnapshot]);
+  }, [currentDeck, quantities, savedDeck]);
   const changeCount =
     changes.quantityChanges.length +
     changes.moves.length +

--- a/src/components/editor/deckBuilder.unsavedChanges.ts
+++ b/src/components/editor/deckBuilder.unsavedChanges.ts
@@ -4,7 +4,7 @@ import type { EditorDeck } from "@/types/manabrew";
 
 let _hasUnsavedChanges = false;
 const _listeners = new Set<() => void>();
-let _lastSavedSnapshotRef: string | null = null;
+let _lastSavedDeckRef: EditorDeck | null = null;
 
 export function setUnsavedState(snapshot: string, current: string) {
   const next = current !== snapshot;
@@ -14,8 +14,8 @@ export function setUnsavedState(snapshot: string, current: string) {
   }
 }
 
-export function setLastSavedSnapshotRef(snapshot: string | null) {
-  _lastSavedSnapshotRef = snapshot;
+export function setLastSavedDeckRef(deck: EditorDeck | null) {
+  _lastSavedDeckRef = deck;
 }
 
 export function buildDeckSnapshot(deck: EditorDeck): string {
@@ -60,11 +60,6 @@ export function useDeckUnsavedChanges(): boolean {
 }
 
 export function revertDeckToLastSaved() {
-  if (!_lastSavedSnapshotRef) return;
-  try {
-    const deck = JSON.parse(_lastSavedSnapshotRef);
-    useDeckStore.getState().loadDeck(deck);
-  } catch {
-    /* ignore parse errors */
-  }
+  if (!_lastSavedDeckRef) return;
+  useDeckStore.getState().loadDeck(_lastSavedDeckRef);
 }


### PR DESCRIPTION
## Summary

- `DeckBuilder` keeps the last saved **deck** in state and derives the snapshot from it, instead of keeping the snapshot string and reconstructing a deck out of it.
- `DeckChangeSummary` takes that deck; it no longer parses the snapshot.
- `revertDeckToLastSaved` loads the stored deck.

The snapshot format is unchanged, so the dirty-tracking fix in #722 and its test stand.

## Why

#722 slimmed `buildDeckSnapshot` so every zone serialises card identities instead of whole cards. Two consumers still read that string back as a deck of full cards:

- `DeckChangeSummary` parsed it and read `card.identity.name`, but `card` is now an identity, so `card.identity` is `undefined`. `DeckBuilder` builds the baseline snapshot as soon as a deck opens, so the editor hit its error boundary — "undefined is not an object (evaluating 'l.identity.name')" — on **every** deck with cards, on desktop and web. Shipped in 3.17.3.
- `revertDeckToLastSaved` ("Leave Without Saving") fed the parsed snapshot to `loadDeck`, which would have replaced the deck with identity-only cards and thrown in `normalizeDeck`.

## Test plan

- Reproduced on `main` in a dev build seeded with a real desktop `localStorage`: `TypeError: Cannot read properties of undefined (reading 'name')` at `DeckChangeSummary.tsx:41` in `cardCounts`.
- After the fix, on the same data: the deck opens; moving a card to the maybeboard reports "Resplendent Angel main → maybeboard" in the change summary; "Leave Without Saving" restores the deck to 100 cards with card data intact.
- `yarn lint:all`, `yarn test src/components/editor`.

## Demo

No visual change: the deck editor renders instead of "Something went wrong".
