### PR TITLE
fix(node): release the forge AiCache game-scoping fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6371,7 +6371,7 @@ dependencies = [
 
 [[package]]
 name = "self-hosted-node"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "forge-carddb",
  "forge-foundation",

--- a/manabrew-rs/crates/self-hosted-node/Cargo.toml
+++ b/manabrew-rs/crates/self-hosted-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "self-hosted-node"
-version = "0.18.3"
+version = "0.18.4"
 edition = "2021"
 license.workspace = true
 description = "Headless manabrew engine node for hosting AI games"

--- a/ops/manifest.json
+++ b/ops/manifest.json
@@ -19,7 +19,7 @@
     "manabrew_game_runtime": "0.3.24",
     "parity": "0.4.1",
     "parity-debugger": "0.2.16",
-    "self-hosted-node": "0.18.3",
+    "self-hosted-node": "0.18.4",
     "tree-sitter-forge-card-script": "0.2.0",
     "wasm": "0.6.5"
   }


### PR DESCRIPTION
#737 bumped the forge submodule to the `AiCache` game-scoping fix, but it landed as `chore(forge):`, which is level `none`. The release run on main printed `nothing to release`, so the fix is on main and nowhere else.

Hand-bump `self-hosted-node` to 0.18.4. The app cascades as a dependent, so the release plan is:

- `manabrew` 3.18.4 -> 3.18.5 (dependency self-hosted-node released)
- `self-hosted-node` 0.18.4 (hand-bumped in Cargo.toml)

That produces the `v3.18.5` tag the node image build and the prod deploy hang off.

Follow-up worth doing separately: a forge gitlink change should never be a `chore`. Either the type is wrong at PR-title time or the plan should force a patch when `forge` moves.
