### PR TITLE
docs(protocol): explain the two protocol versions, document state patches

### DIFF
--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -23,5 +23,7 @@ import type { Prompt, PromptInput, PromptOutput } from "@manabrew/protocol";
 import { VERSION, PROTOCOL_VERSION } from "@manabrew/protocol";
 ```
 
-`VERSION` is the package version; `PROTOCOL_VERSION` is the integer wire version
-a client must match to interoperate.
+`PROTOCOL_VERSION` is the integer wire version a client must report to a relay
+to interoperate. It is the major of `manabrew-relay-protocol`, so it only moves
+on a breaking wire change. `VERSION` is the version of the crate the bindings
+were generated from; it is not the version of this package.

--- a/website/src/content/docs/protocol/index.mdx
+++ b/website/src/content/docs/protocol/index.mdx
@@ -13,9 +13,25 @@ that implements it can host the Manabrew engine. This section documents the
 protocol so you can implement it for your own engine.
 
 :::note[Versioning]
-This is **v1** of the protocol, versioned as the
-[`manabrew-protocol`](https://crates.io/crates/manabrew-protocol) crate under
-[semantic versioning](https://semver.org/).
+Two numbers describe this protocol. They answer different questions.
+
+**The release version** is the [semantic version](https://semver.org/) of the
+[`manabrew-protocol`](https://crates.io/crates/manabrew-protocol) crate and of
+the [`@manabrew/protocol`](https://www.npmjs.com/package/@manabrew/protocol) npm
+package generated from it. One job publishes both at the same number, so a
+version pins the same message shapes on either side of the wire. It moves on
+every change to these messages, additive ones included. This page documents the
+current release; the crates.io link gives what that is today.
+
+**The wire version** is the `PROTOCOL_VERSION` integer in the relay handshake.
+A client and a relay must report the same one to talk at all. It is the major
+of the [`manabrew-relay-protocol`](https://crates.io/crates/manabrew-relay-protocol)
+crate, which owns the envelopes on [Transport](/protocol/transport/), so a
+breaking wire change ships as a major release of that crate and never as a
+separate constant. Most releases leave it untouched.
+
+A high release version does not mean the protocol has been rewritten that many
+times. It means the message set has grown.
 :::
 
 ## Goals

--- a/website/src/content/docs/protocol/transport.mdx
+++ b/website/src/content/docs/protocol/transport.mdx
@@ -27,18 +27,19 @@ the engine host and the remote clients (the reference relay is
 opaque `state` value inside the relay's own envelope, discriminated by a `kind`
 field:
 
-| `kind`      | Direction                      | Payload                                                                                            |
-| ----------- | ------------------------------ | -------------------------------------------------------------------------------------------------- |
-| `state`     | engine host → remote client    | `{ "kind": "state", "forPlayer": "player-N"?, "state": <StateUpdate> }`                             |
-| `display`   | engine host → all              | `{ "kind": "display", "event": <DisplayEvent> }`                                                    |
-| `prompt`    | engine host → remote client    | `{ "kind": "prompt", "forPlayer": "player-N", "prompt": <AgentPrompt> }`                            |
-| `error`     | engine host → remote client    | `{ "kind": "error", "forPlayer": "player-N", "error": <ProtocolError> }`                            |
-| `response`  | remote client → engine host    | `{ "kind": "response", "fromPlayer": "player-N", "promptId": <n>, "action": <PromptOutput> }`       |
-| `directive` | remote client → engine host    | `{ "kind": "directive", "fromPlayer": "player-N", "directive": <DirectiveInput> }`                  |
-| `log`       | engine host → all              | `{ "kind": "log", "fromPlayer": "player-N", "entry": <GameLogEntry> }`                              |
-| `snapshot`  | engine host → joining observer | `{ "kind": "snapshot", "fromPlayer": "player-N", "entry": <GameSnapshot> }`                         |
-| `fatal`     | engine host → all              | `{ "kind": "fatal", "message": <string> }` — the engine died; the session is over                   |
-| `roomRelay` | any → any                      | room-control messages (e.g. bot lifecycle) — implementation defined                                 |
+| `kind`       | Direction                      | Payload                                                                                                           |
+| ------------ | ------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `state`      | engine host → remote client    | `{ "kind": "state", "forPlayer": "player-N"?, "state": <StateUpdate>, "fingerprint": <string>? }`                 |
+| `stateDelta` | engine host → remote client    | `{ "kind": "stateDelta", "forPlayer": "player-N"?, "base": <string>, "fingerprint": <string>, "patch": <Patch> }` |
+| `display`    | engine host → all              | `{ "kind": "display", "event": <DisplayEvent> }`                                                                  |
+| `prompt`     | engine host → remote client    | `{ "kind": "prompt", "forPlayer": "player-N", "prompt": <AgentPrompt> }`                                          |
+| `error`      | engine host → remote client    | `{ "kind": "error", "forPlayer": "player-N", "error": <ProtocolError> }`                                          |
+| `response`   | remote client → engine host    | `{ "kind": "response", "fromPlayer": "player-N", "promptId": <n>, "action": <PromptOutput> }`                     |
+| `directive`  | remote client → engine host    | `{ "kind": "directive", "fromPlayer": "player-N", "directive": <DirectiveInput> }`                                |
+| `log`        | engine host → all              | `{ "kind": "log", "fromPlayer": "player-N", "entry": <GameLogEntry> }`                                            |
+| `snapshot`   | engine host → joining observer | `{ "kind": "snapshot", "fromPlayer": "player-N", "entry": <GameSnapshot> }`                                       |
+| `fatal`      | engine host → all              | `{ "kind": "fatal", "message": <string> }` — the engine died; the session is over                                 |
+| `roomRelay`  | any → any                      | room-control messages (e.g. bot lifecycle) — implementation defined                                               |
 
 `prompt` and `error` envelopes are private. Engine hosts send them with the
 relay's `BroadcastState.target_player` set to the deciding player's username;
@@ -57,9 +58,60 @@ the rest of the game. Prompts and errors are likewise acted on only when
 
 The reference relay can deliver an envelope to a single room member instead of
 broadcasting, and caches the last state per seat so a reconnecting client
-resyncs into its own view. Relays never read inside `state`.
+resyncs into its own view. Relays route on the envelope, not on the game state
+inside it. A relay that caches states also folds patches into that cache, as
+described below, so what it holds for a seat is always a whole board.
 
 The lobby/room-control layer that wraps this (authentication, room creation,
 ready state, …) is specific to the reference relay and beyond the scope of the
 wire protocol itself. Implementations MAY define additional `kind` values;
 consumers MUST ignore unknown `kind` values rather than treating them as errors.
+
+## State patches
+
+A full board is large and most updates change little of it, so an engine host
+MAY send a `stateDelta` instead of a `state`. A `stateDelta` is a patch against
+the last state that seat received, not a board.
+
+Both envelopes carry a `fingerprint`: a content hash of the `state` value they
+resolve to. A `stateDelta` also carries `base`, the fingerprint of the state it
+was diffed against. For each seat it tracks, a client keeps the fingerprint of
+the last state it applied. When `base` does not match the fingerprint it holds,
+the client MUST drop the patch and keep the board it already has. It recovers on
+the next full `state`. The reference hash is FNV-1a over key-sorted JSON, so both
+sides agree without depending on map iteration order.
+
+Patches are optional on both sides. An engine host MAY always send full states.
+A client that does not implement them ignores the `stateDelta` kind, like any
+other unknown kind, and a relay that caches states SHOULD fold a patch back into
+a full `state` for any recipient that cannot apply one. The reference relay
+decides that from the client build reported in the handshake.
+
+### Patch encoding
+
+A patch mirrors the shape of the value it edits. Four reserved keys, all
+prefixed with `$`, carry the operations:
+
+| Key  | Meaning                                                                |
+| ---- | ---------------------------------------------------------------------- |
+| `$v` | Literal replacement. The value under it replaces the target outright.  |
+| `$d` | Removal. An array of object keys, or of array element keys, to delete. |
+| `$k` | Keyed array edits. An object of element key to patch.                  |
+| `$o` | Keyed array order. The full list of element keys, in their new order.  |
+
+Objects merge: every other key is a patch applied to the value at that key, and
+a key absent from the patch is unchanged. Values that are not objects appear as
+themselves, so `null` and numbers survive without a sentinel. An object that
+must replace rather than merge is wrapped in `$v`.
+
+Arrays take one of two forms. Where every element carries a **stable key**, the
+patch edits them one by one under `$k`, with `$d` for removals and `$o` when the
+order changes; `$o` is omitted when the order is unchanged. The element key
+is the element's `id`, or `"<zone>/<ownerId>"` for zone entries, which have no
+id of their own. Any other array is replaced whole, as a literal.
+
+Applying `$k` for a key that is not present inserts the element and appends it
+to the order, so a patch can add cards as well as change them.
+
+The reference implementation of both sides is `state_delta` in
+[`manabrew-relay-protocol`](https://crates.io/crates/manabrew-relay-protocol).


### PR DESCRIPTION
The protocol docs said "This is **v1** of the protocol" while the crate reads 5.2.0. That is where the confusion in Discord starts.

There are actually three numbers in play and the docs named none of them:

- `manabrew-protocol` 5.2.0 on crates.io, which is also the `@manabrew/protocol` npm version. Moves on every message change.
- `manabrew-relay-protocol` 5.4.1, which owns the relay envelopes.
- `PROTOCOL_VERSION` = 5, the handshake integer, defined as the major of `manabrew-relay-protocol`.

The versioning note now separates the release version from the wire version and says outright that a high release number means the message set grew, not that the protocol was rewritten.

Two other things were stale:

- The transport envelope table listed nine kinds and was missing `stateDelta`, plus the `fingerprint` field on `state`. Since STATE_DELTA defaults on, an implementer following the table would drop most of what we send. Added a **State patches** section covering the envelope, the `base`/`fingerprint` check, the relay downgrade, and the `$v`/`$d`/`$k`/`$o` patch encoding.
- `packages/protocol/README.md` claimed the exported `VERSION` is the package version. It is not: `gen_protocol` writes `CARGO_PKG_VERSION` of `manabrew-relay-protocol` (5.4.1) while the package publishes at the `manabrew-protocol` version (5.2.0). Corrected the sentence.

Docs-only. `astro build` clean, `yarn lint:all` clean.

## Follow-up worth deciding separately

`VERSION` in `@manabrew/protocol` is genuinely the wrong number, not just badly documented. Either point the generator at `manabrew-protocol`'s version or drop the export. Left alone here because it is a published-API change, not a docs fix.