### PR TITLE
fix(ui): preserve dragged battlefield placement

### DIFF
--- a/src/hooks/useHandDrag.ts
+++ b/src/hooks/useHandDrag.ts
@@ -14,6 +14,7 @@ interface UseHandDragOptions {
   battlefieldContainerRef: React.RefObject<HTMLDivElement | null>;
   handDropExclusionPx?: number;
   onCastSpell: (cardId: string) => void;
+  onBattlefieldDrop?: (card: CardDto, position: { clientX: number; clientY: number }) => void;
   dismissHover: () => void;
   onLongPress?: (card: CardDto, pos: { x: number; y: number }) => void;
 }
@@ -22,6 +23,7 @@ export function useHandDrag({
   battlefieldContainerRef,
   handDropExclusionPx = 0,
   onCastSpell,
+  onBattlefieldDrop,
   dismissHover,
   onLongPress,
 }: UseHandDragOptions) {
@@ -106,7 +108,12 @@ export function useHandDrag({
     const handlePointerUp = (pe: PointerEvent) => {
       if (pe.pointerId !== start.pointerId) return;
       teardown();
-      if (!moved || isOverBattlefieldRef.current) onCastSpell(card.id);
+      if (!moved || isOverBattlefieldRef.current) {
+        if (moved && isOverBattlefieldRef.current) {
+          onBattlefieldDrop?.(card, { clientX: pe.clientX, clientY: pe.clientY });
+        }
+        onCastSpell(card.id);
+      }
       reset();
     };
 

--- a/src/pixi/board/BoardRegion.ts
+++ b/src/pixi/board/BoardRegion.ts
@@ -158,7 +158,7 @@ export class BoardRegion {
   private combatRowAvatars: { sprite: Sprite; mask: Graphics; url: string | null }[] = [];
   private effectiveChildrenMap = new Map<string, string[]>();
   private lastState: BattlefieldState | null = null;
-  private pendingDropSlot: { col: number; row: number } | null = null;
+  private pendingDrop: { cardId: string; slot: { col: number; row: number } } | null = null;
   private lastDropCell: { col: number; row: number } | null = null;
   private hoveredCardId: string | null = null;
   private dropActive = false;
@@ -460,14 +460,21 @@ export class BoardRegion {
   setDropActive(active: boolean): void {
     if (this.dropActive === active) return;
     this.dropActive = active;
-    if (active) {
-      this.lastDropCell = null;
-    } else {
-      this.pendingDropSlot = this.lastDropCell;
-      this.lastDropCell = null;
-      this.hideGridSkeleton();
-    }
+    this.lastDropCell = null;
+    if (!active) this.hideGridSkeleton();
     this.drawBackground();
+  }
+
+  commitPendingDrop(cardId: string): boolean {
+    if (!this.lastDropCell) return false;
+    this.pendingDrop = { cardId, slot: this.lastDropCell };
+    return true;
+  }
+
+  clearPendingDrop(cardId: string): void {
+    if (this.pendingDrop?.cardId !== cardId) return;
+    this.pendingDrop = null;
+    if (this.lastState) this.updateBattlefield(this.lastState);
   }
 
   setAutoSort(value: boolean): void {
@@ -493,10 +500,6 @@ export class BoardRegion {
   private isDeclaredBlocker(cardId: string): boolean {
     if (this.combatStaging?.blockerIds.has(cardId)) return true;
     return this.combatRowBlocks.some((b) => b.blockerId === cardId);
-  }
-
-  setPendingDropSlot(slot: { col: number; row: number } | null): void {
-    this.pendingDropSlot = slot;
   }
 
   getGridInfo(): GridLayoutInfo | null {
@@ -751,6 +754,9 @@ export class BoardRegion {
       if (!effectiveParent.has(childId)) {
         effectiveParent.set(childId, parentId);
       }
+    }
+    if (this.pendingDrop && effectiveParent.has(this.pendingDrop.cardId)) {
+      this.pendingDrop = null;
     }
 
     const effectiveChildren = new Map<string, string[]>();
@@ -1099,7 +1105,8 @@ export class BoardRegion {
       !c.isFaceDown &&
       !c.isTransformed &&
       (!c.attachmentIds || c.attachmentIds.length === 0) &&
-      !this.userPlacedCards.has(c.id);
+      !this.userPlacedCards.has(c.id) &&
+      c.id !== this.pendingDrop?.cardId;
 
     const byIdentity = new Map<string, CardDto[]>();
     for (const c of topLevel) {
@@ -1140,6 +1147,9 @@ export class BoardRegion {
 
     const prioritized = topLevelCandidates.map((card, i) => ({ card, i }));
     prioritized.sort((a, b) => {
+      const aPending = a.card.id === this.pendingDrop?.cardId ? 0 : 1;
+      const bPending = b.card.id === this.pendingDrop?.cardId ? 0 : 1;
+      if (aPending !== bPending) return aPending - bPending;
       const aHas = this.userSlots.has(a.card.id) ? 1 : 0;
       const bHas = this.userSlots.has(b.card.id) ? 1 : 0;
       if (aHas !== bHas) return aHas - bHas;
@@ -1224,17 +1234,26 @@ export class BoardRegion {
       occupied.add(cellKey(cell.col, cell.row));
     }
 
-    if (this.pendingDropSlot && unplaced.length > 0) {
-      const dropCell = cellAt(grid, this.pendingDropSlot.col, this.pendingDropSlot.row);
-      if (dropCell && !dropCell.blocked && !occupied.has(cellKey(dropCell.col, dropCell.row))) {
-        const dropCandidate = unplaced[0]!;
-        this.userSlots.set(dropCandidate.id, this.pendingDropSlot);
-        this.userPlacedCards.add(dropCandidate.id);
-        positions.set(dropCandidate.id, { x: dropCell.cx, y: dropCell.cy });
-        occupied.add(cellKey(dropCell.col, dropCell.row));
-        unplaced.shift();
+    if (this.pendingDrop) {
+      const { cardId, slot } = this.pendingDrop;
+      const dropCell = cellAt(grid, slot.col, slot.row);
+      const dropCandidateIndex = unplaced.findIndex((card) => card.id === cardId);
+      if (dropCell && !dropCell.blocked) {
+        const dropCellKey = cellKey(dropCell.col, dropCell.row);
+        if (!occupied.has(dropCellKey)) {
+          if (dropCandidateIndex >= 0) {
+            const dropCandidate = unplaced[dropCandidateIndex]!;
+            this.userSlots.set(dropCandidate.id, slot);
+            this.userPlacedCards.add(dropCandidate.id);
+            positions.set(dropCandidate.id, { x: dropCell.cx, y: dropCell.cy });
+            unplaced.splice(dropCandidateIndex, 1);
+          }
+          occupied.add(dropCellKey);
+        }
       }
-      this.pendingDropSlot = null;
+      if (dropCandidateIndex >= 0) {
+        this.pendingDrop = null;
+      }
     }
 
     const centerX = zone.x + zone.width / 2;
@@ -1365,8 +1384,8 @@ export class BoardRegion {
       if (cell) occupied.add(cellKey(cell.col, cell.row));
     }
 
-    if (this.pendingDropSlot) {
-      const dropCell = cellAt(grid, this.pendingDropSlot.col, this.pendingDropSlot.row);
+    if (this.pendingDrop) {
+      const dropCell = cellAt(grid, this.pendingDrop.slot.col, this.pendingDrop.slot.row);
       if (dropCell && !dropCell.blocked && !occupied.has(cellKey(dropCell.col, dropCell.row))) {
         return { x: dropCell.x, y: dropCell.y };
       }

--- a/src/pixi/board/BoardScene.ts
+++ b/src/pixi/board/BoardScene.ts
@@ -1243,6 +1243,18 @@ export class BoardScene {
     this.hand?.setDropActive(active);
   }
 
+  commitPendingDrop(cardId: string, clientX: number, clientY: number): boolean {
+    const region = this.localRegion();
+    if (!region) return false;
+    const canvasRect = this.app.canvas.getBoundingClientRect();
+    region.drawDropGrid(clientX - canvasRect.left, clientY - canvasRect.top);
+    return region.commitPendingDrop(cardId);
+  }
+
+  clearPendingDrop(cardId: string): void {
+    this.localRegion()?.clearPendingDrop(cardId);
+  }
+
   setAutoSort(value: boolean): void {
     this.autoSort = value;
     for (const rec of this.regions.values()) rec.region.setAutoSort(value);
@@ -1250,10 +1262,6 @@ export class BoardScene {
 
   previewEtb(): void {
     for (const rec of this.regions.values()) rec.region.previewEtb();
-  }
-
-  setPendingDropSlot(slot: { col: number; row: number } | null): void {
-    this.localRegion()?.setPendingDropSlot(slot);
   }
 
   setCardStyle(style: BattlefieldCardStyle): void {

--- a/src/views/Game.tsx
+++ b/src/views/Game.tsx
@@ -211,6 +211,7 @@ export default function Game({ exitTo }: GameProps = {}) {
     (location.state as { devExtraOpponents?: number } | null)?.devExtraOpponents ?? 0;
   const containerRef = useRef<HTMLDivElement>(null);
   const boardSceneRef = useRef<BoardScene | null>(null);
+  const placementIntentRef = useRef<{ cardId: string; castStarted: boolean } | null>(null);
   const [boardLayout, setBoardLayout] = useState<BoardCanvasLayout | null>(null);
   const [handCardLifted, setHandCardLifted] = useState(false);
   const [boardMenuOpen, setBoardMenuOpen] = useState(false);
@@ -924,6 +925,14 @@ export default function Game({ exitTo }: GameProps = {}) {
     battlefieldContainerRef,
     handDropExclusionPx: Math.round(HAND_CARD_BASE.containerH * vScale * 0.35),
     onCastSpell: handleCastSpell,
+    onBattlefieldDrop: (card, position) => {
+      if (
+        isPermanentSpellCard(card) &&
+        boardSceneRef.current?.commitPendingDrop(card.id, position.clientX, position.clientY)
+      ) {
+        placementIntentRef.current = { cardId: card.id, castStarted: false };
+      }
+    },
     dismissHover: preview.dismiss,
     onLongPress: (card, pos) => preview.showSticky(card, pos.x, pos.y),
   });
@@ -1009,6 +1018,24 @@ export default function Game({ exitTo }: GameProps = {}) {
     gameView?.players?.find((p) => p.id === myPlayerSlot) ??
     gameView?.players?.find((p) => p.isHuman) ??
     gameView?.players?.[0];
+  useEffect(() => {
+    const intent = placementIntentRef.current;
+    if (!intent || !gameView || !me) return;
+    if (gameView.battlefield.some((card) => card.id === intent.cardId)) {
+      placementIntentRef.current = null;
+      return;
+    }
+
+    const onStack = gameView.stack.some((item) => item.sourceId === intent.cardId);
+    const promptingForCard =
+      casting.castingCardId === intent.cardId || activePrompt?.sourceCard?.id === intent.cardId;
+    const inHand = me.hand.some((card) => card.id === intent.cardId);
+    if (onStack || promptingForCard || !inHand) intent.castStarted = true;
+    if (!intent.castStarted || onStack || promptingForCard) return;
+
+    boardSceneRef.current?.clearPendingDrop(intent.cardId);
+    placementIntentRef.current = null;
+  }, [activePrompt, casting.castingCardId, gameView, me]);
   const opponents = useMemo(
     () => gameView?.players?.filter((p) => p.id !== me?.id) ?? [],
     [gameView?.players, me?.id],


### PR DESCRIPTION
## Summary

- Bind a manually selected battlefield cell to the permanent that the player dragged.
- Keep the cell through intervening triggers, then release it when the cast is canceled, countered, attached, or otherwise does not produce a top-level permanent.

## Why

Triggered permanents could take the selected cell before the dragged permanent entered. The dragged permanent then fell back to automatic placement.

Fixes #61

## Test plan

- yarn lint:all
- yarn build:web
- yarn test: 74 tests pass and 3 skip. useScryfallStore.test.ts has the existing __APP_VERSION__ test-environment failure.

## Demo

No recording. The collaborative browser is not cross-origin isolated, so its game runtime cannot create SharedArrayBuffer.