### PR TITLE
fix(protocol): export the package's own version as VERSION

### DIFF
--- a/manabrew-rs/crates/manabrew-protocol/src/lib.rs
+++ b/manabrew-rs/crates/manabrew-protocol/src/lib.rs
@@ -1,6 +1,16 @@
 //! Engine-free DTOs shared by the game clients: decks, the game-domain types,
 //! prompts, display events and the agent transport envelopes. The relay wire
 //! protocol lives in `manabrew-relay-protocol`, which depends on this crate.
+/// This crate's version, which is also the version `@manabrew/protocol`
+/// publishes at: `publish-protocol.yml` reads it out of this crate's
+/// `Cargo.toml` and passes it to `npm version`. The generated `VERSION`
+/// constant in the npm package is this string, so a consumer comparing
+/// `VERSION` against the version they installed gets a match.
+///
+/// Distinct from `manabrew_relay_protocol::PROTOCOL_VERSION`, the integer
+/// handshake number, which is that crate's major.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub mod deck_dto;
 pub mod display;
 pub mod game;

--- a/manabrew-rs/crates/manabrew-relay-protocol/src/bin/gen_protocol.rs
+++ b/manabrew-rs/crates/manabrew-relay-protocol/src/bin/gen_protocol.rs
@@ -78,11 +78,17 @@ fn main() {
     )
     .expect("write transport/index.ts");
 
+    // `VERSION` is the npm package's own version, so it must come from
+    // `manabrew-protocol` (which `publish-protocol.yml` publishes the package
+    // at), NOT from `CARGO_PKG_VERSION` of this generator crate. Those are
+    // different crates on independent version lines, and using this one made
+    // `VERSION` disagree with the installed package version (#777).
     fs::write(
         out.join("version.ts"),
         format!(
-            "{HEADER}export const VERSION = \"{}\";\nexport const PROTOCOL_VERSION = {PROTOCOL_VERSION};\n",
-            env!("CARGO_PKG_VERSION")
+            "{HEADER}export const VERSION = \"{}\";\nexport const RELAY_PROTOCOL_VERSION = \"{}\";\nexport const PROTOCOL_VERSION = {PROTOCOL_VERSION};\n",
+            manabrew_protocol::VERSION,
+            env!("CARGO_PKG_VERSION"),
         ),
     )
     .expect("write version.ts");

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -20,10 +20,13 @@ npm install @manabrew/protocol
 
 ```ts
 import type { Prompt, PromptInput, PromptOutput } from "@manabrew/protocol";
-import { VERSION, PROTOCOL_VERSION } from "@manabrew/protocol";
+import { VERSION, PROTOCOL_VERSION, RELAY_PROTOCOL_VERSION } from "@manabrew/protocol";
 ```
+
+`VERSION` is this package's own version, matching what you installed.
 
 `PROTOCOL_VERSION` is the integer wire version a client must report to a relay
 to interoperate. It is the major of `manabrew-relay-protocol`, so it only moves
-on a breaking wire change. `VERSION` is the version of the crate the bindings
-were generated from; it is not the version of this package.
+on a breaking wire change, and most releases leave it alone.
+`RELAY_PROTOCOL_VERSION` is that crate's full version, for anyone who needs to
+tell two releases apart at the same wire version.

--- a/website/src/content/docs/protocol/index.mdx
+++ b/website/src/content/docs/protocol/index.mdx
@@ -18,8 +18,9 @@ Two numbers describe this protocol. They answer different questions.
 **The release version** is the [semantic version](https://semver.org/) of the
 [`manabrew-protocol`](https://crates.io/crates/manabrew-protocol) crate and of
 the [`@manabrew/protocol`](https://www.npmjs.com/package/@manabrew/protocol) npm
-package generated from it. One job publishes both at the same number, so a
-version pins the same message shapes on either side of the wire. It moves on
+package generated from it. One job publishes both at the same number, and the
+package re-exports it as `VERSION`, so a version pins the same message shapes on
+either side of the wire. It moves on
 every change to these messages, additive ones included. This page documents the
 current release; the crates.io link gives what that is today.
 


### PR DESCRIPTION
The known defect flagged in #777.

`@manabrew/protocol` publishes at the `manabrew-protocol` version — `publish-protocol.yml` greps it out of that crate's `Cargo.toml` and passes it to `npm version`. But the generated `VERSION` constant was `env!("CARGO_PKG_VERSION")` evaluated in `manabrew-relay-protocol`, the crate that owns the `gen-protocol` bin.

Those are separate crates on independent version lines. The result shipped today:

```ts
// inside @manabrew/protocol@5.2.0
export const VERSION = "5.4.1";
```

So the one constant a consumer would reach for to answer "which version of this package am I on" answered with a different crate's version.

## Change

`VERSION` now comes from `manabrew_protocol::VERSION`, a new `pub const` on the crate the npm version is read from, so the two cannot drift apart again.

The relay crate's version is still exported, under a name that says what it is:

```ts
export const VERSION = "5.2.1";                 // this package
export const RELAY_PROTOCOL_VERSION = "5.4.2";  // the wire/envelope crate
export const PROTOCOL_VERSION = 5;              // handshake integer, unchanged
```

`RELAY_PROTOCOL_VERSION` is additive and worth keeping: `PROTOCOL_VERSION` only moves on a breaking wire change, so it cannot distinguish two relay releases at the same major.

`PROTOCOL_VERSION` is untouched.

## Verification

- `cargo run -p manabrew-relay-protocol --bin gen-protocol` — emits the three constants above.
- `yarn gen:types` — regenerates `src/protocol/version.ts` clean.
- `yarn lint:all` — clean.
- `cargo xtask plan` — `manabrew-protocol 5.2.0 -> 5.2.1`, cascading a patch to the app (`manabrew 3.22.0 -> 3.22.1`). So the package will publish as 5.2.1 with `VERSION = "5.2.1"`, self-consistent on the first release after this.

Also corrected the `packages/protocol/README.md` sentence #777 added, which described the old (wrong) behaviour, and the one clause on the docs versioning page that referred to it.

## Note on scope

This is deliberately a `fix`, not a `fix!`. No type signature changes and nothing is removed; a value that was simply wrong becomes right. Anyone who was comparing `VERSION` to their installed version was already getting a mismatch.