### PR TITLE
ci: build the landing page and docs site on PRs

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -30,6 +30,7 @@ jobs:
       run_rust: ${{ steps.scope.outputs.run_rust }}
       run_native: ${{ steps.scope.outputs.run_native }}
       run_forge_room: ${{ steps.scope.outputs.run_forge_room }}
+      run_website: ${{ steps.scope.outputs.run_website }}
     steps:
       - name: Classify changed files
         id: scope
@@ -73,6 +74,22 @@ jobs:
               '.github/workflows/build-checks.yml',
             ];
 
+            // The landing page + docs site. Nothing else in CI builds it: it is
+            // baked into the web image at release time (Dockerfile.web runs
+            // `yarn build` in website/ and copies dist/landing + dist/docs into
+            // /srv), so before this job a broken MDX page merged green and only
+            // surfaced on the next tag. The site's imports escape website/ —
+            // `../images`, `../public`, `../src` — which is why an asset move
+            // outside it can break the build and belongs in this list.
+            const WEBSITE_PATHS = [
+              'website/',
+              'images/',
+              'src/themes/',
+              'src/assets/manaBrew.png',
+              'public/manabrew_brewery_1.png',
+              '.github/workflows/build-checks.yml',
+            ];
+
             // The mobile shells: the tauri crate plus everything the native
             // binaries link (the Rust workspace + card data) and the JS
             // toolchain that drives `tauri build` itself. Pure UI changes are
@@ -94,7 +111,13 @@ jobs:
             ];
 
             if (context.eventName !== 'pull_request') {
-              for (const key of ['run_checks', 'run_rust', 'run_native', 'run_forge_room']) {
+              for (const key of [
+                'run_checks',
+                'run_rust',
+                'run_native',
+                'run_forge_room',
+                'run_website',
+              ]) {
                 core.setOutput(key, 'true');
               }
               return;
@@ -111,6 +134,41 @@ jobs:
             core.setOutput('run_rust', matches(files, RUST_PATHS) ? 'true' : 'false');
             core.setOutput('run_native', matches(files, NATIVE_PATHS) ? 'true' : 'false');
             core.setOutput('run_forge_room', matches(files, FORGE_ROOM_PATHS) ? 'true' : 'false');
+            core.setOutput('run_website', matches(files, WEBSITE_PATHS) ? 'true' : 'false');
+
+  # ── Website: landing page + docs site ──────────────────────────────
+  # Deliberately NOT gated on `run_checks`. A website-only PR sets that to
+  # false, which is precisely the case where this is the only build that can
+  # fail — gating on it would leave the gap this job exists to close.
+  #
+  # Runs the same `yarn build` (both Astro configs) that Dockerfile.web's
+  # website stage runs, so a green job here means the next image build of the
+  # same tree succeeds.
+  website:
+    name: Website (landing + docs)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.run_website == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: yarn
+          cache-dependency-path: website/yarn.lock
+
+      - name: Install Yarn
+        run: npm install --global yarn
+
+      - name: Install dependencies
+        working-directory: website
+        run: yarn install --frozen-lockfile
+
+      - name: Build landing + docs
+        working-directory: website
+        run: yarn build
 
   # ── TypeScript type-check ──────────────────────────────────────────
   # Builds the wasm bundle (or restores it from cache) and uploads it as an


### PR DESCRIPTION
Follow-up to #777, which went in unverified by CI. Nothing in this repo has ever built the website.

## The gap

The site is not separately deployed. It ships inside the web image:

- `Dockerfile.web:118-130` — a `website` stage runs `yarn build` (both Astro configs)
- `Dockerfile.web:139-140` — copies `dist/landing` and `dist/docs` into `/srv`
- `ops/web.Caddyfile:182` — Caddy serves `/srv/docs` as docs.manabrew.app

So the only thing that builds it is a tagged release. A malformed MDX page or a bad Starlight component merged green and surfaced hours later on the release, and there is no docs-only deploy to fix it with.

The one docs-adjacent job, `protocol-docs.yml`, only checks that `website/src/generated/protocol-types.json` has not drifted. It is path-gated to the protocol crates, so it correctly skips for content changes and never builds anything.

Worse, the gap is widest where the site actually changes. `build-checks.yml:109`:

```js
const websiteOnly = files.length > 0 && files.every((file) => file.filename.startsWith('website/'));
core.setOutput('run_checks', websiteOnly ? 'false' : 'true');
```

A PR touching nothing but `website/` turns the remaining checks off, so it ran no build whatsoever. #777 only got `Web build (full)` and `TypeScript & Wasm` because it happened to also touch `packages/protocol/README.md`.

## The job

`Website (landing + docs)`, gated on a new `run_website` output. **Not** gated on `run_checks` — that is the whole point, since `run_checks` is false exactly when this job is the only one that can fail.

Runs the same `yarn build` as the image stage, so green here means the next image build of the same tree succeeds.

Path list covers the assets the site imports from outside its own directory (`images/`, `src/themes/`, and the two named files). Those imports escape `website/` via `../images`, `../public`, `../src`, which is why `Dockerfile.web` copies them in and why moving one can break the build.

## Verification

- `yarn install --frozen-lockfile && yarn build` in `website/` from a clean checkout — both builds pass, 42 docs pages, **7.5s** total. Cheapest job in the workflow.
- Confirmed it actually fails: appended an unclosed `<Card>` to `protocol/index.mdx`, build exited non-zero; reverted, green again. A job that cannot fail would have been worse than no job.
- `prettier --check` clean; workflow parses and the `changes` job exposes `run_website`.

## Not done

Left `websiteOnly` alone. Skipping the wasm and Rust builds for a content-only PR is a sound saving and this job removes the harm in it. Happy to revisit separately if you would rather it went.