### PR TITLE
fix(ui): support platform deck export variants

### DIFF
--- a/src/api/scryfallBatch.test.ts
+++ b/src/api/scryfallBatch.test.ts
@@ -1,0 +1,35 @@
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+import {
+  canonicalCardName,
+  matchesIdentifier,
+  normalizeIdentifierForRequest,
+} from "./scryfallBatch";
+import type { ScryfallCard } from "@/types/scryfall";
+
+vi.hoisted(() => vi.stubGlobal("__APP_VERSION__", "test"));
+
+afterAll(() => vi.unstubAllGlobals());
+
+const boggartTrawler = {
+  name: "Boggart Trawler // Boggart Bog",
+  set: "mh3",
+  collector_number: "243",
+  card_faces: [{ name: "Boggart Trawler" }, { name: "Boggart Bog" }],
+} as ScryfallCard;
+
+describe("Scryfall card identifiers", () => {
+  it("canonicalizes the single and double slash forms used by deck platforms", () => {
+    expect(canonicalCardName("Boggart Trawler / Boggart Bog")).toBe(
+      "boggart trawler // boggart bog",
+    );
+    expect(matchesIdentifier(boggartTrawler, { name: "Boggart Trawler / Boggart Bog" })).toBe(true);
+    expect(matchesIdentifier(boggartTrawler, { name: "Boggart Trawler" })).toBe(true);
+  });
+
+  it("sends only the front face for collection name lookups", () => {
+    expect(normalizeIdentifierForRequest({ name: "Boggart Trawler / Boggart Bog" })).toEqual({
+      name: "Boggart Trawler",
+    });
+  });
+});

--- a/src/api/scryfallBatch.ts
+++ b/src/api/scryfallBatch.ts
@@ -48,22 +48,31 @@ export function matchesIdentifier(card: ScryfallCard, id: CardIdentifier): boole
       card.collector_number?.toLowerCase() === id.collector_number.toLowerCase()
     );
   }
-  const expectedName = id.name.toLowerCase();
-  const cardName = card.name.toLowerCase();
-  const faceMatches = card.card_faces?.some((face) => face.name.toLowerCase() === expectedName);
-  const splitNameMatches = cardName
-    .split(/\s+\/\/\s+/)
-    .some((part) => part.toLowerCase() === expectedName);
+  const expectedName = canonicalCardName(id.name);
+  const cardName = canonicalCardName(card.name);
+  const faceMatches = card.card_faces?.some(
+    (face) => canonicalCardName(face.name) === expectedName,
+  );
+  const splitNameMatches = cardName.split(" // ").some((part) => part === expectedName);
   if (cardName !== expectedName && !faceMatches && !splitNameMatches) return false;
   return id.set ? card.set?.toLowerCase() === id.set.toLowerCase() : true;
+}
+
+export function canonicalCardName(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .split(/\s*\/{1,2}\s*/)
+    .map((part) => part.trim())
+    .join(" // ");
 }
 
 // Scryfall's /cards/collection matches `name` against a single face — the
 // full DFC display name returns not_found. Strip the back-face half before
 // sending; matchesIdentifier still accepts the full name on the way back.
 export function normalizeIdentifierForRequest(id: CardIdentifier): CardIdentifier {
-  if ("name" in id && id.name.includes("//")) {
-    const front = id.name.split(/\s*\/\/\s*/)[0]?.trim();
+  if ("name" in id && /\/{1,2}/.test(id.name)) {
+    const front = id.name.split(/\s*\/{1,2}\s*/)[0]?.trim();
     if (front) return { ...id, name: front };
   }
   return id;

--- a/src/components/editor/ImportDeckTextDialog.tsx
+++ b/src/components/editor/ImportDeckTextDialog.tsx
@@ -14,7 +14,12 @@ import { Input } from "@/components/ui/input";
 import { DEFAULT_IMPORT_NAME } from "@/lib/constants";
 import { GAME_FORMATS } from "@/lib/formats";
 import { cn } from "@/lib/utils";
-import { parseDeckListText, type ParsedDeckEntry } from "@/lib/deckImport";
+import {
+  isDetectedCommander,
+  parseDeckListText,
+  suggestedDeckName,
+  type ParsedDeckEntry,
+} from "@/lib/deckImport";
 import type { DeckFormat } from "@/protocol/deck";
 
 interface ImportDeckTextDialogProps {
@@ -44,7 +49,7 @@ export function ImportDeckTextDialog({
   mode = "create",
 }: ImportDeckTextDialogProps) {
   const [text, setText] = useState("");
-  const [name, setName] = useState("");
+  const [customName, setCustomName] = useState<string | null>(null);
   const [formatId, setFormatId] = useState<DeckFormat | "">("");
   const [importing, setImporting] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -54,7 +59,7 @@ export function ImportDeckTextDialog({
   useEffect(() => {
     if (open) return;
     setText("");
-    setName("");
+    setCustomName(null);
     setFormatId("");
     setImporting(false);
     setProgress(0);
@@ -63,13 +68,20 @@ export function ImportDeckTextDialog({
   /* eslint-enable react-hooks/set-state-in-effect */
 
   const entries = useMemo(() => parseDeckListText(text), [text]);
+  const name = customName ?? suggestedDeckName(entries);
   const mainCount = entries.reduce(
-    (s, e) => (e.side || e.maybe || e.commander ? s : s + e.count),
+    (s, e) => (e.side || e.maybe || isDetectedCommander(e) ? s : s + e.count),
     0,
   );
-  const sideCount = entries.reduce((s, e) => (e.side && !e.commander ? s + e.count : s), 0);
-  const maybeCount = entries.reduce((s, e) => (e.maybe && !e.commander ? s + e.count : s), 0);
-  const commanderCount = entries.reduce((s, e) => (e.commander ? s + e.count : s), 0);
+  const sideCount = entries.reduce(
+    (s, e) => (e.side && !isDetectedCommander(e) ? s + e.count : s),
+    0,
+  );
+  const maybeCount = entries.reduce(
+    (s, e) => (e.maybe && !isDetectedCommander(e) ? s + e.count : s),
+    0,
+  );
+  const commanderCount = entries.reduce((s, e) => (isDetectedCommander(e) ? s + e.count : s), 0);
   const valid = entries.length > 0;
   const dirty = text.trim().length > 0;
   const unrecognizedLines = useMemo(() => {
@@ -173,7 +185,7 @@ export function ImportDeckTextDialog({
                         <td className="px-3 py-2 font-mono">{entry.count}</td>
                         <td className="px-3 py-2 font-medium">{entry.name}</td>
                         <td className="px-3 py-2 text-muted-foreground">
-                          {entry.commander
+                          {isDetectedCommander(entry)
                             ? "Command zone"
                             : entry.side
                               ? "Sideboard"
@@ -237,7 +249,7 @@ export function ImportDeckTextDialog({
                     <label className="text-xs font-medium">Deck name</label>
                     <Input
                       value={name}
-                      onChange={(e) => setName(e.target.value)}
+                      onChange={(e) => setCustomName(e.target.value)}
                       placeholder={DEFAULT_IMPORT_NAME}
                     />
                   </div>

--- a/src/components/editor/useDeckTextImport.test.ts
+++ b/src/components/editor/useDeckTextImport.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ScryfallCard } from "@/types/scryfall";
 
 const { fetchCardCollection, fetchCardByFuzzyName } = vi.hoisted(() => ({
   fetchCardCollection: vi.fn(),
@@ -8,10 +9,12 @@ const { fetchCardCollection, fetchCardByFuzzyName } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/api/scryfall", () => ({
+  getScryfallManaCost: (card: ScryfallCard) => card.mana_cost,
   scryfallCardKey: (name: string, setCode?: string, collectorNumber?: string) =>
     [name, setCode, collectorNumber].filter(Boolean).join("::").toLowerCase(),
 }));
 vi.mock("@/stores/useScryfallStore", () => ({
+  chooseImageUrisForCard: (card: ScryfallCard) => card.image_uris,
   useScryfallStore: {
     getState: () => ({ fetchCardCollection, fetchCardByFuzzyName }),
   },
@@ -38,27 +41,28 @@ describe("deck text import printing resolution", () => {
     fetchCardByFuzzyName.mockReset();
   });
 
-  it("does not substitute a name-only result for an exact printing", async () => {
-    fetchCardCollection.mockResolvedValue(
-      new Map([["lightning bolt", { name: "Lightning Bolt" }]]),
+  it("substitutes a name-only result when an exact printing is unavailable", async () => {
+    fetchCardCollection
+      .mockResolvedValueOnce(new Map())
+      .mockResolvedValueOnce(new Map([["lightning bolt", scryfallCard("Lightning Bolt")]]));
+
+    const result = await resolveDeckTextImport(
+      [
+        {
+          name: "Lightning Bolt",
+          count: 1,
+          side: false,
+          maybe: false,
+          commander: false,
+          setCode: "lea",
+          collectorNumber: "161",
+        },
+      ],
+      () => undefined,
     );
 
-    await expect(
-      resolveDeckTextImport(
-        [
-          {
-            name: "Lightning Bolt",
-            count: 1,
-            side: false,
-            maybe: false,
-            commander: false,
-            setCode: "lea",
-            collectorNumber: "161",
-          },
-        ],
-        () => undefined,
-      ),
-    ).rejects.toThrow("None of the cards could be found");
+    expect(result.cards).toHaveLength(1);
+    expect(result.substitutedPrintings).toEqual(["Lightning Bolt"]);
     expect(fetchCardByFuzzyName).not.toHaveBeenCalled();
   });
 
@@ -83,4 +87,95 @@ describe("deck text import printing resolution", () => {
     ).rejects.toThrow("None of the cards could be found");
     expect(fetchCardByFuzzyName).not.toHaveBeenCalled();
   });
+
+  it("moves a legal first-card candidate into the command zone", async () => {
+    const valgavoth = scryfallCard(
+      "Valgavoth, Harrower of Souls",
+      "Legendary Creature — Elder Demon",
+    );
+    fetchCardCollection.mockResolvedValue(new Map([["valgavoth, harrower of souls", valgavoth]]));
+
+    const result = await resolveDeckTextImport(
+      [
+        {
+          name: "Valgavoth, Harrower of Souls",
+          count: 1,
+          side: false,
+          maybe: false,
+          commander: false,
+          commanderCandidate: true,
+        },
+      ],
+      () => undefined,
+    );
+
+    expect(result.commanders.map((card) => card.identity.name)).toEqual([
+      "Valgavoth, Harrower of Souls",
+    ]);
+    expect(result.cards).toHaveLength(0);
+  });
 });
+
+function scryfallCard(name: string, typeLine = "Instant"): ScryfallCard {
+  return {
+    id: name,
+    oracle_id: name,
+    lang: "en",
+    released_at: "2026-01-01",
+    uri: "uri",
+    scryfall_uri: "scryfall-uri",
+    name,
+    highres_image: true,
+    image_status: "highres_scan",
+    set: "tst",
+    set_id: "test-set",
+    set_name: "Test Set",
+    set_type: "expansion",
+    set_uri: "set-uri",
+    set_search_uri: "set-search-uri",
+    scryfall_set_uri: "scryfall-set-uri",
+    rulings_uri: "rulings-uri",
+    prints_search_uri: "prints-search-uri",
+    collector_number: "1",
+    type_line: typeLine,
+    oracle_text: "",
+    image_uris: {
+      small: "small",
+      normal: "normal",
+      large: "large",
+      png: "png",
+      art_crop: "art",
+      border_crop: "border",
+    },
+    colors: [],
+    color_identity: [],
+    keywords: [],
+    legalities: {},
+    games: [],
+    cmc: 1,
+    layout: "normal",
+    reserved: false,
+    foil: false,
+    nonfoil: true,
+    finishes: ["nonfoil"],
+    oversized: false,
+    promo: false,
+    reprint: false,
+    variation: false,
+    digital: false,
+    rarity: "common",
+    card_back_id: "card-back",
+    artist: "Test Artist",
+    artist_ids: [],
+    illustration_id: "illustration",
+    border_color: "black",
+    frame: "2015",
+    full_art: false,
+    textless: false,
+    booster: true,
+    story_spotlight: false,
+    prices: {},
+    related_uris: {},
+    purchase_uris: {},
+  };
+}

--- a/src/components/editor/useDeckTextImport.ts
+++ b/src/components/editor/useDeckTextImport.ts
@@ -4,7 +4,7 @@ import { scryfallCardKey } from "@/api/scryfall";
 import { DEFAULT_IMPORT_NAME } from "@/lib/constants";
 import { inferImportedFormat, type ParsedDeckEntry } from "@/lib/deckImport";
 import { resolveDeckName } from "@/lib/deckName";
-import { getFormat } from "@/lib/formats";
+import { getFormat, isCommanderEligible } from "@/lib/formats";
 import { useScryfallStore } from "@/stores/useScryfallStore";
 import { scryfallToDeckCard } from "@/lib/scryfall.utils";
 import { useDeckStore } from "@/stores/useDeckStore";
@@ -18,6 +18,7 @@ export interface ResolvedDeckTextImport {
   maybeboard: DeckCard[];
   commanders: DeckCard[];
   notFound: string[];
+  substitutedPrintings: string[];
 }
 
 export async function resolveDeckTextImport(
@@ -32,9 +33,24 @@ export async function resolveDeckTextImport(
       collectorNumber: e.collectorNumber,
     })),
   );
+  const exactPrintingMisses = entries.filter(
+    (entry) =>
+      entry.setCode &&
+      entry.collectorNumber &&
+      !scryfallMap.has(scryfallCardKey(entry.name, entry.setCode, entry.collectorNumber)),
+  );
+  if (exactPrintingMisses.length > 0) {
+    const fallbacks = await useScryfallStore
+      .getState()
+      .fetchCardCollection(exactPrintingMisses.map((entry) => ({ name: entry.name })));
+    for (const [key, card] of fallbacks) scryfallMap.set(key, card);
+  }
   const lookup = (entry: ParsedDeckEntry) => {
     if (entry.setCode && entry.collectorNumber) {
-      return scryfallMap.get(scryfallCardKey(entry.name, entry.setCode, entry.collectorNumber));
+      return (
+        scryfallMap.get(scryfallCardKey(entry.name, entry.setCode, entry.collectorNumber)) ??
+        scryfallMap.get(scryfallCardKey(entry.name))
+      );
     }
     return (
       scryfallMap.get(scryfallCardKey(entry.name, entry.setCode)) ??
@@ -70,6 +86,7 @@ export async function resolveDeckTextImport(
   const maybeboard: DeckCard[] = [];
   const commanders: DeckCard[] = [];
   const notFound: string[] = [];
+  const substitutedPrintings: string[] = [];
   for (const entry of entries) {
     const { count, side, maybe, commander } = entry;
     const sc = lookup(entry);
@@ -77,9 +94,16 @@ export async function resolveDeckTextImport(
       notFound.push(entry.name);
       continue;
     }
-    const target = commander ? commanders : side ? sideboard : maybe ? maybeboard : cards;
+    const exactPrintingFound =
+      !entry.setCode ||
+      !entry.collectorNumber ||
+      scryfallMap.has(scryfallCardKey(entry.name, entry.setCode, entry.collectorNumber));
+    if (!exactPrintingFound) substitutedPrintings.push(entry.name);
+    const base = scryfallToDeckCard(sc);
+    const inferredCommander = entry.commanderCandidate && isCommanderEligible(base);
+    const target =
+      commander || inferredCommander ? commanders : side ? sideboard : maybe ? maybeboard : cards;
     for (let i = 0; i < count; i++) {
-      const base = scryfallToDeckCard(sc);
       target.push({
         ...base,
         identity: { ...base.identity, id: crypto.randomUUID(), foil: entry.foil },
@@ -94,7 +118,7 @@ export async function resolveDeckTextImport(
   ) {
     throw new Error("None of the cards could be found on Scryfall");
   }
-  return { cards, sideboard, maybeboard, commanders, notFound };
+  return { cards, sideboard, maybeboard, commanders, notFound, substitutedPrintings };
 }
 
 export function useDeckTextImport() {
@@ -106,10 +130,8 @@ export function useDeckTextImport() {
       onProgress: (fraction: number) => void,
     ): Promise<string> => {
       const customName = name.trim();
-      const { cards, sideboard, maybeboard, commanders, notFound } = await resolveDeckTextImport(
-        entries,
-        onProgress,
-      );
+      const { cards, sideboard, maybeboard, commanders, notFound, substitutedPrintings } =
+        await resolveDeckTextImport(entries, onProgress);
       const deckName = resolveDeckName(customName || DEFAULT_IMPORT_NAME, commanders);
       const importedFormat =
         formatId ??
@@ -140,6 +162,10 @@ export function useDeckTextImport() {
         const shown = notFound.slice(0, 3).join(", ");
         const extra = notFound.length > 3 ? ` +${notFound.length - 3} more` : "";
         toast.warning(`Imported "${deckName}" — couldn't find: ${shown}${extra}`);
+      } else if (substitutedPrintings.length > 0) {
+        toast.warning(
+          `Imported "${deckName}" with ${substitutedPrintings.length} default printing ${substitutedPrintings.length === 1 ? "substitution" : "substitutions"}`,
+        );
       } else {
         toast.success(`Imported "${deckName}"`);
       }
@@ -175,6 +201,10 @@ export function useDeckTextImportIntoCurrent() {
         const shown = result.notFound.slice(0, 3).join(", ");
         const extra = result.notFound.length > 3 ? ` +${result.notFound.length - 3} more` : "";
         toast.warning(`Added ${count} cards — couldn't find: ${shown}${extra}`);
+      } else if (result.substitutedPrintings.length > 0) {
+        toast.warning(
+          `Added ${count} cards with ${result.substitutedPrintings.length} default printing ${result.substitutedPrintings.length === 1 ? "substitution" : "substitutions"}`,
+        );
       } else {
         toast.success(`Added ${count} cards to this deck`);
       }

--- a/src/lib/deckImport.test.ts
+++ b/src/lib/deckImport.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, it, vi } from "vitest";
 
-import { mergeDeckImportIntoDeck, parseDeckListText } from "./deckImport";
+import { mergeDeckImportIntoDeck, parseDeckListText, suggestedDeckName } from "./deckImport";
 import type { DeckCard } from "@/protocol/deck";
 
 vi.hoisted(() => vi.stubGlobal("__APP_VERSION__", "test"));
@@ -69,6 +69,111 @@ Maybeboard
     expect(entries[0]).toEqual(
       expect.objectContaining({ name: "Atraxa, Praetors' Voice", commander: true }),
     );
+    expect(suggestedDeckName(entries)).toBe("Atraxa, Praetors' Voice");
+  });
+
+  it("recognizes the commander in the printing export from Moxfield deck 5Ou3mB9KDEmU-kIAbQHznA", () => {
+    const main = [
+      "1 Boggart Trawler / Boggart Bog (MH3) 243",
+      "1 Malakir Rebirth / Malakir Mire (ZNR) 111",
+      ...Array.from({ length: 74 }, (_, index) => `1 Main Card ${index + 1} (TST) ${index + 1}`),
+      "13 Mountain (DSK) 283",
+      "10 Swamp (DSK) 282",
+    ].join("\n");
+    const entries = parseDeckListText(`1 Valgavoth, Harrower of Souls (DSC) 6 *F*\n${main}`);
+
+    expect(entries.reduce((sum, entry) => sum + entry.count, 0)).toBe(100);
+    expect(entries[0]).toEqual(
+      expect.objectContaining({
+        name: "Valgavoth, Harrower of Souls",
+        commander: false,
+        commanderCandidate: true,
+        foil: true,
+      }),
+    );
+    expect(suggestedDeckName(entries)).toBe("Valgavoth, Harrower of Souls");
+    expect(entries.slice(1, 3).map((entry) => entry.name)).toEqual([
+      "Boggart Trawler / Boggart Bog",
+      "Malakir Rebirth / Malakir Mire",
+    ]);
+  });
+
+  it("recognizes Archidekt categories from public deck 14863038", () => {
+    const entries = parseDeckListText(`1x Ulalek, Fused Atrocity (M3C) 4 [Commander]
+1x Eldrazi Displacer (OGW) 13 [Mainboard]
+1x Path of Annihilation (M3C) 8 [Ramp]
+1x Ulamog, the Ceaseless Hunger (BFZ) 15 [Maybeboard]`);
+
+    expect(entries).toEqual([
+      expect.objectContaining({ name: "Ulalek, Fused Atrocity", commander: true }),
+      expect.objectContaining({ name: "Eldrazi Displacer", commander: false, maybe: false }),
+      expect.objectContaining({ name: "Path of Annihilation", commander: false }),
+      expect.objectContaining({ name: "Ulamog, the Ceaseless Hunger", maybe: true }),
+    ]);
+  });
+
+  it("parses Archidekt category modifiers and collector number variants", () => {
+    const entries = parseDeckListText(`Commander
+1x Witherbloom, the Balancer (psos) 245p [Commander{top}]
+
+Mainboard
+1x Boreal Druid (csp) 105 *F* [Creature] ^Buy,#0066ff^
+1x Studious First-Year // Rampant Growth (sos) 162 [Creature]
+1x Ambition's Cost (plst) C15-113 [Draw]
+1x Skullclamp (td0) A120 [Draw]
+1x Fyndhorn Elves (wc97) sg244 [Ramp]
+1x Rude Awakening (wc04) jn92sb [Ramp]
+6x Forest (dft) 291 [Land]
+
+Maybeboard
+1x Boseiju, Who Endures (neo) 266 *F* [Maybeboard{noDeck}{noPrice},Land]
+
+Sideboard
+1x Arasta of the Endless Web (thb) 165 [Sideboard{noPrice}]`);
+
+    expect(entries.reduce((sum, entry) => sum + entry.count, 0)).toBe(15);
+    expect(entries[0]).toEqual(
+      expect.objectContaining({
+        name: "Witherbloom, the Balancer",
+        commander: true,
+        setCode: "psos",
+        collectorNumber: "245p",
+      }),
+    );
+    expect(entries[1]).toEqual(
+      expect.objectContaining({ name: "Boreal Druid", foil: true, commander: false }),
+    );
+    expect(entries[2].name).toBe("Studious First-Year // Rampant Growth");
+    expect(entries.slice(3, 7).map((entry) => entry.collectorNumber)).toEqual([
+      "C15-113",
+      "A120",
+      "sg244",
+      "jn92sb",
+    ]);
+    expect(entries[7]).toEqual(expect.objectContaining({ name: "Forest", count: 6 }));
+    expect(entries[8]).toEqual(
+      expect.objectContaining({ name: "Boseiju, Who Endures", maybe: true, foil: true }),
+    );
+    expect(entries[9]).toEqual(
+      expect.objectContaining({ name: "Arasta of the Endless Web", side: true }),
+    );
+  });
+
+  it("recognizes the headed export documented by Archidekt", () => {
+    const entries = parseDeckListText(`Commander
+1 Teval, the Balanced Scale (TDC) 8
+
+Deck
+1 Agadeem's Awakening / Agadeem, the Undercrypt (ZNR) 90
+1 Fell the Profane / Fell Mire (MH3) 244`);
+
+    expect(entries[0]).toEqual(
+      expect.objectContaining({ name: "Teval, the Balanced Scale", commander: true }),
+    );
+    expect(entries.slice(1).map((entry) => entry.name)).toEqual([
+      "Agadeem's Awakening / Agadeem, the Undercrypt",
+      "Fell the Profane / Fell Mire",
+    ]);
   });
 
   it("prefers a trailing commander block when both ends are singletons", () => {

--- a/src/lib/deckImport.ts
+++ b/src/lib/deckImport.ts
@@ -45,9 +45,21 @@ export interface ParsedDeckEntry {
   side: boolean;
   maybe: boolean;
   commander: boolean;
+  commanderCandidate?: boolean;
   setCode?: string;
   collectorNumber?: string;
   foil?: boolean;
+}
+
+export function isDetectedCommander(entry: ParsedDeckEntry): boolean {
+  return entry.commander || entry.commanderCandidate === true;
+}
+
+export function suggestedDeckName(entries: ParsedDeckEntry[]): string {
+  return entries
+    .filter(isDetectedCommander)
+    .map((entry) => entry.name)
+    .join(" / ");
 }
 
 const SIDEBOARD_LINE_REGEX = /^(sideboard|side)\s*:?$/i;
@@ -148,7 +160,12 @@ function markHeaderlessCommanderBlock(
 ): void {
   if (sawHeader || entries.some((e) => e.commander || e.side || e.maybe)) return;
   const lastBlock = blockOf.at(-1);
-  if (lastBlock === undefined || lastBlock === 0) return;
+  if (lastBlock === undefined) return;
+  if (lastBlock === 0) {
+    const total = entries.reduce((sum, entry) => sum + entry.count, 0);
+    if (total === 100 && entries[0]?.count === 1) entries[0].commanderCandidate = true;
+    return;
+  }
   for (const candidateBlock of [lastBlock, 0]) {
     const candidate = entries.filter((_, index) => blockOf[index] === candidateBlock);
     const mainCount = entries.reduce(


### PR DESCRIPTION
## Summary

- normalize single-slash and double-slash card names during Scryfall matching
- preserve complete imports by substituting unavailable exact printings and reporting the substitution
- detect commander-first exports and prefill the importer deck name
- cover Moxfield and Archidekt export variants with regression tests

## Why

Printing-aware Moxfield exports could drop modal double-faced cards because their names use a different slash form from Scryfall. Headerless exports could also place the commander in the main deck. Archidekt exports add categories, category modifiers, labels, foil markers, and alphanumeric collector numbers that must survive parsing.

## Test plan

- yarn vitest run src/api/scryfallBatch.test.ts src/lib/deckImport.test.ts src/components/editor/useDeckTextImport.test.ts
- yarn lint:all
- git diff --check

## Demo

Before: the Valgavoth printing export omitted two modal double-faced cards, placed Valgavoth in the main deck, and left the deck-name field blank.

After: the importer retains all cards, shows Valgavoth in the command zone during review, and prefills the deck name with Valgavoth, Harrower of Souls.