### PR TITLE
feat(relay): measure the outbound write and its backlog

### DIFF
--- a/manabrew-rs/crates/manabrew-server/src/connection.rs
+++ b/manabrew-rs/crates/manabrew-server/src/connection.rs
@@ -108,7 +108,11 @@ fn authorize_game_message(
 /// Background task: drains channel and writes to the WebSocket sink.
 async fn write_loop(mut rx: mpsc::UnboundedReceiver<Message>, mut sink: WsSender) {
     while let Some(msg) = rx.recv().await {
-        if sink.send(msg).await.is_err() {
+        let backlog = rx.len();
+        let started = Instant::now();
+        let sent = sink.send(msg).await;
+        metrics::record_socket_write(backlog, started.elapsed());
+        if sent.is_err() {
             break;
         }
     }

--- a/manabrew-rs/crates/manabrew-server/src/metrics.rs
+++ b/manabrew-rs/crates/manabrew-server/src/metrics.rs
@@ -20,6 +20,8 @@ const DECK_PLAY_EVENTS_DROPPED: &str = "manabrew_relay_deck_play_events_dropped_
 const STATE_PATCH_DOWNGRADES: &str = "manabrew_relay_state_patch_downgrades_total";
 const CLIENT_RTT: &str = "manabrew_relay_client_rtt_ms";
 const STATE_HANDLING: &str = "manabrew_relay_state_handling_seconds";
+const SOCKET_WRITE: &str = "manabrew_relay_socket_write_seconds";
+const OUTBOUND_BACKLOG: &str = "manabrew_relay_outbound_backlog";
 
 const LABEL_KIND: &str = "kind";
 const LABEL_STATUS: &str = "status";
@@ -53,6 +55,8 @@ const STATE_HANDLING_BUCKETS: &[f64] = &[
     0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0,
 ];
 
+const BACKLOG_BUCKETS: &[f64] = &[1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 512.0, 2048.0];
+
 fn builder() -> PrometheusBuilder {
     PrometheusBuilder::new()
         .set_buckets_for_metric(
@@ -60,6 +64,13 @@ fn builder() -> PrometheusBuilder {
             STATE_HANDLING_BUCKETS,
         )
         .expect("state handling buckets are a non-empty literal")
+        .set_buckets_for_metric(
+            Matcher::Full(SOCKET_WRITE.to_string()),
+            STATE_HANDLING_BUCKETS,
+        )
+        .expect("socket write buckets are a non-empty literal")
+        .set_buckets_for_metric(Matcher::Full(OUTBOUND_BACKLOG.to_string()), BACKLOG_BUCKETS)
+        .expect("backlog buckets are a non-empty literal")
 }
 
 pub fn install() -> PrometheusHandle {
@@ -84,6 +95,20 @@ pub fn detached_handle() -> PrometheusHandle {
 /// in a script, after the fact, on a box.
 pub fn record_state_handling(seats: usize, elapsed: std::time::Duration) {
     histogram!(STATE_HANDLING, LABEL_SEATS => seats.to_string()).record(elapsed.as_secs_f64());
+}
+
+/// The websocket write itself, and how many messages were already waiting when
+/// this one was taken off the queue.
+///
+/// Everything else between the engine and the player is now measured; this was
+/// the last gap. The outbound channel is unbounded and the writer awaits the
+/// sink, so a client that stops draining applies backpressure and every later
+/// message queues behind it. That is invisible in the handling metric, which
+/// stops at the hand-off, and it grows with seat count because a four-seat room
+/// enqueues five envelopes per decision where a two-seat room enqueues three.
+pub fn record_socket_write(backlog: usize, elapsed: std::time::Duration) {
+    histogram!(SOCKET_WRITE).record(elapsed.as_secs_f64());
+    histogram!(OUTBOUND_BACKLOG).record(backlog as f64);
 }
 
 pub fn record_game_started(engine: EngineKind) {

--- a/ops/observability/grafana/dashboards/live-ops.json
+++ b/ops/observability/grafana/dashboards/live-ops.json
@@ -29,6 +29,70 @@
   ],
   "panels": [
     {
+      "id": 108,
+      "type": "timeseries",
+      "title": "Outbound socket write and backlog",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "The last unmeasured segment between the engine and the player. The outbound channel is unbounded and the writer awaits the sink, so a client that stops draining applies backpressure and every later message queues behind it. Backlog is how many messages were already waiting when this one was written. A rising backlog with flat handling time means the cost is a slow consumer, not the relay's own work. Backlog is a count, not seconds; read it against the right axis.",
+      "gridPos": {
+        "x": 12,
+        "y": 74,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(manabrew_relay_socket_write_seconds_bucket[30m])))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "legendFormat": "write p99 (s)"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(manabrew_relay_outbound_backlog_bucket[30m])))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "legendFormat": "backlog p99 (messages)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "backlog p99 (messages)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
       "id": 107,
       "type": "timeseries",
       "title": "Relay state handling p99 by seats",


### PR DESCRIPTION
## Summary

- Time the websocket write in the relay's writer task, and record how many messages were already queued when each one was taken off.
- Add a dashboard panel plotting both.

## Why

This was the last unmeasured segment between the engine and the player.

`manabrew_relay_state_handling_seconds` (#767) stops at the hand-off to the audience. `send_msg` then pushes into an **unbounded** channel and the writer task awaits `sink.send()`, so a client that stops draining applies backpressure and every later message for that connection queues behind it. None of that appears in any existing metric.

That shape fits what we still cannot explain. With #767 live, relay handling measures **28.6ms per decision at four seats against 4.9ms at two** — a clean 5.8x that confirms the seat scaling, but milliseconds where the unexplained tail is seconds. A queue behind a slow consumer is the one mechanism left in this path that can hold seconds, and it grows with seat count for the same reason handling does: a four-seat room enqueues five envelopes per decision where a two-seat room enqueues three.

Recording the backlog alongside the duration separates the two causes rather than conflating them:

- backlog rising, write flat → a slow consumer, and the latency is queueing
- write rising → the socket itself, and the latency is the network or TLS

## Test plan

- `cargo check`, `cargo clippy` zero warnings, `cargo fmt` clean.
- `cargo test -p manabrew-server`: 16 pass.
- Full `yarn lint:all` green via the pre-commit hook.
- Dashboard JSON validated; the backlog series is overridden to a count unit on the right axis, since plotting a message count against a seconds axis would be unreadable.

## Notes

Deliberately measured in the writer rather than by timestamping each message. Carrying an enqueue `Instant` through the channel would give true residency, but the channel item type appears in `ServerState` and a dozen signatures. Backlog plus write duration answers the same question in one place; if residency turns out to be needed, that is the follow-up.

Unlabelled on purpose. Per-connection labels would be unbounded cardinality, and the question here is distribution across the fleet, not which socket.

This does not change behaviour. The unbounded channel is left as it is: bounding it would drop messages under load, which is a product decision rather than an instrumentation one, and worth taking only once this metric shows whether it happens at all.
