### PR TITLE
fix(node): stop discarding the slowest engine timings

### DIFF
--- a/manabrew-rs/crates/self-hosted-node/src/host.rs
+++ b/manabrew-rs/crates/self-hosted-node/src/host.rs
@@ -2007,15 +2007,28 @@ impl EngineClock {
             .store(Self::now(), std::sync::atomic::Ordering::Relaxed);
     }
 
+    /// Cleared once the decision it was timing completes, so an envelope emitted
+    /// later, while a player is thinking, cannot report that wait as engine time.
+    pub fn mark_decision_complete(&self) {
+        self.0.store(0, std::sync::atomic::Ordering::Relaxed);
+    }
+
     /// Milliseconds since the last response, or `None` if none has arrived yet
-    /// or the gap is implausibly long (the engine was idle, not working).
+    /// or the decision it was timing has already completed.
+    ///
+    /// There is deliberately no upper bound. Idle time used to be excluded by
+    /// discarding anything past 120s, which also discarded the slow decisions
+    /// the metric exists to expose: a real 175s decision reported no `engineMs`
+    /// at all, so the field was absent exactly when it mattered and every
+    /// quantile built from it was understated. `mark_decision_complete` draws
+    /// that line by state instead of by duration.
     pub fn elapsed_ms(&self) -> Option<u32> {
         let at = self.0.load(std::sync::atomic::Ordering::Relaxed);
         if at == 0 {
             return None;
         }
         let delta = Self::now().saturating_sub(at);
-        (delta < 120_000).then_some(delta as u32)
+        Some(delta.min(u32::MAX as u64) as u32)
     }
 }
 
@@ -2071,6 +2084,9 @@ fn spawn_remote_prompt_forwarder(
             let per_seat = seat_usernames.is_some() && player_index != OBSERVER_SEAT;
             let slot = player_slot(player_index);
             let engine_ms = engine_clock.elapsed_ms();
+            if matches!(message, AgentMessage::Prompt(_)) {
+                engine_clock.mark_decision_complete();
+            }
             let emit_started = Instant::now();
             let envelope = match &message {
                 AgentMessage::State(state_update) if !per_seat => StateEnvelope::State {


### PR DESCRIPTION
## Summary

- Remove the 120s ceiling on `engineMs`, which discarded the slowest decisions instead of reporting them.
- Clear the engine clock when the prompt is emitted, so idle time still cannot be counted as engine time.

## Why

`EngineClock::elapsed_ms` returned `None` for any gap of 120s or more. A real 175s decision on prod therefore carried no `engineMs` at all: the field was absent exactly when it mattered, and every quantile built from it summarised only the decisions that were already fast enough. Chasing that stall cost an evening of capture forensics that the field was supposed to make unnecessary.

The ceiling was standing in for a disarm. `mark_response` arms the clock on every response and nothing cleared it, so an envelope emitted later, while a player was thinking, would have reported that wait as engine time. A duration bound is a poor proxy for that: it cannot tell a slow decision from an idle room, so it throws away both.

Clearing the clock when the prompt is emitted draws the line by state rather than by duration. That is the same boundary the node's own `decision_total` uses (response to next prompt), so the two now agree, and the bound is no longer needed.

Same failure shape as #757: a guard that silently produced no series at all, which reads as "nothing to see" rather than "not measured".

## Test plan

- `cargo check -p self-hosted-node`, `cargo clippy` zero warnings, `cargo fmt` clean.
- Full `yarn lint:all` green via the pre-commit hook.
- Behaviour is unchanged for decisions under 120s, which is all of the current data: the field is stamped from the same call site with the same clock. Above 120s it now reports a value instead of omitting the field.
- Envelopes emitted after the prompt (during a player's think time) now report no `engineMs`, which is the intended narrowing: previously they reported the wait as engine time whenever it happened to be under 120s.

## Follow-up

With this and #761 in place, the next occurrence is attributed as it happens: shape on `manabrew_node_forge_decision_seconds`, game id in the `slow engine decision` log, and a real duration in `engineMs`.
