### PR TITLE
fix(harness): report colorless floating mana instead of always zero

### DIFF
--- a/forge-harness/src/main/java/forge/harness/host/InteractiveSnapshotExtractor.java
+++ b/forge-harness/src/main/java/forge/harness/host/InteractiveSnapshotExtractor.java
@@ -13,6 +13,7 @@ import forge.ImageKeys;
 import forge.card.ColorSet;
 import forge.card.CardStateName;
 import forge.card.MagicColor;
+import forge.card.mana.ManaAtom;
 import forge.game.Game;
 import forge.game.GameEntity;
 import forge.ai.ComputerUtilCombat;
@@ -332,7 +333,9 @@ public final class InteractiveSnapshotExtractor {
         pool.put("B", player.getManaPool().getAmountOfColor(MagicColor.BLACK));
         pool.put("R", player.getManaPool().getAmountOfColor(MagicColor.RED));
         pool.put("G", player.getManaPool().getAmountOfColor(MagicColor.GREEN));
-        pool.put("C", player.getManaPool().getAmountOfColor(MagicColor.COLORLESS));
+        // ManaPool keys colorless by ManaAtom.COLORLESS (1 << 5), not
+        // MagicColor.COLORLESS (0, "the absence of any color").
+        pool.put("C", player.getManaPool().getAmountOfColor((byte) ManaAtom.COLORLESS));
         return pool;
     }
 


### PR DESCRIPTION
## Summary

- `manaPool` in `InteractiveSnapshotExtractor` asked `getAmountOfColor(MagicColor.COLORLESS)`. That constant is `0`, "the absence of any color", while `ManaPool` keys floating mana by `ManaAtom.COLORLESS`, which is `1 << 5`.
- The lookup matched nothing, so every colorless mana a player had floating went over the wire as zero.
- One line, plus the import.

## Why

Fixes #614.

The five colours work because `ManaAtom.WHITE..GREEN` alias the `MagicColor` values. Colorless is the one that does not, and Forge's own source carries a comment warning about exactly this.

It is not only a display bug. Anything that reconstructs a board from a state view sees the player short of mana, so a player who answers "pay from pool" for a generic cost appears to do it with an empty pool.

**This PR is also the release trigger for #746, #747 and #748.** Those three merged cleanly but touch no path that maps to the desktop app, so `cargo xtask release` bumped the backend crates and never cut a `vX.Y.Z` tag. Production deploy hangs off that tag, so the engine fix and the new latency instrumentation are released as crates but not deployed. `forge-harness/**` maps to both the app and `self-hosted-node`, so this lands them.

`cargo xtask plan` on this branch:

```
manabrew          3.19.0 -> 3.19.1  (patch)
self-hosted-node  0.18.5 -> 0.19.1  (patch)
```

## Test plan

- `yarn build:harness` — BUILD SUCCESS.
- Verified against production captures: across ~5,000 states in two games, `manaPool.C` is never non-zero while colorless-producing sources are tapped repeatedly, and coloured mana reports correctly throughout.
- After deploy, `manaPool.C` should start appearing as non-zero. That is also the first chance to see `engineMs` and `manabrew_relay_client_rtt_ms` from #747 on live traffic.