### PR TITLE
perf(engine): stop cloning every card to test cost restrictions

### DIFF
--- a/manabrew-rs/crates/manabrew-engine/src/cost/cost_collect_evidence.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/cost/cost_collect_evidence.rs
@@ -22,13 +22,12 @@ pub fn can_pay(
         return false;
     };
     let resolved_amount = amount.resolve(game, source, player);
-    let static_source_cards = super::static_ability_source_cards(game);
     let total_mv: i32 = game
         .cards_in_zone(forge_foundation::ZoneType::Graveyard, player)
         .iter()
         .filter(|&&cid| {
             !crate::staticability::static_ability_cant_exile::cant_exile(
-                &static_source_cards,
+                &game.cards,
                 game.card(cid),
                 ability,
                 true,

--- a/manabrew-rs/crates/manabrew-engine/src/cost/cost_exile.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/cost/cost_exile.rs
@@ -45,7 +45,6 @@ pub fn can_pay(
     part: &super::CostPart,
 ) -> bool {
     let card = game.card(source);
-    let static_source_cards = super::static_ability_source_cards(game);
     match part {
         super::CostPart::Exile {
             amount,
@@ -60,7 +59,7 @@ pub fn can_pay(
                     return false;
                 }
                 return !crate::staticability::static_ability_cant_exile::cant_exile(
-                    &static_source_cards,
+                    &game.cards,
                     card,
                     ability,
                     true,
@@ -73,7 +72,7 @@ pub fn can_pay(
                     .into_iter()
                     .filter(|&cid| {
                         !crate::staticability::static_ability_cant_exile::cant_exile(
-                            &static_source_cards,
+                            &game.cards,
                             game.card(cid),
                             ability,
                             true,
@@ -166,7 +165,7 @@ pub fn can_pay(
                 let src = game.card(source);
                 let is_eligible = src.zone == forge_foundation::ZoneType::Graveyard
                     && !crate::staticability::static_ability_cant_exile::cant_exile(
-                        &static_source_cards,
+                        &game.cards,
                         src,
                         ability,
                         true,
@@ -190,7 +189,7 @@ pub fn can_pay(
                             &[],
                         ))
                         && !crate::staticability::static_ability_cant_exile::cant_exile(
-                            &static_source_cards,
+                            &game.cards,
                             game.card(cid),
                             ability,
                             true,
@@ -218,7 +217,7 @@ pub fn can_pay(
                         )
                     {
                         if crate::staticability::static_ability_cant_exile::cant_exile(
-                            &static_source_cards,
+                            &game.cards,
                             game.card(cid),
                             ability,
                             true,

--- a/manabrew-rs/crates/manabrew-engine/src/cost/cost_exile_ctrl_or_grave.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/cost/cost_exile_ctrl_or_grave.rs
@@ -35,13 +35,12 @@ pub fn can_pay(
         return false;
     };
     let resolved_amount = amount.resolve(game, source, player);
-    let static_source_cards = super::static_ability_source_cards(game);
     let base_filter = super::normalize_exile_base_filter(type_filter);
     let bf = super::get_zone_targets(game, player, ZoneType::Battlefield, &base_filter)
         .into_iter()
         .filter(|&cid| {
             !crate::staticability::static_ability_cant_exile::cant_exile(
-                &static_source_cards,
+                &game.cards,
                 game.card(cid),
                 ability,
                 true,
@@ -52,7 +51,7 @@ pub fn can_pay(
         .into_iter()
         .filter(|&cid| {
             !crate::staticability::static_ability_cant_exile::cant_exile(
-                &static_source_cards,
+                &game.cards,
                 game.card(cid),
                 ability,
                 true,

--- a/manabrew-rs/crates/manabrew-engine/src/cost/cost_forage.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/cost/cost_forage.rs
@@ -16,13 +16,12 @@ pub fn can_pay(
     ability: Option<&crate::spellability::SpellAbility>,
     _part: &super::CostPart,
 ) -> bool {
-    let static_source_cards = super::static_ability_source_cards(game);
     let gy_count = game
         .cards_in_zone(forge_foundation::ZoneType::Graveyard, player)
         .iter()
         .filter(|&&cid| {
             !crate::staticability::static_ability_cant_exile::cant_exile(
-                &static_source_cards,
+                &game.cards,
                 game.card(cid),
                 ability,
                 true,
@@ -35,7 +34,7 @@ pub fn can_pay(
         .any(|&cid| {
             game.card(cid).type_line.has_subtype("Food")
                 && !crate::staticability::static_ability_cant_sacrifice::cant_sacrifice(
-                    &static_source_cards,
+                    &game.cards,
                     game.card(cid),
                     ability,
                     true,

--- a/manabrew-rs/crates/manabrew-engine/src/cost/cost_part.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/cost/cost_part.rs
@@ -158,13 +158,12 @@ pub fn get_max_amount_x(
                     (type_filter.clone(), false)
                 };
             let type_list = if type_filter.contains('X') {
-                let static_sources = crate::cost::static_ability_source_cards(game);
                 game.cards_in_zone(forge_foundation::ZoneType::Battlefield, player)
                     .iter()
                     .copied()
                     .filter(|&cid| {
                         !crate::staticability::static_ability_cant_sacrifice::cant_sacrifice(
-                            &static_sources,
+                            &game.cards,
                             game.card(cid),
                             Some(ability),
                             true,

--- a/manabrew-rs/crates/manabrew-engine/src/cost/cost_sacrifice.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/cost/cost_sacrifice.rs
@@ -67,7 +67,7 @@ pub fn can_pay(
             return false;
         }
         return !crate::staticability::static_ability_cant_sacrifice::cant_sacrifice(
-            &super::static_ability_source_cards(game),
+            &game.cards,
             card,
             ability,
             true,

--- a/manabrew-rs/crates/manabrew-engine/src/cost/mod.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/cost/mod.rs
@@ -56,7 +56,7 @@ use forge_foundation::{ManaCost, ZoneType};
 use serde::{Deserialize, Serialize};
 
 use crate::ability::effects::matches_change_type;
-use crate::card::{Card, CounterType};
+use crate::card::CounterType;
 use crate::game::GameState;
 use crate::ids::{CardId, PlayerId};
 use crate::mana::ManaPool;
@@ -878,10 +878,9 @@ pub fn get_sacrifice_targets_for_cost(
     type_filter: &str,
     ability: Option<&SpellAbility>,
 ) -> Vec<CardId> {
-    let static_sources = static_ability_source_cards(game);
     get_sacrifice_targets(game, player, type_filter)
         .into_iter()
-        .filter(|&cid| !cant_sacrifice(&static_sources, game.card(cid), ability, true))
+        .filter(|&cid| !cant_sacrifice(&game.cards, game.card(cid), ability, true))
         .collect()
 }
 
@@ -1404,30 +1403,6 @@ fn can_pay_part_distributed(
             cost_exile_ctrl_or_grave::can_pay(game, source, player, ability, part)
         }
     }
-}
-pub fn static_ability_source_cards(game: &GameState) -> Vec<Card> {
-    use std::collections::HashSet;
-
-    let mut ids: HashSet<CardId> = HashSet::new();
-    for p in &game.players {
-        for &zone in &[
-            ZoneType::Battlefield,
-            ZoneType::Graveyard,
-            ZoneType::Exile,
-            ZoneType::Command,
-        ] {
-            for &cid in game.cards_in_zone(zone, p.id) {
-                ids.insert(cid);
-            }
-        }
-    }
-    for entry in game.stack.iter() {
-        if let Some(cid) = entry.spell_ability.source {
-            ids.insert(cid);
-        }
-    }
-
-    ids.into_iter().map(|cid| game.card(cid).clone()).collect()
 }
 
 pub(crate) fn shares_creature_type(game: &GameState, a: CardId, b: CardId) -> bool {

--- a/manabrew-rs/crates/manabrew-engine/src/game_loop/cost_payment.rs
+++ b/manabrew-rs/crates/manabrew-engine/src/game_loop/cost_payment.rs
@@ -3683,9 +3683,8 @@ fn shares_creature_type(game: &GameState, a: CardId, b: CardId) -> bool {
 }
 
 fn can_exile_for_cost(game: &GameState, card_id: CardId) -> bool {
-    let static_sources = crate::cost::static_ability_source_cards(game);
     !crate::staticability::static_ability_cant_exile::cant_exile(
-        &static_sources,
+        &game.cards,
         game.card(card_id),
         None,
         true,


### PR DESCRIPTION
## Summary

- `cost::static_ability_source_cards` gathered every card in every battlefield, graveyard, exile and command zone plus the stack, and returned deep clones of all of them. Each clone carried the card's triggers, replacement effects and compiled selectors.
- Every one of its eight call sites passed the result to `cant_exile` or `cant_sacrifice`, and both already filter to the battlefield themselves, so passing `game.cards` straight through is equivalent and allocates nothing.
- The function is deleted.

## Why

It sits under `can_pay`, which action-space enumeration calls once per candidate, which the priority loop calls on every prompt. On a small board nobody notices. On a real Commander board it is thousands of full `Card` clones per prompt, and the cost grows with the board rather than with the decision.

Found while pointing a harness at captured production games: a stack sample of a stalled run put 2,129 of 2,187 samples under `Card::clone` below this function.

## Test plan

- `cargo test -p manabrew-engine --lib` — 334 passed, 0 failed.
- Replayed two captured production Commander games and compared action-space output either side of the change: byte-identical (949 menus, 13,114 offered actions, same 12,991 matched).
- Wall clock on those two games, same machine and same binary settings:
  - 8,804-entry game: 2 min 00 s to 29.5 s
  - 7,618-entry game, 114,113 offered actions across 817 menus: had not finished after 35 min, now 6 min 43 s

Note that `cargo test -p manabrew-engine` (integration tests) does not compile on `main`: `tests/cleansing_wildfire_regression.rs` implements `confirm_action` with `Option<&str>` where the trait now takes `Option<CardId>`. Unrelated to this change, but it is why the test plan above is `--lib`.