### PR TITLE
feat(relay): measure how long the relay spends on a state envelope

### DIFF
--- a/manabrew-rs/crates/manabrew-server/src/connection.rs
+++ b/manabrew-rs/crates/manabrew-server/src/connection.rs
@@ -1283,6 +1283,7 @@ fn handle_client_message(
             state: game_state,
             target_player,
         } => {
+            let handling_started = Instant::now();
             let room_id = { state.players.get(player_id).and_then(|p| p.room_id.clone()) };
             if let Some(rid) = room_id {
                 let Some(mut room) = state.rooms.get_mut(&rid) else {
@@ -1317,6 +1318,7 @@ fn handle_client_message(
                         .capture_enabled()
                         .then(|| replay.game_id.clone())
                 });
+                let seats = room.players.len();
                 // `observe` has already folded this patch into the cached
                 // board, so an older seat can be handed the state the patch
                 // would have produced rather than an envelope it drops.
@@ -1347,6 +1349,7 @@ fn handle_client_message(
                     );
                 }
                 if !should_deliver {
+                    metrics::record_state_handling(seats, handling_started.elapsed());
                     return;
                 }
                 let ready = || {
@@ -1382,6 +1385,7 @@ fn handle_client_message(
                         broadcast_to_room_except(state, player_id, &rid, &msg);
                     }
                 }
+                metrics::record_state_handling(seats, handling_started.elapsed());
             } else {
                 warn!(
                     "[game] '{}' tried to broadcast state but not in a room",

--- a/manabrew-rs/crates/manabrew-server/src/metrics.rs
+++ b/manabrew-rs/crates/manabrew-server/src/metrics.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use metrics::{counter, gauge, histogram};
-use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 
 use crate::analytics::GameEndReason;
 use crate::protocol::{EngineKind, RoomStatus};
@@ -19,12 +19,14 @@ const ANALYTICS_DROPPED: &str = "manabrew_relay_analytics_dropped_total";
 const DECK_PLAY_EVENTS_DROPPED: &str = "manabrew_relay_deck_play_events_dropped_total";
 const STATE_PATCH_DOWNGRADES: &str = "manabrew_relay_state_patch_downgrades_total";
 const CLIENT_RTT: &str = "manabrew_relay_client_rtt_ms";
+const STATE_HANDLING: &str = "manabrew_relay_state_handling_seconds";
 
 const LABEL_KIND: &str = "kind";
 const LABEL_STATUS: &str = "status";
 const LABEL_HOSTED: &str = "hosted";
 const LABEL_ENGINE: &str = "engine";
 const LABEL_REASON: &str = "reason";
+const LABEL_SEATS: &str = "seats";
 
 pub const REJECTION_OUTDATED_WIRE: &str = "outdated_wire";
 
@@ -45,14 +47,43 @@ impl ConnectionKind {
     }
 }
 
-pub fn install() -> PrometheusHandle {
+// Only the state-handling metric gets buckets. Everything else stays a summary,
+// whose quantiles are per process and cannot be aggregated.
+const STATE_HANDLING_BUCKETS: &[f64] = &[
+    0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0,
+];
+
+fn builder() -> PrometheusBuilder {
     PrometheusBuilder::new()
+        .set_buckets_for_metric(
+            Matcher::Full(STATE_HANDLING.to_string()),
+            STATE_HANDLING_BUCKETS,
+        )
+        .expect("state handling buckets are a non-empty literal")
+}
+
+pub fn install() -> PrometheusHandle {
+    builder()
         .install_recorder()
         .expect("failed to install metrics recorder")
 }
 
 pub fn detached_handle() -> PrometheusHandle {
-    PrometheusBuilder::new().build_recorder().handle()
+    builder().build_recorder().handle()
+}
+
+/// How long the relay itself spends on one state envelope: folding the patch
+/// into the cached board, deciding whether a full board is needed, and handing
+/// it to the audience. Labelled by seat count because the node emits one
+/// envelope per seat plus an observer, so the work per decision scales with the
+/// room even when the engine's own time does not.
+///
+/// This interval had no metric at all. Replaying captures put a four-seat room
+/// at a p99 of 2.3s outside the rules engine against 0.27s for two seats, and
+/// the only way to see that was to subtract `engineMs` from capture timestamps
+/// in a script, after the fact, on a box.
+pub fn record_state_handling(seats: usize, elapsed: std::time::Duration) {
+    histogram!(STATE_HANDLING, LABEL_SEATS => seats.to_string()).record(elapsed.as_secs_f64());
 }
 
 pub fn record_game_started(engine: EngineKind) {

--- a/ops/observability/grafana/dashboards/live-ops.json
+++ b/ops/observability/grafana/dashboards/live-ops.json
@@ -29,6 +29,53 @@
   ],
   "panels": [
     {
+      "id": 107,
+      "type": "timeseries",
+      "title": "Relay state handling p99 by seats",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "How long the relay spends on one state envelope: folding the patch into the cached board, deciding whether a full board is needed, and handing it to the audience. Labelled by seat count because the node emits one envelope per seat plus an observer, so the work per decision scales with the room even when the engine's own time does not. This interval previously had no metric: replaying captures put a four-seat room at a p99 of 2.3s outside the rules engine against 0.27s for two seats, and seeing that meant subtracting engineMs from capture timestamps in a script after the fact. Compare against 'Engine decision p99 by room shape': engine flat while this rises is relay-side cost.",
+      "gridPos": {
+        "x": 0,
+        "y": 74,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.99, sum by (le, seats) (rate(manabrew_relay_state_handling_seconds_bucket[30m])))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "legendFormat": "p99 {{seats}} seats"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.5, sum by (le, seats) (rate(manabrew_relay_state_handling_seconds_bucket[30m])))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "legendFormat": "p50 {{seats}} seats"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
       "id": 105,
       "type": "timeseries",
       "title": "Engine decision p99 by room shape",


### PR DESCRIPTION
## Summary

- Add `manabrew_relay_state_handling_seconds`, a histogram of how long the relay spends handling one state envelope, labelled by seat count.
- Add a dashboard panel to read it beside the engine's own metric.

## Why

This is the interval that holds the latency we could not explain, and it had no metric at all.

Every existing relay metric is a counter or gauge of events — connections, rooms, rejections — plus the heartbeat echo. Nothing measured the relay's own work. Replaying two days of captures and subtracting `engineMs` from capture timestamps gave this:

| seats | end to end p99 | engine p99 | outside the engine |
| --- | --- | --- | --- |
| 2p (479 games, 136k decisions) | 0.461 | 0.194 | 0.270 |
| 4p (59 games, 49k decisions) | 2.856 | 0.473 | **2.298** |

Getting that number required a script, a capture archive and several hours. Nothing alerted, nothing named the game, and the node-side histogram stayed flat the whole time because the cost is not node-side. Read the two panels together and the question answers itself: engine flat while this rises is relay-side cost.

It times the whole handling path — folding the patch into the cached board, deciding whether an older seat needs a full board, and handing it to the audience. Labelled by seats because the node emits one envelope per seat plus an observer, so the work per decision scales with the room even when the engine's time does not. Cardinality is 2-4.

A histogram rather than a summary, so it aggregates across instances; the existing summaries cannot, which is why `max by (stage)` over the fleet was never a fleet p99.

## Test plan

- `cargo check`, `cargo clippy` zero warnings, `cargo fmt` clean.
- `cargo test -p manabrew-server`: 16 pass.
- Full `yarn lint:all` green via the pre-commit hook.
- Dashboard JSON validated.
- Recorded on both exits of the envelope path, including the one where delivery is skipped, so a room whose host has dropped still reports the work done.

## Notes

Touches the same region as #763, which rewrites the fold and the copy decision. Whichever lands second will need a small conflict resolution; the metric lines are independent of that change.

This does not measure the client leg. `manabrew_relay_client_rtt_ms` covers the heartbeat echo separately, and the node's `manabrew_node_relay_send_seconds` covers the node's send.
