### PR TITLE
feat(node): report engine time and client round trip

### DIFF
--- a/manabrew-rs/crates/manabot/src/state.rs
+++ b/manabrew-rs/crates/manabot/src/state.rs
@@ -227,7 +227,10 @@ impl BotState {
                 return Vec::new();
             }
         };
-        let StateEnvelope::Prompt { for_player, prompt } = envelope else {
+        let StateEnvelope::Prompt {
+            for_player, prompt, ..
+        } = envelope
+        else {
             return Vec::new();
         };
         let prompt_type = prompt

--- a/manabrew-rs/crates/manabrew-agent-interface/src/protocol.rs
+++ b/manabrew-rs/crates/manabrew-agent-interface/src/protocol.rs
@@ -19,6 +19,13 @@ pub enum StateEnvelope {
         #[serde(rename = "forPlayer", default, skip_serializing_if = "Option::is_none")]
         for_player: Option<String>,
         state: Value,
+        /// Milliseconds the engine host spent between receiving the response
+        /// that caused this state and sending it. Lets a receiver separate
+        /// engine work from the hop to the engine host, which is otherwise
+        /// impossible: only the relay stamps these envelopes, and comparing
+        /// clocks across hosts is not something we want to rely on.
+        #[serde(rename = "engineMs", default, skip_serializing_if = "Option::is_none")]
+        engine_ms: Option<u32>,
         /// Set only when the sender also emits [`StateEnvelope::StateDelta`],
         /// so a receiver can tell whether a later patch applies to what it
         /// holds. Receivers never compute it: the sender is the only authority,
@@ -36,6 +43,8 @@ pub enum StateEnvelope {
         base: String,
         fingerprint: String,
         patch: Value,
+        #[serde(rename = "engineMs", default, skip_serializing_if = "Option::is_none")]
+        engine_ms: Option<u32>,
     },
     Display {
         event: Value,
@@ -47,6 +56,8 @@ pub enum StateEnvelope {
         #[serde(rename = "forPlayer")]
         for_player: String,
         prompt: Value,
+        #[serde(rename = "engineMs", default, skip_serializing_if = "Option::is_none")]
+        engine_ms: Option<u32>,
     },
     /// Player answers a prompt. `action` is `PlayerAction` for Rust; raw value
     Response {
@@ -111,12 +122,23 @@ pub enum StateEnvelope {
 
 impl StateEnvelope {
     pub fn for_agent_message(for_player: String, message: &crate::prompt::AgentMessage) -> Self {
+        Self::for_agent_message_timed(for_player, message, None)
+    }
+
+    /// As [`Self::for_agent_message`], carrying how long the engine host took
+    /// to produce this message.
+    pub fn for_agent_message_timed(
+        for_player: String,
+        message: &crate::prompt::AgentMessage,
+        engine_ms: Option<u32>,
+    ) -> Self {
         use crate::prompt::AgentMessage;
         match message {
             AgentMessage::State(state) => StateEnvelope::State {
                 for_player: Some(for_player),
                 state: serde_json::to_value(state).unwrap_or(Value::Null),
                 fingerprint: None,
+                engine_ms,
             },
             AgentMessage::Display(event) => StateEnvelope::Display {
                 event: serde_json::to_value(event).unwrap_or(Value::Null),
@@ -124,6 +146,7 @@ impl StateEnvelope {
             AgentMessage::Prompt(prompt) => StateEnvelope::Prompt {
                 for_player,
                 prompt: serde_json::to_value(prompt).unwrap_or(Value::Null),
+                engine_ms,
             },
             AgentMessage::Error(error) => StateEnvelope::Error {
                 for_player,

--- a/manabrew-rs/crates/manabrew-server/src/connection.rs
+++ b/manabrew-rs/crates/manabrew-server/src/connection.rs
@@ -335,12 +335,20 @@ pub async fn handle_connection(
     }
 
     let heartbeat_tx = tx.clone();
+    let heartbeat_start = Instant::now();
     let heartbeat_task = tokio::spawn(async move {
         let mut ticker = tokio::time::interval(HEARTBEAT_INTERVAL);
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         loop {
             ticker.tick().await;
-            if heartbeat_tx.send(Message::Ping(Vec::new())).is_err() {
+            // The payload comes back untouched in the pong (RFC 6455 §5.5.2),
+            // so the relay can time the round trip without the client
+            // participating or the two clocks agreeing.
+            let stamp = heartbeat_start.elapsed().as_millis() as u64;
+            if heartbeat_tx
+                .send(Message::Ping(stamp.to_be_bytes().to_vec()))
+                .is_err()
+            {
                 break;
             }
         }
@@ -432,8 +440,13 @@ pub async fn handle_connection(
                 debug!("[recv] '{}' ping", username);
                 let _ = tx.send(Message::Pong(data));
             }
-            Message::Pong(_) => {
+            Message::Pong(data) => {
                 debug!("[recv] '{}' pong", username);
+                if let Ok(bytes) = <[u8; 8]>::try_from(data.as_slice()) {
+                    let sent = u64::from_be_bytes(bytes);
+                    let now = heartbeat_start.elapsed().as_millis() as u64;
+                    metrics::record_client_rtt(now.saturating_sub(sent) as f64);
+                }
             }
             _ => {}
         }

--- a/manabrew-rs/crates/manabrew-server/src/metrics.rs
+++ b/manabrew-rs/crates/manabrew-server/src/metrics.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use metrics::{counter, gauge};
+use metrics::{counter, gauge, histogram};
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 
 use crate::analytics::GameEndReason;
@@ -18,6 +18,7 @@ const SESSION_TAKEOVERS: &str = "manabrew_relay_session_takeovers_total";
 const ANALYTICS_DROPPED: &str = "manabrew_relay_analytics_dropped_total";
 const DECK_PLAY_EVENTS_DROPPED: &str = "manabrew_relay_deck_play_events_dropped_total";
 const STATE_PATCH_DOWNGRADES: &str = "manabrew_relay_state_patch_downgrades_total";
+const CLIENT_RTT: &str = "manabrew_relay_client_rtt_ms";
 
 const LABEL_KIND: &str = "kind";
 const LABEL_STATUS: &str = "status";
@@ -71,6 +72,14 @@ pub fn record_rejection(reason: &'static str) {
 /// `SELF_HOSTED_NODE_STATE_DELTA` is saving bandwidth for everyone.
 pub fn record_state_patch_downgrade() {
     counter!(STATE_PATCH_DOWNGRADES).increment(1);
+}
+
+/// Round trip from the relay to a client and back, taken from the websocket
+/// heartbeat. The heartbeat carries the send time and RFC 6455 requires the
+/// peer to echo a ping's payload, so this is measured entirely on the relay's
+/// own clock and needs nothing from the client.
+pub fn record_client_rtt(ms: f64) {
+    histogram!(CLIENT_RTT).record(ms);
 }
 
 pub fn record_resync() {

--- a/manabrew-rs/crates/networking-tests/tests/support/mod.rs
+++ b/manabrew-rs/crates/networking-tests/tests/support/mod.rs
@@ -496,7 +496,10 @@ impl Client {
         if let Some(kind) = state.get("kind").and_then(serde_json::Value::as_str) {
             self.envelope_kinds.insert(kind.to_string());
         }
-        let Ok(StateEnvelope::Prompt { for_player, prompt }) = serde_json::from_value(state) else {
+        let Ok(StateEnvelope::Prompt {
+            for_player, prompt, ..
+        }) = serde_json::from_value(state)
+        else {
             return Ok(None);
         };
         if self.slot.as_deref() != Some(for_player.as_str()) {

--- a/manabrew-rs/crates/self-hosted-node/src/host.rs
+++ b/manabrew-rs/crates/self-hosted-node/src/host.rs
@@ -50,11 +50,13 @@ enum EngineSession {
     Manabrew {
         game_id: String,
         remote_response_txs: HashMap<usize, std_mpsc::Sender<ClientToServerMessage>>,
+        engine_clock: EngineClock,
     },
     Forge {
         game_id: String,
         remote_response_txs: HashMap<usize, std_mpsc::Sender<ClientToServerMessage>>,
         cancel: Arc<AtomicBool>,
+        engine_clock: EngineClock,
     },
 }
 
@@ -64,6 +66,13 @@ impl EngineSession {
             EngineSession::Manabrew { game_id, .. } | EngineSession::Forge { game_id, .. } => {
                 game_id
             }
+        }
+    }
+
+    fn engine_clock(&self) -> &EngineClock {
+        match self {
+            EngineSession::Manabrew { engine_clock, .. }
+            | EngineSession::Forge { engine_clock, .. } => engine_clock,
         }
     }
 }
@@ -1497,9 +1506,11 @@ fn maybe_start_hosted_engine(
                 remote_response_txs.insert(i, response_tx);
                 remote_response_rxs.push((i, response_rx));
             }
+            let engine_clock = EngineClock::default();
             *guard = Some(EngineSession::Manabrew {
                 game_id: game_id.clone(),
                 remote_response_txs,
+                engine_clock: engine_clock.clone(),
             });
             drop(guard);
 
@@ -1511,6 +1522,7 @@ fn maybe_start_hosted_engine(
                 remote_prompt_rx,
                 Some(player_names.clone()),
                 config.state_delta,
+                engine_clock,
             );
             let (game_over_tx, game_over_rx) = std_mpsc::channel::<HostedGameOver>();
             spawn_game_over_forwarder(
@@ -1570,10 +1582,12 @@ fn maybe_start_hosted_engine(
                 remote_response_rxs.push((i, response_rx));
             }
             let cancel = Arc::new(AtomicBool::new(false));
+            let engine_clock = EngineClock::default();
             *guard = Some(EngineSession::Forge {
                 game_id: game_id.clone(),
                 remote_response_txs,
                 cancel: cancel.clone(),
+                engine_clock: engine_clock.clone(),
             });
             drop(guard);
 
@@ -1585,6 +1599,7 @@ fn maybe_start_hosted_engine(
                 remote_prompt_rx,
                 Some(player_names.clone()),
                 config.state_delta,
+                engine_clock,
             );
             let (game_over_tx, game_over_rx) = std_mpsc::channel::<HostedGameOver>();
             spawn_game_over_forwarder(
@@ -1879,6 +1894,7 @@ fn route_remote_response(
         debug!(from_player, player_index, "no response channel for player");
         return;
     };
+    session.engine_clock().mark_response();
     if let Err(error) = tx.send(ClientToServerMessage::Response { prompt_id, action }) {
         warn!(from_player, %error, "failed to route relay response");
         return;
@@ -1957,12 +1973,44 @@ fn stamp_fingerprint(mut envelope: Value) -> Value {
 /// Patch form of a fingerprinted state envelope, against the last one sent to
 /// this seat. `None` the first time a seat is served, or if anything is missing,
 /// and the caller falls back to the full state, which is always correct.
+/// When the engine host last received a player's response, as milliseconds on
+/// its own monotonic clock. The response path writes it and the emit path
+/// reads it, so an outgoing envelope can say how long the engine took without
+/// anyone comparing clocks across hosts.
+#[derive(Clone, Default)]
+pub struct EngineClock(std::sync::Arc<std::sync::atomic::AtomicU64>);
+
+impl EngineClock {
+    fn now() -> u64 {
+        use std::sync::OnceLock;
+        static START: OnceLock<Instant> = OnceLock::new();
+        START.get_or_init(Instant::now).elapsed().as_millis() as u64
+    }
+
+    pub fn mark_response(&self) {
+        self.0
+            .store(Self::now(), std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Milliseconds since the last response, or `None` if none has arrived yet
+    /// or the gap is implausibly long (the engine was idle, not working).
+    pub fn elapsed_ms(&self) -> Option<u32> {
+        let at = self.0.load(std::sync::atomic::Ordering::Relaxed);
+        if at == 0 {
+            return None;
+        }
+        let delta = Self::now().saturating_sub(at);
+        (delta < 120_000).then_some(delta as u32)
+    }
+}
+
 fn patch_against_last(
     bases: &mut HashMap<usize, (Value, String)>,
     player_index: usize,
     per_seat: bool,
     slot: &str,
     envelope: &Value,
+    engine_ms: Option<u32>,
 ) -> Option<Value> {
     let next = envelope.get("state")?.clone();
     let fingerprint = envelope.get("fingerprint")?.as_str()?.to_string();
@@ -1974,6 +2022,7 @@ fn patch_against_last(
         base,
         fingerprint,
         patch,
+        engine_ms,
     })
     .ok()
 }
@@ -1986,6 +2035,7 @@ fn spawn_remote_prompt_forwarder(
     remote_prompt_rx: std_mpsc::Receiver<(usize, AgentMessage)>,
     seat_usernames: Option<Vec<String>>,
     state_delta: bool,
+    engine_clock: EngineClock,
 ) {
     thread::spawn(move || {
         let mut last_state_by_seat: HashMap<usize, Value> = HashMap::new();
@@ -2004,13 +2054,15 @@ fn spawn_remote_prompt_forwarder(
             }
             let per_seat = seat_usernames.is_some() && player_index != OBSERVER_SEAT;
             let slot = player_slot(player_index);
+            let engine_ms = engine_clock.elapsed_ms();
             let envelope = match &message {
                 AgentMessage::State(state_update) if !per_seat => StateEnvelope::State {
                     for_player: None,
                     state: serde_json::to_value(state_update).unwrap_or(Value::Null),
                     fingerprint: None,
+                    engine_ms,
                 },
-                _ => StateEnvelope::for_agent_message(slot.clone(), &message),
+                _ => StateEnvelope::for_agent_message_timed(slot.clone(), &message, engine_ms),
             };
             let Ok(state) = serde_json::to_value(envelope) else {
                 continue;
@@ -2045,10 +2097,15 @@ fn spawn_remote_prompt_forwarder(
                 }
             }
             let state = match &message {
-                AgentMessage::State(_) if state_delta => {
-                    patch_against_last(&mut delta_bases, player_index, per_seat, &slot, &state)
-                        .unwrap_or(state)
-                }
+                AgentMessage::State(_) if state_delta => patch_against_last(
+                    &mut delta_bases,
+                    player_index,
+                    per_seat,
+                    &slot,
+                    &state,
+                    engine_ms,
+                )
+                .unwrap_or(state),
                 _ => state,
             };
             let target_player = if per_seat
@@ -2121,6 +2178,7 @@ fn spawn_game_over_forwarder(
                         for_player: None,
                         state: serde_json::to_value(state_update).unwrap_or(Value::Null),
                         fingerprint: None,
+                        engine_ms: None,
                     },
                     _ => StateEnvelope::for_agent_message(player_slot(player_index), &message),
                 };

--- a/manabrew-rs/crates/self-hosted-node/tests/hosted_smoke.rs
+++ b/manabrew-rs/crates/self-hosted-node/tests/hosted_smoke.rs
@@ -204,7 +204,10 @@ async fn play_game(
                     let Ok(envelope) = serde_json::from_value::<StateEnvelope>(state) else {
                         continue;
                     };
-                    if let StateEnvelope::Prompt { for_player, prompt } = envelope {
+                    if let StateEnvelope::Prompt {
+                        for_player, prompt, ..
+                    } = envelope
+                    {
                         if my_slot.as_deref() != Some(for_player.as_str()) {
                             continue;
                         }


### PR DESCRIPTION
## Summary

- Engine hosts stamp `engineMs` on the envelopes they emit: milliseconds spent between receiving the response that caused the envelope and sending it.
- The relay's websocket heartbeat now carries its send time, and the pong is timed into a new `manabrew_relay_client_rtt_ms` histogram.
- Both additions are optional fields on existing types. `StateEnvelope` has no `deny_unknown_fields`, so older clients, bots and harnesses ignore them.

## Why

Only the relay stamps game envelopes, so today a decision's latency arrives as a single number covering both the hop to the engine host and the engine's own work, with no way to tell them apart.

Neither addition requires clocks on different machines to agree, which is what makes them worth doing:

- `engineMs` is a **duration** on the engine host's own clock, not a timestamp. The relay subtracts it from what it measured and is left with the hop.
- The client round trip uses the heartbeat that already exists. RFC 6455 requires a peer to echo a ping's payload, so the relay times it on its own clock and **the client needs no change at all**.

Context from 40 days of production captures: the median hosted decision is about 180ms, of which roughly 107ms looks like the hop and 37ms engine work. Those figures are inferred from the fastest decisions in each game, which is the best available today. This makes them measured.

The client leg is currently not measured anywhere. The obvious proxy does not work: dice-roll acknowledgements look human-free but the client waits for the roll animation before answering, so the number is animation plus network.

## Test plan

- `cargo check --workspace` clean.
- `yarn lint:all` clean (runs on commit).
- `engineMs` is `Option<u32>`, absent on the game-over path where there is no response to measure from, and suppressed when the gap exceeds 120s so an idle engine does not report a long "work" time.
- Round-trip decode of the heartbeat payload is length-checked; a pong with any other payload is ignored.

Not yet observed on a live fleet. Worth watching `manabrew_relay_client_rtt_ms` and the distribution of `engineMs` for a day before drawing conclusions from either.

### For reviewers

The engine clock is per game session and the emit path stamps every envelope with the time since the last response, not per envelope. For the first envelope after a response that is exactly the number wanted, and it is what pairs with the relay's own response-to-state measurement. For later envelopes in the same burst it is cumulative.