### PR TITLE
docs(agents): remove obsolete crew workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,6 @@ The PR body itself must follow `.github/pull_request_template.md`: `Summary`, `W
 - **Pull with merge, never rebase.** When integrating `main` into a feature branch, or pulling someone else's work, use `git merge` (or `git pull` with `pull.rebase=false`) — never `git rebase`, never `git pull --rebase`. The repo's history convention is merge-based; rebasing rewrites already-pushed commits and creates divergence for collaborators. This applies to every branch, every time.
 - **No unit tests** unless explicitly asked.
 - **UI work** must reference `docs/STYLE_GUIDELINES.md` (and `docs/agents/UI_THEME_RULES.md` for colors).
-- **Non-trivial tasks** load the `crew-orchestrator` skill first (DISCOVER → PLAN → APPROVAL → EXECUTE → REVIEW → TEST). Trivial tasks (one-liners, simple questions, file renames) skip it.
 
 ## Hygiene
 


### PR DESCRIPTION
## Summary

- remove the obsolete `crew-orchestrator` workflow requirement from repository guidance

## Why

The global `crew-*` agents and skills are retired, so the repository must not direct agents to load the removed orchestrator.

## Test plan

- `yarn prettier --check AGENTS.md`
- `git diff --check`