### PR TITLE
fix(forge): resolve a deck's flavor name to the card Forge knows

### DIFF
--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewEngineAdapter.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewEngineAdapter.java
@@ -10,7 +10,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import forge.ai.LobbyPlayerAi;
+import forge.StaticData;
 import forge.card.CardDb;
+import forge.card.CardEdition;
 import forge.deck.CardPool;
 import forge.deck.Deck;
 import forge.deck.DeckSection;
@@ -21,6 +23,7 @@ import forge.game.Match;
 import forge.game.player.RegisteredPlayer;
 import forge.gui.GuiBase;
 import forge.item.PaperCard;
+import forge.localinstance.properties.ForgePreferences;
 import forge.model.FModel;
 
 import java.util.ArrayList;
@@ -58,7 +61,11 @@ public final class ManaBrewEngineAdapter {
             throw new IllegalArgumentException("assetsDir is required");
         }
         GuiBase.setInterface(new HeadlessGuiBase(assetsDir));
-        FModel.initialize(null, null);
+        FModel.initialize(null, prefs -> {
+            prefs.setPref(ForgePreferences.FPref.LOAD_CARD_SCRIPTS_LAZILY, true);
+            prefs.setPref(ForgePreferences.FPref.DECKGEN_CARDBASED, false);
+            return null;
+        });
         initialized = true;
     }
 
@@ -79,6 +86,8 @@ public final class ManaBrewEngineAdapter {
         // multiplexed processes only reset between idle periods.
         if (sessions.isEmpty()) {
             ForgeEngineReset.resetAllIdCounters();
+            forge.StaticData.instance().resetLazyLoadedCards();
+            forge.ImageKeys.clearCaches();
         }
         final ManaBrewInteractiveSession session =
                 new ManaBrewInteractiveSession(request.getGameId());
@@ -207,7 +216,11 @@ public final class ManaBrewEngineAdapter {
     }
 
     static String cardRequest(final CardIdentity card) {
-        final String name = CardDb.CardRequest.compose(card.getName(), card.isFoil());
+        return cardRequest(card, staticDataNames());
+    }
+
+    static String cardRequest(final CardIdentity card, final CardNameIndex names) {
+        final String name = CardDb.CardRequest.compose(resolveCardName(card, names), card.isFoil());
         if (card.getSetCode() == null || card.getSetCode().isBlank()) {
             return name;
         }
@@ -215,6 +228,92 @@ public final class ManaBrewEngineAdapter {
             return CardDb.CardRequest.compose(name, card.getSetCode());
         }
         return CardDb.CardRequest.compose(name, card.getSetCode(), card.getCollectorNumber());
+    }
+
+    /**
+     * The name Forge files a card under, given the name a deck asked for.
+     *
+     * <p>Scryfall names an alt-art printing by its flavor name — FCA #40 is a
+     * Lightning Bolt called "Thrum of the Vestige" — and decks reach us carrying
+     * that name. Forge has no card by it, so the deck lookup misses and Forge
+     * substitutes a placeholder that says the card is unsupported: the game then
+     * plays on around a dead card instead of failing.
+     *
+     * <p>The edition file is the source of truth, and it is also the only one
+     * that works here — Forge's own flavor-name index is built as cards load, so
+     * under {@code LOAD_CARD_SCRIPTS_LAZILY} it is empty for a card no game has
+     * touched yet. Ask the edition what it prints at that collector number, and
+     * take its name only when the flavor name is the one the deck asked for, so
+     * a genuinely mistyped card is never silently swapped for its neighbour.
+     * The printing is still requested by set and number, so the art is unchanged.
+     */
+    static String resolveCardName(final CardIdentity card, final CardNameIndex names) {
+        final String requested = card.getName();
+        if (requested == null || requested.isBlank() || names == null) {
+            return requested;
+        }
+        if (names.knowsCard(requested)) {
+            return requested;
+        }
+        final String printed = names.cardNamePrintedAs(
+                card.getSetCode(), card.getCollectorNumber(), requested);
+        if (printed != null && !printed.isBlank()) {
+            return printed;
+        }
+        // No printing to go on: Forge's flavor index still answers for a card
+        // whose script is already loaded.
+        final String byFlavorName = names.cardNameForFlavorName(requested);
+        return byFlavorName == null || byFlavorName.isBlank() ? requested : byFlavorName;
+    }
+
+    /** The card-database questions {@link #resolveCardName} asks, so a test can answer them. */
+    interface CardNameIndex {
+        boolean knowsCard(String name);
+
+        /** The card at this printing, when the edition files it under the given flavor name. */
+        String cardNamePrintedAs(String setCode, String collectorNumber, String flavorName);
+
+        String cardNameForFlavorName(String flavorName);
+    }
+
+    private static CardNameIndex staticDataNames() {
+        final StaticData data = StaticData.instance();
+        final CardDb cards = data == null ? null : data.getCommonCards();
+        if (cards == null) {
+            return null;
+        }
+        return new CardNameIndex() {
+            @Override
+            public boolean knowsCard(final String name) {
+                return !cards.getAllCards(name).isEmpty();
+            }
+
+            @Override
+            public String cardNamePrintedAs(
+                    final String setCode, final String collectorNumber, final String flavorName) {
+                if (setCode == null || setCode.isBlank()
+                        || collectorNumber == null || collectorNumber.isBlank()) {
+                    return null;
+                }
+                final CardEdition edition =
+                        data.getEditions().get(setCode.toUpperCase(Locale.ROOT));
+                if (edition == null) {
+                    return null;
+                }
+                final CardEdition.EditionEntry entry =
+                        edition.getCardFromCollectorNumber(collectorNumber);
+                if (entry == null) {
+                    return null;
+                }
+                return flavorName.equalsIgnoreCase(entry.getFlavorName()) ? entry.name() : null;
+            }
+
+            @Override
+            public String cardNameForFlavorName(final String flavorName) {
+                final PaperCard card = cards.getUniqueByName(flavorName);
+                return card == null ? null : card.getName();
+            }
+        };
     }
 
     private static void requireSessionId(final String sessionId) {

--- a/forge-harness/src/test/java/forge/harness/host/ManaBrewEngineAdapterTest.java
+++ b/forge-harness/src/test/java/forge/harness/host/ManaBrewEngineAdapterTest.java
@@ -16,5 +16,65 @@ public final class ManaBrewEngineAdapterTest {
                 || !request.isFoil) {
             throw new AssertionError("exact printing identity did not survive the Forge request");
         }
+
+        // A deck can name a printing by its Scryfall flavor name. Forge files
+        // FCA #40 under "Lightning Bolt", so the request has to carry that name
+        // and keep the printing, or Forge builds an unsupported placeholder.
+        final ManaBrewEngineAdapter.CardNameIndex names =
+                new ManaBrewEngineAdapter.CardNameIndex() {
+                    @Override
+                    public boolean knowsCard(final String name) {
+                        return "Lightning Bolt".equals(name);
+                    }
+
+                    @Override
+                    public String cardNamePrintedAs(
+                            final String setCode,
+                            final String collectorNumber,
+                            final String flavorName) {
+                        return "FCA".equals(setCode)
+                                        && "40".equals(collectorNumber)
+                                        && "Thrum of the Vestige".equals(flavorName)
+                                ? "Lightning Bolt"
+                                : null;
+                    }
+
+                    @Override
+                    public String cardNameForFlavorName(final String flavorName) {
+                        return null; // empty under lazy card loading, as in the harness
+                    }
+                };
+
+        final CardDb.CardRequest flavor = CardDb.CardRequest.fromString(
+                ManaBrewEngineAdapter.cardRequest(
+                        new ManaBrewEngineAdapter.CardIdentity(
+                                "Thrum of the Vestige", "FCA", "40", false),
+                        names));
+        if (!"Lightning Bolt".equals(flavor.cardName)
+                || !"FCA".equals(flavor.edition)
+                || !"40".equals(flavor.collectorNumber)) {
+            throw new AssertionError("a flavor name did not resolve to the card Forge knows: "
+                    + flavor.cardName + "|" + flavor.edition + "|" + flavor.collectorNumber);
+        }
+
+        // A name Forge does not know, at a printing whose flavor name is a
+        // different one, is left alone rather than swapped for its neighbour.
+        final CardDb.CardRequest mistyped = CardDb.CardRequest.fromString(
+                ManaBrewEngineAdapter.cardRequest(
+                        new ManaBrewEngineAdapter.CardIdentity("Lightnin Bolt", "FCA", "40", false),
+                        names));
+        if (!"Lightnin Bolt".equals(mistyped.cardName)) {
+            throw new AssertionError("a mistyped card was swapped for the printing: "
+                    + mistyped.cardName);
+        }
+
+        // A card Forge already knows is never rewritten, flavor index or not.
+        final CardDb.CardRequest plain = CardDb.CardRequest.fromString(
+                ManaBrewEngineAdapter.cardRequest(
+                        new ManaBrewEngineAdapter.CardIdentity("Lightning Bolt", "LEA", "161", false),
+                        names));
+        if (!"Lightning Bolt".equals(plain.cardName) || !"LEA".equals(plain.edition)) {
+            throw new AssertionError("a known card name was rewritten: " + plain.cardName);
+        }
     }
 }

--- a/public/preset_decks/neheb_minotaur_commander.json
+++ b/public/preset_decks/neheb_minotaur_commander.json
@@ -248,10 +248,19 @@
       "allParts": []
     },
     {
-      "name": "Thrum of the Vestige",
+      "name": "Lightning Bolt",
       "count": 1,
       "set": "fca",
       "cardNumber": "40",
+      "manaCost": "{R}",
+      "colors": ["R"],
+      "colorIdentity": ["R"],
+      "cmc": 1,
+      "types": ["Instant"],
+      "subtypes": [],
+      "supertypes": [],
+      "text": "Lightning Bolt deals 3 damage to any target.",
+      "layout": "normal",
       "uris": {
         "small": "https://cards.scryfall.io/small/front/e/8/e89794ab-6070-4916-936f-2b42fe41d31b.jpg?1759413293",
         "normal": "https://cards.scryfall.io/normal/front/e/8/e89794ab-6070-4916-936f-2b42fe41d31b.jpg?1759413293",


### PR DESCRIPTION
A deck can name an alt-art printing by its Scryfall flavor name. FCA #40 is a Lightning Bolt the deck calls "Thrum of the Vestige", and Forge has no card by that name, so the lookup missed and Forge substituted its "this card is not supported" placeholder. The game then played on around a dead card.

This is not a browser-engine bug. Confirmed against the JVM Forge the hosted nodes run, driving the harness with that printing:

```
An unsupported card was requested: "Thrum of the Vestige" from "fca".
Forge could not find this card in the Database.
```

After the fix the same run reports none.

## What changed

- `ManaBrewEngineAdapter` asks the edition what it prints at that collector number, and takes its name only when the flavor name matches the one requested. A mistyped card is never swapped for its neighbour. The printing is still requested by set and number, so the art does not change.
- The Neheb preset was the only shipped deck naming one. It now says Lightning Bolt, with the type line and oracle text that were missing while the name resolved to nothing.

Forge's own flavor-name index cannot answer here: it is built as scripts load, and the harness runs with `LOAD_CARD_SCRIPTS_LAZILY`, so it is empty for a card no game has touched. It stays as a fallback for decks that carry no printing.

492 printings in the current card set carry a flavor name, so any imported deck can hit this.

## Verification

`ManaBrewEngineAdapterTest` covers the flavor name resolving, a mistyped name being left alone, and a known name never being rewritten. Watched failing with the resolver stubbed out.

## Follow-up

The browser build needs one more change, since it frames only the card scripts a deck names: `khaliostr/web-image-spike` carries it (`fix(forge-wasm): frame the script a flavor name really asks for`). Nothing here depends on it.
