### PR TITLE
fix(telemetry): label the engine that ran, and stop losing reports

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -103,8 +103,14 @@ Everything about how fast an engine answers, in one place. The hosted half was t
 | Games reported per day by engine           | timeseries | `engine_stats` count by day and engine, which is also browser-engine adoption                                     |
 | forge-wasm think time against turnaround   | timeseries | `engine_p50` against `turnaround_p50`; only the browser build reports its own think time                          |
 | Client versions reporting                  | table      | `client_version`, `platform`, `engine`, games, average duration                                                   |
+| Games with a player, and how many reported | timeseries | `games` with a human seat against those with an `engine_stats` row, per day                                       |
+| Engine reports at the relay, by outcome    | timeseries | `sum by (outcome) (increase(manabrew_relay_engine_reports_total[1h]))`                                            |
 
 Turnaround is measured on the client: the answer leaving to the next prompt landing. It includes the network for a hosted engine and nothing but the engine for a local one, which is what makes the engines comparable at all. Per-game percentiles are aggregated as medians across games, never as an average of averages. A game reports once, when it ends, and only if it had at least five decisions in it.
+
+`engine` names what ran, not what the room asked for: `forge-hosted` (a self-hosted node), `forge-desktop` (the desktop build hosting its own room), `forge-wasm` (the browser build), `manabrew`, `ironsmith`. The label is fixed when the game starts, because a hosted game is driven through the Manabrew runtime like any other and cannot be recognised afterwards.
+
+The last two panels are the ones to read before believing any of the others. A report that is never sent, or that arrives after the seat is gone, leaves no row anywhere: the engine panels above simply undercount, silently and without a gap in the series.
 
 ### Analytics Explorer (`product.json`)
 
@@ -156,6 +162,7 @@ Defined in `manabrew-rs/crates/manabrew-server/src/metrics.rs`, served on the he
 | `manabrew_relay_players`                        | gauge   | `kind`, `status`                |
 | `manabrew_relay_rooms`                          | gauge   | `status`, `hosted`              |
 | `manabrew_relay_games_started_total`            | counter | `engine`                        |
+| `manabrew_relay_engine_reports_total`           | counter | `outcome`                       |
 | `manabrew_relay_games_ended_total`              | counter | `reason`                        |
 | `manabrew_relay_client_rejections_total`        | counter | `reason` (e.g. `outdated_wire`) |
 | `manabrew_relay_reconnect_resyncs_total`        | counter | —                               |

--- a/manabrew-rs/crates/manabrew-server/src/connection.rs
+++ b/manabrew-rs/crates/manabrew-server/src/connection.rs
@@ -1249,6 +1249,7 @@ fn handle_client_message(
 
         ClientMessage::ReportEngineStats { game_id, stats } => {
             if !stats.is_plausible() {
+                metrics::record_engine_report(metrics::ENGINE_REPORT_IMPLAUSIBLE);
                 debug!(
                     "[analytics] '{}' sent an implausible engine report",
                     username
@@ -1257,12 +1258,14 @@ fn handle_client_message(
             }
             let room_id = state.players.get(player_id).and_then(|p| p.room_id.clone());
             let Some(room_id) = room_id else {
+                metrics::record_engine_report(metrics::ENGINE_REPORT_OUTSIDE_ROOM);
                 debug!(
                     "[analytics] '{}' reported engine stats outside a room",
                     username
                 );
                 return;
             };
+            metrics::record_engine_report(metrics::ENGINE_REPORT_ACCEPTED);
             state.analytics.emit(AnalyticsEvent::EngineStats {
                 ts: analytics::now_ts(),
                 room_id,

--- a/manabrew-rs/crates/manabrew-server/src/metrics.rs
+++ b/manabrew-rs/crates/manabrew-server/src/metrics.rs
@@ -18,6 +18,7 @@ const SESSION_TAKEOVERS: &str = "manabrew_relay_session_takeovers_total";
 const ANALYTICS_DROPPED: &str = "manabrew_relay_analytics_dropped_total";
 const DECK_PLAY_EVENTS_DROPPED: &str = "manabrew_relay_deck_play_events_dropped_total";
 const STATE_PATCH_DOWNGRADES: &str = "manabrew_relay_state_patch_downgrades_total";
+const ENGINE_REPORTS: &str = "manabrew_relay_engine_reports_total";
 const CLIENT_RTT: &str = "manabrew_relay_client_rtt_ms";
 const STATE_HANDLING: &str = "manabrew_relay_state_handling_seconds";
 const SOCKET_WRITE: &str = "manabrew_relay_socket_write_seconds";
@@ -29,8 +30,13 @@ const LABEL_HOSTED: &str = "hosted";
 const LABEL_ENGINE: &str = "engine";
 const LABEL_REASON: &str = "reason";
 const LABEL_SEATS: &str = "seats";
+const LABEL_OUTCOME: &str = "outcome";
 
 pub const REJECTION_OUTDATED_WIRE: &str = "outdated_wire";
+
+pub const ENGINE_REPORT_ACCEPTED: &str = "accepted";
+pub const ENGINE_REPORT_OUTSIDE_ROOM: &str = "outside_room";
+pub const ENGINE_REPORT_IMPLAUSIBLE: &str = "implausible";
 
 #[derive(Clone, Copy)]
 enum ConnectionKind {
@@ -128,6 +134,14 @@ pub fn record_rejection(reason: &'static str) {
 /// `SELF_HOSTED_NODE_STATE_DELTA` is saving bandwidth for everyone.
 pub fn record_state_patch_downgrade() {
     counter!(STATE_PATCH_DOWNGRADES).increment(1);
+}
+
+/// What became of a client's end-of-game engine report. Both drop paths are
+/// silent by design — a report is not worth an error to a player — so without
+/// a count the only visible symptom is a dashboard that undercounts games and
+/// no way to tell a client that never sent from a relay that threw it away.
+pub fn record_engine_report(outcome: &'static str) {
+    counter!(ENGINE_REPORTS, LABEL_OUTCOME => outcome).increment(1);
 }
 
 /// Round trip from the relay to a client and back, taken from the websocket

--- a/ops/observability/grafana/dashboards/engine-health.json
+++ b/ops/observability/grafana/dashboards/engine-health.json
@@ -1,6 +1,6 @@
 {
   "uid": "manabrew-engine-health",
-  "title": "Manabrew \u2014 Engine Health",
+  "title": "Manabrew — Engine Health",
   "tags": ["manabrew", "ops", "engine"],
   "schemaVersion": 39,
   "editable": true,
@@ -26,7 +26,7 @@
     {
       "id": 200,
       "type": "row",
-      "title": "Hosted engine \u2014 node fleet (#684 watch)",
+      "title": "Hosted engine — node fleet (#684 watch)",
       "collapsed": false,
       "gridPos": {
         "x": 0,
@@ -485,7 +485,7 @@
     {
       "id": 220,
       "type": "row",
-      "title": "Player-side engines \u2014 one report per finished game",
+      "title": "Player-side engines — one report per finished game",
       "collapsed": false,
       "gridPos": {
         "x": 0,
@@ -926,6 +926,95 @@
       ],
       "fieldConfig": {
         "defaults": {},
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 240,
+      "type": "row",
+      "title": "Are the reports arriving?",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 71,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 241,
+      "type": "timeseries",
+      "title": "Games with a player, and how many of them reported",
+      "description": "The denominator for everything above. A client reports once per finished game with at least five decisions in it, so the two lines never meet — but a wide, persistent gap means reports are being lost, not that games are short. Games with only bots in them are excluded; they have no client to report. Reports that reach the hub instead of the relay carry no game id and cannot be joined, so they count in the panels above and not here.",
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "events-sqlite"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 72,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryText": "SELECT CAST(strftime('%s', date(g.started_at)) AS INTEGER) AS t, count(*) AS \"games with a player\", sum(CASE WHEN s.game_id IS NOT NULL THEN 1 ELSE 0 END) AS \"games reported\" FROM games g LEFT JOIN (SELECT DISTINCT game_id FROM engine_stats WHERE game_id IS NOT NULL) s ON s.game_id = g.game_id WHERE EXISTS (SELECT 1 FROM game_players p WHERE p.game_id = g.game_id AND p.is_bot = 0) AND CAST(strftime('%s', g.started_at) AS INTEGER) > $__from / 1000 AND CAST(strftime('%s', g.started_at) AS INTEGER) <= $__to / 1000 GROUP BY 1 ORDER BY 1",
+          "rawQueryText": "SELECT CAST(strftime('%s', date(g.started_at)) AS INTEGER) AS t, count(*) AS \"games with a player\", sum(CASE WHEN s.game_id IS NOT NULL THEN 1 ELSE 0 END) AS \"games reported\" FROM games g LEFT JOIN (SELECT DISTINCT game_id FROM engine_stats WHERE game_id IS NOT NULL) s ON s.game_id = g.game_id WHERE EXISTS (SELECT 1 FROM game_players p WHERE p.game_id = g.game_id AND p.is_bot = 0) AND CAST(strftime('%s', g.started_at) AS INTEGER) > $__from / 1000 AND CAST(strftime('%s', g.started_at) AS INTEGER) <= $__to / 1000 GROUP BY 1 ORDER BY 1",
+          "queryType": "table",
+          "timeColumns": ["t"]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 242,
+      "type": "timeseries",
+      "title": "Engine reports at the relay, by outcome",
+      "description": "What the relay did with the reports it was sent. Both drop paths are silent to the player by design: `outside_room` is a report that arrived after the seat was gone, `implausible` is a malformed or hostile one. Anything but `accepted` is invisible in every other panel here — the report simply never becomes a row. Offline games and games reported after the relay went away go to the hub and never appear on this panel at all.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 72,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (outcome) (increase(manabrew_relay_engine_reports_total[1h]))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "legendFormat": "{{outcome}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1,
+            "fillOpacity": 60
+          }
+        },
         "overrides": []
       },
       "options": {}

--- a/src/hooks/useGameEventListeners.ts
+++ b/src/hooks/useGameEventListeners.ts
@@ -9,6 +9,7 @@ import {
 import { teardownForgeAiSession } from "@/game/hostedAiPlay";
 import { reportEngineStats } from "@/lib/engineStatsReport";
 import { useGameStore } from "@/stores/useGameStore";
+import type { GameState } from "@/stores/useGameStore";
 import { useServerStore } from "@/stores/useServerStore";
 import { SELF_RECONNECT_WINDOW_S } from "@/hooks/useMultiplayerInterruption";
 import { clearActiveGameSession, peekActiveGameSession } from "@/lib/activeGameSession";
@@ -134,6 +135,27 @@ function toastOpponentPublicAction(entry: GameLogEntry) {
   }
 }
 
+function isOver(state: Pick<GameState, "gameView" | "currentPrompt">): boolean {
+  return (state.gameView?.gameOver ?? false) || isGameOverPrompt(state.currentPrompt);
+}
+
+/** Close the book on the current game. Safe to call more than once. */
+function reportEngineGame(): void {
+  const state = useGameStore.getState();
+  reportEngineStats({
+    multiplayer: state.isMultiplayer,
+    seats: Object.keys(state.gameDecks).length || 2,
+    format: state.gameConfig?.formatId ?? null,
+    endReason: state.gameView?.gameOver ? "gameOver" : "left",
+    gameId: useServerStore.getState().gameId ?? null,
+    send: state.isMultiplayer
+      ? async (stats, gameId) => {
+          await getPlatform().server?.reportEngineStats(stats, gameId);
+        }
+      : undefined,
+  });
+}
+
 /**
  * Sets up platform event listeners for the four engine→UI message families:
  * `state` (game view), `display` (animations), `prompt` (decisions) and
@@ -143,25 +165,18 @@ function toastOpponentPublicAction(entry: GameLogEntry) {
  */
 export function useGameEventListeners() {
   useEffect(() => {
-    const report = () => {
-      const state = useGameStore.getState();
-      reportEngineStats({
-        multiplayer: state.isMultiplayer,
-        seats: Object.keys(state.gameDecks).length || 2,
-        format: state.gameConfig?.formatId ?? null,
-        endReason: state.gameView?.gameOver ? "gameOver" : "left",
-        gameId: useServerStore.getState().gameId ?? null,
-        send: state.isMultiplayer
-          ? async (stats, gameId) => {
-              await getPlatform().server?.reportEngineStats(stats, gameId);
-            }
-          : undefined,
-      });
-    };
-    window.addEventListener("pagehide", report);
+    window.addEventListener("pagehide", reportEngineGame);
+    // A finished game is reported the moment it finishes, not at teardown:
+    // teardown is three seconds later, and by then the tab may be gone, the
+    // socket closed or a pooled hosted room recycled out from under the seat.
+    // Reporting twice is free — the summary is drained by the first caller.
+    const unsubscribe = useGameStore.subscribe((state, previous) => {
+      if (isOver(state) && !isOver(previous)) reportEngineGame();
+    });
     return () => {
-      window.removeEventListener("pagehide", report);
-      report();
+      window.removeEventListener("pagehide", reportEngineGame);
+      unsubscribe();
+      reportEngineGame();
     };
   }, []);
 

--- a/src/lib/engineStatsReport.test.ts
+++ b/src/lib/engineStatsReport.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.hoisted(() => vi.stubGlobal("__APP_VERSION__", "test"));
+
+const recordEngineStats = vi.fn<(stats: unknown) => Promise<void>>();
+
+vi.mock("@/api/hub", () => ({
+  recordEngineStats: (stats: unknown) => recordEngineStats(stats),
+  HubRequestError: class HubRequestError extends Error {
+    status = 500;
+  },
+}));
+
+vi.mock("@/platform", () => ({ getPlatform: () => ({ type: "web" }) }));
+
+import { reportEngineStats } from "@/lib/engineStatsReport";
+import { beginGame, noteAnswerSent, notePromptArrived } from "@/lib/engineTelemetry";
+
+function playSixDecisions(engine: string) {
+  beginGame(engine);
+  for (let i = 0; i < 6; i += 1) {
+    noteAnswerSent();
+    notePromptArrived("chooseAction");
+  }
+}
+
+describe("engine stats reporting", () => {
+  beforeEach(() => {
+    recordEngineStats.mockReset();
+    recordEngineStats.mockResolvedValue(undefined);
+    const store = new Map<string, string>();
+    vi.stubGlobal("window", {
+      localStorage: {
+        getItem: (key: string) => store.get(key) ?? null,
+        setItem: (key: string, value: string) => void store.set(key, value),
+      },
+    });
+  });
+
+  it("keeps a report the relay could not take, and sends it to the hub", async () => {
+    playSixDecisions("forge-hosted");
+    reportEngineStats({
+      multiplayer: true,
+      seats: 2,
+      format: "standard",
+      endReason: "gameOver",
+      gameId: "game-1",
+      send: () => Promise.reject(new Error("relay is not connected")),
+    });
+    await vi.waitFor(() => expect(recordEngineStats).toHaveBeenCalledTimes(1));
+    expect(recordEngineStats.mock.calls[0]?.[0]).toMatchObject({
+      engine: "forge-hosted",
+      multiplayer: true,
+      endReason: "gameOver",
+    });
+  });
+
+  it("reports a finished game once, however many times the game ends", () => {
+    playSixDecisions("forge-hosted");
+    const send = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const end = () =>
+      reportEngineStats({
+        multiplayer: true,
+        seats: 2,
+        format: "standard",
+        endReason: "gameOver",
+        gameId: "game-1",
+        send,
+      });
+    end();
+    end();
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/engineStatsReport.ts
+++ b/src/lib/engineStatsReport.ts
@@ -16,6 +16,7 @@ import { getPlatform } from "@/platform";
 import { getSelectedGameRuntimeKind } from "@/game/runtimeRegistry";
 import { isForgeWasmSelected } from "@/lib/forgeWasm";
 import { APP_VERSION, STORAGE_KEYS } from "@/lib/constants";
+import type { EngineKind } from "@/types/server";
 import type { EngineGameStats } from "@/lib/engineTelemetry";
 import { summariseGame } from "@/lib/engineTelemetry";
 
@@ -30,20 +31,39 @@ interface PendingReport {
 }
 
 /**
- * Which engine actually ran. Not the same question as which engine the room
- * asked for: a desktop build hosts Forge locally, and a browser with the
- * wasm engine enabled runs Forge for a room that calls itself Manabrew.
+ * Which engine actually ran, for a game whose rules engine is in this process.
+ *
+ * The browser Forge build runs under the "manabrew" runtime — it is the local
+ * engine, whatever the room calls it — so the label has to come from the engine
+ * selection rather than the runtime kind, or every wasm game would be filed as
+ * the Rust one.
  */
-export function currentEngineLabel(): string {
+export function localEngineLabel(): string {
   const kind = getSelectedGameRuntimeKind();
-  const platform = getPlatform().type;
-  // The browser Forge build runs under the "manabrew" runtime — it is the
-  // local engine, whatever the room calls it — so the label has to come from
-  // the engine selection rather than the runtime kind, or every wasm game
-  // would be filed as the Rust one.
   if (kind === "manabrew" && isForgeWasmSelected()) return "forge-wasm";
-  if (kind === "forge") return platform === "tauri" ? "forge-desktop" : "forge-hosted";
   return kind;
+}
+
+/**
+ * Forge, running outside this tab: on one of the hosted nodes, or on this
+ * machine when the desktop build hosts the room itself.
+ */
+export function forgeHostLabel(onThisMachine: boolean): string {
+  return onThisMachine ? "forge-desktop" : "forge-hosted";
+}
+
+/**
+ * The engine behind a relay room. The "forge" runtime kind is never selectable
+ * — a hosted room is driven through the Manabrew runtime like any other — so
+ * the room's own engine is the only thing that says Forge ran.
+ */
+export function roomEngineLabel(
+  engine: EngineKind | null | undefined,
+  hostedHere: boolean,
+): string {
+  if (engine === "Forge") return forgeHostLabel(hostedHere);
+  if (engine === "Ironsmith") return "ironsmith";
+  return localEngineLabel();
 }
 
 function loadPending(): PendingReport[] {
@@ -125,7 +145,6 @@ export function reportEngineStats(meta: {
   let stats: EngineGameStats | null = null;
   try {
     stats = summariseGame({
-      engine: currentEngineLabel(),
       clientVersion: APP_VERSION,
       platform: getPlatform().type,
       format: meta.format,
@@ -140,8 +159,11 @@ export function reportEngineStats(meta: {
   if (!stats) return;
   if (meta.multiplayer && meta.send) {
     void meta.send(stats, meta.gameId).catch(() => {
-      // The relay went away mid-report; the hub can have it instead.
+      // The relay went away mid-report; the hub can have it instead, and it can
+      // have it now — a closed websocket says nothing about the network, and a
+      // report left in the queue waits for the next time the app starts.
       queue(stats);
+      void flushEngineStatsReports();
     });
     return;
   }

--- a/src/lib/engineTelemetry.test.ts
+++ b/src/lib/engineTelemetry.test.ts
@@ -13,7 +13,6 @@ import {
 } from "@/lib/engineTelemetry";
 
 const meta = {
-  engine: "forge-wasm",
   clientVersion: "test",
   platform: "web",
   format: "standard",
@@ -43,7 +42,7 @@ describe("engine telemetry", () => {
   });
 
   it("measures the gap from an answer to the next prompt, and nothing else", () => {
-    beginGame();
+    beginGame("forge-wasm");
     // A prompt with no answer behind it is the engine speaking first, not a
     // turnaround: the opening prompt would otherwise report the whole boot.
     notePromptArrived("mulligan");
@@ -58,10 +57,11 @@ describe("engine telemetry", () => {
     expect(stats?.engineThink?.n).toBe(1);
     expect(stats?.byType[0]?.type).toBe("chooseAction");
     expect(stats?.clientVersion).toBe("test");
+    expect(stats?.engine).toBe("forge-wasm");
   });
 
   it("reports nothing for a game that barely started", () => {
-    beginGame();
+    beginGame("manabrew");
     noteAnswerSent();
     notePromptArrived("chooseAction");
     expect(summariseGame(meta)).toBeNull();
@@ -70,8 +70,17 @@ describe("engine telemetry", () => {
 
 describe("engine label", () => {
   it("names what actually ran, not what the room asked for", async () => {
-    const { currentEngineLabel } = await import("@/lib/engineStatsReport");
+    const { localEngineLabel, roomEngineLabel, forgeHostLabel } =
+      await import("@/lib/engineStatsReport");
     // The registry defaults to the Rust engine in a fresh module graph.
-    expect(currentEngineLabel()).toBe("manabrew");
+    expect(localEngineLabel()).toBe("manabrew");
+    // A hosted room is driven through that same runtime, so only the room's
+    // engine says Forge ran — this is the case that was filed as "manabrew"
+    // for every hosted game in production.
+    expect(roomEngineLabel("Forge", false)).toBe("forge-hosted");
+    expect(roomEngineLabel("Forge", true)).toBe("forge-desktop");
+    expect(roomEngineLabel("Ironsmith", false)).toBe("ironsmith");
+    expect(roomEngineLabel("Manabrew", false)).toBe("manabrew");
+    expect(forgeHostLabel(false)).toBe("forge-hosted");
   });
 });

--- a/src/lib/engineTelemetry.ts
+++ b/src/lib/engineTelemetry.ts
@@ -18,6 +18,7 @@ export interface Turnaround {
 export interface EngineGameStats {
   /** Client-generated, so a retry cannot double-count the game. */
   reportId: string;
+  /** Which engine actually ran; recorded at launch, see `beginGame`. */
   engine: string;
   clientVersion: string;
   platform: string;
@@ -48,6 +49,7 @@ let samples: Sample[] = [];
 let engineThink: number[] = [];
 let answeredAt: number | null = null;
 let startedAtMs: number | null = null;
+let engineLabel = "unknown";
 
 /** Percentiles over a copy, so the caller's array keeps its order. */
 export function summarise(values: number[]): Turnaround {
@@ -81,11 +83,20 @@ export function byPromptType(
     .slice(0, MAX_TYPES);
 }
 
-export function beginGame(): void {
+/**
+ * Start the clock for one game, and record which engine is about to run it.
+ *
+ * The label belongs here rather than at the end because only the launch knows
+ * it: a hosted game runs Forge on a node while the client still drives the
+ * relay through the Manabrew runtime, and the launch resets that runtime on the
+ * way in. Read afterwards, every hosted game looks like the Rust engine.
+ */
+export function beginGame(engine: string): void {
   samples = [];
   engineThink = [];
   answeredAt = null;
   startedAtMs = Date.now();
+  engineLabel = engine;
 }
 
 export function noteAnswerSent(): void {
@@ -106,7 +117,6 @@ export function noteEngineThinkTime(ms: number): void {
 }
 
 export function summariseGame(meta: {
-  engine: string;
   clientVersion: string;
   platform: string;
   format: string | null;
@@ -119,7 +129,7 @@ export function summariseGame(meta: {
   if (startedAtMs === null || samples.length < 5) return null;
   const stats: EngineGameStats = {
     reportId: meta.reportId,
-    engine: meta.engine,
+    engine: engineLabel,
     clientVersion: meta.clientVersion,
     platform: meta.platform,
     format: meta.format,

--- a/src/platform/web.ts
+++ b/src/platform/web.ts
@@ -1205,6 +1205,13 @@ class WebServerApi implements IServerApi {
   }
 
   async reportEngineStats(stats: EngineGameStats, gameId?: string | null): Promise<void> {
+    // `send` swallows a closed socket, which for a report means losing it
+    // silently: the caller queues for the hub only when this rejects, and a
+    // game that ends with the relay already gone is exactly the case the queue
+    // exists for.
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error("Relay is not connected; queue the engine report instead.");
+    }
     this.send({ type: "ReportEngineStats", game_id: gameId ?? null, stats });
   }
 

--- a/src/stores/useGameStore.ts
+++ b/src/stores/useGameStore.ts
@@ -1,5 +1,10 @@
 import { beginGame, noteAnswerSent } from "@/lib/engineTelemetry";
-import { reportEngineStats } from "@/lib/engineStatsReport";
+import {
+  forgeHostLabel,
+  localEngineLabel,
+  reportEngineStats,
+  roomEngineLabel,
+} from "@/lib/engineStatsReport";
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { toast } from "sonner";
@@ -204,7 +209,10 @@ async function initializeGame({
         gameDecks: hostedDecks,
         debugInfo: "Joining Forge engine...",
       });
-      beginGame();
+      // Forge runs on the node, or in the desktop app's own host — never in
+      // this tab, and never under a "forge" runtime, so the launch is the only
+      // place that can name it.
+      beginGame(forgeHostLabel(platformType === "tauri"));
       await hostedRuntime.api.startMultiplayerGame({
         playerNames: hostedLaunch.playerOrder,
         decks: hostedLaunch.decks,
@@ -260,7 +268,7 @@ async function initializeGame({
     debugInfo: "Starting engine...",
   });
 
-  beginGame();
+  beginGame(localEngineLabel());
   const result = await runtime.api.startGame({
     deck,
     startingLife,
@@ -505,7 +513,7 @@ export const useGameStore = create<GameState>()(
           const runtime =
             engine === "Ironsmith" ? selectGameRuntime("ironsmith") : resetSelectedGameRuntime();
           set({ debugInfo: "Starting engine..." });
-          beginGame();
+          beginGame(roomEngineLabel(engine, getPlatform().type === "tauri" && localIsHost));
           await runtime.api.startMultiplayerGame({
             playerNames,
             decks,


### PR DESCRIPTION
## Summary

- Name the engine that actually ran. Every hosted game reported `manabrew`, because the label was read off the runtime registry and a `forge` runtime is never selectable. The label is now decided at launch and carried with the measurement: `forge-hosted`, `forge-desktop`, `forge-wasm`, `manabrew`, `ironsmith`.
- Stop losing end-of-game reports. Report when the game ends rather than at teardown three seconds later, reject a relay send on a closed socket so the queue-for-the-hub fallback actually runs, and flush that queue immediately instead of at the next app start.
- Count what the relay does with each report (`accepted`, `outside_room`, `implausible`), and chart both the counter and reported-versus-played coverage on Engine Health.

## Why

Fourteen hours of production data after #785 shipped: 55 hosted games, 12 reports, and every report — hosted or not — labelled `manabrew`. Two separate defects behind that.

The label: `currentEngineLabel()` returned `forge-hosted` only for a `forge` runtime kind, but `runtimeRegistry` maps `forge` to `null`, nothing selects it, and the hosted launch calls `resetSelectedGameRuntime()` on the way in. Both Forge branches were unreachable, so the `manabrew` series on Engine Health is roughly 95% hosted Forge and every per-engine panel is meaningless.

The coverage: among clients that have #785, games ending in a natural finish reported at 4 of 36, while games a player quit reported at 8 of 15. The report was built at teardown, and the web transport swallows a send on a closed socket, so a failed send looked like a success and the hub fallback never ran.

Both relay drop paths are silent at debug level, which production does not log, so an undercount looks exactly like a quiet week.

## Test plan

- `yarn lint:all`, `yarn vitest run` (the pre-existing `useScryfallStore` failure on `main` is unrelated: `__APP_VERSION__` undefined), `cargo test -p manabrew-server -p manabrew-protocol` (138 tests), `python3 scripts/test_ingest_events.py`.
- New unit tests cover the label for each launch shape, the hub fallback when the relay send rejects, and reporting a finished game only once however many times the game ends.
- Relay end to end against the built binary: a probe client reports outside a room, inside a room, and with a malformed payload; `/metrics` then reads `outside_room 1`, `accepted 1`, `implausible 1`, and only the accepted one reaches the analytics JSONL.
- Dashboard against a throwaway Grafana 11.6.1 on a fixture database: all 13 SQLite panels return in one batch with no `database is locked`, the new coverage panel renders two named series, and `Games reported per day by engine` splits into four engine series including `forge-hosted`.
