### PR TITLE
docs(website): post on running forge in the browser

### DIFF
--- a/website/src-landing/content.config.ts
+++ b/website/src-landing/content.config.ts
@@ -11,6 +11,7 @@ const blog = defineCollection({
     pubDate: z.coerce.date(),
     author: z.string().default("The Manabrew team"),
     audience: z.enum(["players", "developers"]),
+    kind: z.enum(["announcement", "essay"]).default("essay"),
     hero: z.string().optional(),
     heroAlt: z.string().optional(),
     draft: z.boolean().default(false),

--- a/website/src-landing/content/blog/graalvm.md
+++ b/website/src-landing/content/blog/graalvm.md
@@ -13,9 +13,8 @@ to the Manabrew client using the same protocol and UI as our Rust engine.
 used as its reference implementation and hosted backend. Until now, playing with Forge meant a
 server somewhere running it for you. With GraalVM Web Image, the same engine runs inside the tab.
 
-As far as we can tell this is the first playable browser build of Forge itself. The other ways to
-play Forge in a browser run the engine on a machine elsewhere and send you the game. This one is the
-engine.
+As far as we can tell this is the first playable browser build of Forge itself. Other Forge-based
+services run Forge on a server and send the game to your browser. We run Forge in your browser.
 
 A Java desktop application with fifteen years of card support arrives over the wire in about 12 MB.
 The binary is 35.3 MB and the server sends it compressed with zstd. It downloads once and the
@@ -46,9 +45,12 @@ against Forge. The browser was the one place we could not offer Forge itself.
 
 We were already halfway here without noticing. Nothing we ship runs a JVM any more. `native-image`
 compiles the Forge harness into a shared library, and both the hosted node and the desktop app load
-it in process and call it over FFI: a `.so` on the servers, a `.dll` next to the executable on
-Windows. Web Image is that same compiler with a different backend, so the browser is the third
-target rather than a new engine. Same bytecode, three shapes.
+it in process and call it over FFI: a `.so` on the servers, a `.dll` beside the executable on
+Windows, a `.dylib` inside the app bundle on macOS. Web Image is that same compiler with a different
+backend. Same bytecode, one more shape.
+
+The browser is the only place Forge is WebAssembly. On the desktop the wasm engine is our own Rust
+one, running in the same webview, with Forge sitting next to it as a native library.
 
 So there is no card-script translation and no second Forge-compatible implementation to keep in
 step. During development we ran full games on seeds 7, 42 and 99 to a 40-turn limit through the
@@ -123,7 +125,8 @@ now gives us several interchangeable runtimes behind one client:
              ┌───────────┴───────────┐
              │                       │
          Rust engine               Forge
-            (wasm)        server .so, desktop .dll, wasm
+            (wasm)         server .so, desktop .dll or .dylib,
+                                 browser wasm
 ```
 
 Compiling Forge for a new runtime changed nothing in the game wire format. The engine publishes the

--- a/website/src-landing/content/blog/graalvm.md
+++ b/website/src-landing/content/blog/graalvm.md
@@ -1,0 +1,221 @@
+---
+title: "Forge now runs in the browser"
+description: "How we compiled Forge's Java rules engine to WebAssembly with GraalVM Web Image, kept its synchronous controller model, and connected it to the existing Manabrew client."
+pubDate: 2026-08-30
+author: "The Manabrew team"
+audience: developers
+---
+
+Forge now runs in the browser. We've compiled the Java engine itself to WebAssembly and connected it
+to the Manabrew client using the same protocol and UI as our Rust engine.
+
+[Forge](https://github.com/Card-Forge/forge) is the Magic: The Gathering rules engine Manabrew has
+used as its reference implementation and hosted backend. Until now, playing with Forge meant running
+it on a server or self-hosted node. With GraalVM Web Image, the same engine can run inside a browser.
+As far as we can tell, this is the first playable browser build of Forge itself.
+
+The feature is in production behind a server flag and an explicit opt-in under Settings. It's still
+experimental, but it already supports:
+
+- Play vs AI
+- Constructed
+- Commander
+- Brawl
+- Oathbreaker
+- Multiplayer tables with up to four human players
+- Manabrew autopass
+
+Limited, draft, and sealed still use the Rust worker. Rollback is unavailable once Forge owns a game,
+so a player cannot return to an earlier game state. Cancelling a mana payment still works, because
+Forge answers that itself and never asks for a snapshot.
+
+The WebAssembly binary is 35.3 MB. The server compresses it with zstd, so a browser downloads about
+12 MB. Booting it on the deployed build, assets included, takes around 642 ms. Across seven
+production games the engine's own think time had a median p50 of 16 ms.
+
+## Why run Forge locally?
+
+Manabrew already has a Rust rules engine that runs in WebAssembly. Forge has more than fifteen years
+of rules and card support behind it, which is the reason to bring it into the browser as well.
+
+The browser currently runs the Rust implementation, whose card support grows through parity work
+against Forge. The mature Forge implementation previously required the JVM on a hosted or
+self-hosted node. Web Image allows the original Forge code to run in the browser.
+
+There is no card-script translation and no second Forge-compatible implementation involved. The
+same Java engine that runs on the JVM is compiled through a different GraalVM backend. During
+development we ran full games on seeds 7, 42 and 99 to a 40-turn limit through both builds and
+compared the callback streams. They were byte-identical.
+
+## The latency win is mostly in the tail
+
+Three spans appear below, and they are not interchangeable.
+
+- Turnaround is measured in the client: the player answers, and the next prompt appears on screen.
+  For a hosted game it contains the network. For a local engine it contains nothing else.
+- Engine think time is measured inside the worker: the answer arrives, and the next prompt is ready.
+- Node time is the hosted equivalent, stamped by the relay: a seat answers, and that seat's next
+  board goes out.
+
+Seven production games on the browser engine, 399 decisions, give a turnaround p50 of 47 ms and a
+p90 of 79 ms. The engine's own think time inside those games was 16 ms p50 and 51 ms p90. Nothing
+in that path leaves the tab.
+
+The hosted fleet answers a decision in 77 ms p50, measured node-side over a day. The relay-to-node
+hop adds about 47 ms, and the player's own leg adds a median 41 ms on top. Two hosted commander
+games played by real people on the same day measured 277 ms and 306 ms of turnaround, which is what
+a player actually waits.
+
+The gap widens on expensive decisions. Ability activation on the hosted fleet is a p50 of 385 ms
+node-side on boards under 40 permanents, and it barely grows with board size, so it behaves as a
+fixed charge rather than a scaling one. The browser sampled 54 activations at a p50 near 20 ms, on
+a development server rather than in production. The populations differ, so read that as an order of
+magnitude, not a benchmark.
+
+The benefit is concentrated in decisions where the hosted path is expensive.
+
+## Keeping a synchronous engine synchronous
+
+The main integration problem was preserving Forge's blocking controller model.
+
+Forge's controller model is synchronous. The engine reaches a decision, asks a player for input, and
+waits on the same call stack until the answer arrives. Web Image currently gives us one Java
+execution thread, so Forge's usual threading model isn't useful here.
+
+We retained the synchronous model. Forge runs in a Web Worker. When it needs input, it writes a
+prompt to a `SharedArrayBuffer` and parks the WebAssembly stack with `Atomics.wait`. The client reads
+the prompt, renders it with the normal Manabrew UI, writes the response to the buffer, and wakes the
+worker. Forge resumes at the suspended call site.
+
+`SharedArrayBuffer` requires the document to be cross-origin isolated with COOP and COEP headers.
+Manabrew has shipped under cross-origin isolation since the Rust engine was introduced, so this
+requirement is not new.
+
+```text
+Forge
+  ↓
+prompt
+  ↓
+SharedArrayBuffer
+  ↓
+Manabrew client
+  ↓
+response
+  ↓
+SharedArrayBuffer
+  ↓
+Forge resumes
+```
+
+Manabrew already used this transport for its Rust WebAssembly engine, so the browser uses the
+existing game UI for Forge.
+
+## The protocol did most of the work
+
+The existing protocol reduced the integration work. Manabrew separates the game engine from the
+client. The UI doesn't manipulate Forge objects directly. Engines publish state and prompts through
+the Manabrew protocol, and the client sends actions back across the same boundary.
+
+That separation was originally necessary because we were running our Rust port alongside Forge. It
+now gives us several interchangeable runtimes behind one client:
+
+```text
+                  Manabrew client
+                         │
+                  Manabrew protocol
+                         │
+             ┌───────────┴───────────┐
+             │                       │
+         Rust engine               Forge
+          (Wasm)              JVM / Native / Wasm
+```
+
+Compiling Forge for a new runtime changed nothing in the game wire format. The engine publishes the
+same states and prompts as before, and the client reads them the same way.
+
+## Rebuilding Forge's filesystem
+
+Forge normally expects a filesystem full of card scripts, editions, formats, lists, AI profiles, and
+other resources. Web Image provides an in-memory filesystem for these resources.
+
+Manabrew already downloads a versioned `cardset.rkyv` archive for the Rust engine, containing the
+underlying Forge card data. The browser worker uses that archive to reconstruct the part of Forge's
+filesystem needed for the current game instead of sending another copy of the database. Card scripts
+load lazily, and the bundle frames only the cards the chosen decks name, so a game starts on 43
+scripts instead of the 33,645 Forge ships. Boot on a development server fell from 960 ms to 462 ms.
+The deployed build boots in about 642 ms, because it fetches the archive over the network.
+
+Forge could start without some resources even though their absence changed game behaviour. Removing
+`res/lists`, for example, changed card legality and caused parity to diverge. Side-by-side JVM and
+WebAssembly traces exposed the difference.
+
+## Where Java meets WebAssembly
+
+Web Image isn't a complete JVM running in a browser. We found several assumptions in Forge and its
+dependencies that don't hold in this environment:
+
+- `Thread.start()` could appear to start a thread even though the work never ran.
+- `java.util.zip` wasn't available on the path we needed, so archive decompression moved outside
+  Java.
+- Java object deserialization reached unsupported low-level memory behaviour and could crash the
+  runtime.
+- Some Guava code selected an `Unsafe`-based implementation and had to be initialised differently.
+
+None of this required rewriting Forge. The work was finding the small number of places where a large
+Java desktop application assumes it runs on a normal JVM. We expect further compatibility issues,
+which is one reason the feature remains experimental.
+
+## Multiplayer works too
+
+The first target was local Play vs AI. The same engine can also host a Manabrew multiplayer table,
+with up to four human players connecting through the normal relay while Forge runs in the host's
+browser.
+
+Each seat has its own shared buffer and receives its own filtered view of the game. The relay moves
+messages between players. Game execution remains in one client's browser, using the same hosting
+model as the Rust browser engine.
+
+A four-seat commander game hosted this way answers a decision in 21 ms p50 inside the engine. What
+a guest waits is far longer, because that interval holds three other players' turns as well.
+
+One cost belongs to the host and not to the engine. A self-hosted node sends most boards as patches
+against the previous one. The browser workers have no such pipeline, so every seat receives a full
+board every time. In a seven-minute four-seat game each guest downloaded about 29 MB, and not one
+frame was a patch. Adding that pipeline to the workers is the next piece of work here.
+
+## In production, but not the default
+
+The Forge WebAssembly binary is included in the production web image and disabled by default. The
+server enables the feature, after which the player can opt in under Settings.
+
+This allows browser telemetry and compatibility testing on long games before the engine is enabled
+more broadly.
+
+Seven production games so far, across pioneer, standard and commander, report a turnaround p50 of
+47 ms and an engine-think p50 of 16 ms. A development run on a longer game measured 38 ms
+turnaround and 8 ms engine-side.
+
+## What remains
+
+Automated browser coverage is Chrome-first. Firefox works in manual testing, but nothing guards it.
+Safari is untested. Our multiplayer tests prove that every seat can receive state and act, and a
+four-seat commander game has now run for several hundred decisions, but no four-player game has
+been played to its end.
+
+We have not measured peak heap in the tab for a four-seat table. That number decides whether such a
+table fits in the memory of a normal laptop.
+
+Backgrounding the hosting tab can stall relay polling and park the game. Both browser engines share
+this defect, but it is more visible when the browser hosts the entire table. The rollback limitation
+described above also remains. Web Image itself is still an experimental GraalVM technology.
+
+The feature remains opt-in while these gaps are being measured and tested.
+
+## A slightly unexpected destination
+
+Manabrew started as a self-hosted way for a group of friends to play Magic online. We evaluated XMage
+and Forge before beginning the Rust port of Forge's engine for browser use.
+
+Forge became the parity oracle and a hosted backend. Over the past 30 days 96% of Manabrew games ran
+on Forge rather than on the Rust engine, and almost all of them on the hosted fleet. This build is
+the first version of that path with no server in it.

--- a/website/src-landing/content/blog/graalvm.md
+++ b/website/src-landing/content/blog/graalvm.md
@@ -6,8 +6,8 @@ author: "The Manabrew team"
 audience: developers
 ---
 
-Forge now runs in the browser. We've compiled the Java engine itself to WebAssembly and connected it
-to the Manabrew client using the same protocol and UI as our Rust engine.
+Forge now runs in the browser. We compiled the Java engine to WebAssembly and put it behind the same
+protocol and the same UI the Manabrew client already uses for our Rust engine.
 
 [Forge](https://github.com/Card-Forge/forge) is the Magic: The Gathering rules engine Manabrew has
 used as its reference implementation and hosted backend. Until now, playing with Forge meant a
@@ -20,8 +20,8 @@ A Java desktop application with fifteen years of card support arrives over the w
 The binary is 35.3 MB and the server sends it compressed with zstd. It downloads once and the
 browser keeps it. Booting it on the deployed build, assets included, takes around 642 ms.
 
-The feature is in production behind a server flag and an explicit opt-in under Settings. It's still
-experimental, but it already supports:
+The feature is in production behind a server flag and an explicit opt-in under Settings. It is still
+experimental. What works today:
 
 - Play vs AI
 - Constructed
@@ -31,48 +31,47 @@ experimental, but it already supports:
 - Multiplayer tables with up to four human players
 - Manabrew autopass
 
-Limited, draft, and sealed still use the Rust worker. Rollback is unavailable once Forge owns a game,
-so a player cannot return to an earlier game state. Cancelling a mana payment still works, because
-Forge answers that itself and never asks for a snapshot.
+Limited, draft, and sealed still use the Rust worker. Rollback goes away once Forge owns a game, so a
+player cannot step back to an earlier state. Cancelling a mana payment still works, because Forge
+answers that itself and never asks for a snapshot.
 
 ## The same engine, one more target
 
-Manabrew already has a Rust rules engine that runs in WebAssembly. Forge has more than fifteen years
-of rules and card support behind it, which is the reason to bring it into the browser as well.
+Manabrew already has a Rust rules engine in WebAssembly. Forge has fifteen years of rules and card
+coverage that the port is still working through. That is the whole reason to want it here.
 
-The browser currently runs the Rust implementation, whose card support grows through parity work
-against Forge. The browser was the one place we could not offer Forge itself.
+The Rust engine's card support grows by running it against Forge and fixing whatever differs. The
+browser was the one place we could not simply hand a player Forge.
 
 We were already halfway here without noticing. Nothing we ship runs a JVM any more. `native-image`
 compiles the Forge harness into a shared library, and both the hosted node and the desktop app load
 it in process and call it over FFI: a `.so` on the servers, a `.dll` beside the executable on
-Windows, a `.dylib` inside the app bundle on macOS. Web Image is that same compiler with a different
-backend. Same bytecode, one more shape.
+Windows, a `.dylib` inside the app bundle on macOS. Web Image is that compiler with a different
+backend. The browser is one more target for the same bytecode, not a new engine.
 
-The browser is the only place Forge is WebAssembly. On the desktop the wasm engine is our own Rust
-one, running in the same webview, with Forge sitting next to it as a native library.
+The browser is also the only place Forge is WebAssembly. In the desktop app the wasm engine is our
+Rust one, running in the webview, with Forge beside it as a native library.
 
-So there is no card-script translation and no second Forge-compatible implementation to keep in
-step. During development we ran full games on seeds 7, 42 and 99 to a 40-turn limit through the
-browser build and the reference build, the one our parity harness tests against and the last place a
-JVM still runs here, and compared the callback streams. They were byte-identical.
+So nothing is translated and there is no second Forge-compatible implementation to keep in step.
+During development we ran full games on seeds 7, 42 and 99 to a 40-turn limit through the browser
+build and through the reference build our parity harness tests against, which is the last thing here
+that still runs on a JVM. The callback streams were byte-identical.
 
 ## Keeping a synchronous engine synchronous
 
-The main integration problem was preserving Forge's blocking controller model.
+The hard part was Forge's blocking controller model.
 
-Forge's controller model is synchronous. The engine reaches a decision, asks a player for input, and
-waits on the same call stack until the answer arrives. Web Image currently gives us one Java
-execution thread, so Forge's usual threading model isn't useful here.
+The engine reaches a decision, asks a player for input, and waits on the same call stack until the
+answer arrives. Web Image gives us one Java thread, so Forge's usual threading model is no help.
 
-We retained the synchronous model. Forge runs in a Web Worker. When it needs input, it writes a
-prompt to a `SharedArrayBuffer` and parks the WebAssembly stack with `Atomics.wait`. The client reads
-the prompt, renders it with the normal Manabrew UI, writes the response to the buffer, and wakes the
+So we kept the blocking model. Forge runs in a Web Worker. When it needs input, it writes a prompt to
+a `SharedArrayBuffer` and parks the WebAssembly stack with `Atomics.wait`. The client reads the
+prompt, renders it with the normal Manabrew UI, writes the response to the buffer, and wakes the
 worker. Forge resumes at the suspended call site.
 
 `SharedArrayBuffer` requires the document to be cross-origin isolated with COOP and COEP headers.
-Manabrew has shipped under cross-origin isolation since the Rust engine was introduced, so this
-requirement is not new.
+Manabrew has been cross-origin isolated since we shipped the Rust engine, so that cost was already
+paid.
 
 ```text
 Forge
@@ -90,38 +89,34 @@ SharedArrayBuffer
 Forge resumes
 ```
 
-Manabrew already used this transport for its Rust WebAssembly engine, so the browser uses the
-existing game UI for Forge.
+The Rust engine already used this transport, so Forge arrived behind the game UI we had.
 
 ## The latency win is mostly in the tail
 
-What a player waits for is the gap between answering a prompt and seeing the next one. Seven
-production games on the browser engine, 399 decisions, put that at 47 ms p50. The engine itself
-accounts for 16 ms of it, and nothing in the path leaves the tab. The other 31 ms is the client
-picking the answer up on a requestAnimationFrame poll and rendering the board, so a 60 Hz screen
-sets the floor rather than the engine. The whole exchange fits in about three frames.
+The wait that matters is between answering a prompt and seeing the next one. Seven production games
+on the browser engine, 399 decisions, put that at 47 ms p50, of which the engine is 16 ms. Nothing in
+that path leaves the tab. The other 31 ms belongs to the client, which collects the answer on a
+requestAnimationFrame poll and then renders the board, so the screen sets the floor rather than the
+engine. The whole exchange fits in about three frames.
 
-Two hosted commander games played by real people on the same day measured 277 ms and 306 ms for the
-same gap. The engine is not the reason. The fleet's own decision metric is node time rather than
-engine think time, counting from a seat's answer to that seat's next prompt going out, which is the
-rules work plus the node's step of packing the board for the wire, over real games with larger
-boards than our seven. It sits at 77 ms p50. The rest of those 300 ms is the round trip out to a
-server and back.
+Two hosted commander games played by real people that day measured 277 ms and 306 ms for the same
+gap. The engine is not why. The fleet figure of 77 ms p50 is node time, not think time. It runs from
+a seat's answer to that seat's next prompt going out, so it holds the rules work plus the node
+packing the board for the wire, across real games on bigger boards than our seven. The rest of those
+300 ms is the trip out to a server and back.
 
-The tail is where this gets interesting. Activating an ability costs the hosted fleet a p50 of
-385 ms, and it barely grows with board size, so it reads as a fixed charge rather than a scaling
-one. The browser sampled 54 activations at a p50 near 20 ms, on a development server rather than in
-production, so take that as an order of magnitude and not a benchmark. The cheap decisions were
-never the problem. The expensive ones were.
+Activating an ability costs the hosted fleet a p50 of 385 ms. It barely grows with board size, which
+makes it a fixed charge rather than a scaling one. The browser sampled 54 activations at a p50 near
+20 ms, on a development server rather than in production, so read that as an order of magnitude and
+not a benchmark. Cheap decisions were never the ones that hurt.
 
 ## The protocol did most of the work
 
-The existing protocol reduced the integration work. Manabrew separates the game engine from the
-client. The UI doesn't manipulate Forge objects directly. Engines publish state and prompts through
-the Manabrew protocol, and the client sends actions back across the same boundary.
+Manabrew keeps the engine and the client apart. The UI never touches Forge objects. Engines publish
+state and prompts through the Manabrew protocol, and the client sends actions back the same way.
 
-That separation was originally necessary because we were running our Rust port alongside Forge. It
-now gives us several interchangeable runtimes behind one client:
+We drew that boundary because we were running the Rust port next to Forge and needed both to look
+identical from the outside. It now holds several runtimes behind one client:
 
 ```text
                   Manabrew client
@@ -140,24 +135,24 @@ same states and prompts as before, and the client reads them the same way.
 
 ## Rebuilding Forge's filesystem
 
-Forge normally expects a filesystem full of card scripts, editions, formats, lists, AI profiles, and
-other resources. Web Image provides an in-memory filesystem for these resources.
+Forge expects a filesystem: card scripts, editions, formats, lists, AI profiles. Web Image gives it
+one in memory.
 
-Manabrew already downloads a versioned `cardset.rkyv` archive for the Rust engine, containing the
-underlying Forge card data. The browser worker uses that archive to reconstruct the part of Forge's
-filesystem needed for the current game instead of sending another copy of the database. Card scripts
-load lazily, and the bundle frames only the cards the chosen decks name, so a game starts on 43
-scripts instead of the 33,645 Forge ships. Boot on a development server fell from 960 ms to 462 ms.
-The deployed build boots in about 642 ms, because it fetches the archive over the network.
+Manabrew already downloads a versioned `cardset.rkyv` archive for the Rust engine, and it holds the
+underlying Forge card data. The browser worker rebuilds the part of Forge's filesystem this game
+needs out of that archive rather than shipping a second copy of the database. Card scripts load
+lazily, and the bundle frames only the cards the chosen decks name, so a game starts on 43 scripts
+instead of the 33,645 Forge ships. Boot on a development server fell from 960 ms to 462 ms. The
+deployed build boots in about 642 ms, because it fetches the archive over the network.
 
-Forge could start without some resources even though their absence changed game behaviour. Removing
-`res/lists`, for example, changed card legality and caused parity to diverge. Side-by-side traces
-from the reference build and the WebAssembly one exposed the difference.
+Forge starts happily without some of those files and plays a different game for it. Drop `res/lists`
+and card legality changes, which showed up immediately as a parity divergence. Side-by-side traces
+from the reference build and the WebAssembly one found it.
 
-## Where Java meets WebAssembly
+## What Web Image does not give you
 
-Web Image isn't a complete JVM running in a browser. We found several assumptions in Forge and its
-dependencies that don't hold in this environment:
+Web Image is not a JVM in a browser. Forge and its dependencies make assumptions that stop being true
+here:
 
 - `Thread.start()` could appear to start a thread even though the work never ran.
 - `java.util.zip` wasn't available on the path we needed, so archive decompression moved outside
@@ -166,54 +161,53 @@ dependencies that don't hold in this environment:
   runtime.
 - Some Guava code selected an `Unsafe`-based implementation and had to be initialised differently.
 
-None of this required rewriting Forge. The work was finding the small number of places where a large
-Java desktop application assumes it runs on a normal JVM. We expect further compatibility issues,
-which is one reason the feature remains experimental.
+None of it needed Forge rewritten. The work was finding the handful of places where a large Java
+desktop application assumes a normal JVM. There will be more of them, which is one reason this stays
+experimental.
 
-## Multiplayer works too
+## Hosting a table
 
-The first target was local Play vs AI. The same engine can also host a Manabrew multiplayer table,
-with up to four human players connecting through the normal relay while Forge runs in the host's
-browser.
+The first target was local Play vs AI. The same engine can host a Manabrew table, with up to four
+humans connecting through the normal relay while Forge runs in the host's browser.
 
-Each seat has its own shared buffer and receives its own filtered view of the game. The relay moves
-messages between players. Game execution remains in one client's browser, using the same hosting
-model as the Rust browser engine.
+Each seat has its own shared buffer and its own filtered view of the game. The relay moves messages
+between players. The game itself runs in one client's browser, the same way the Rust browser engine
+hosts.
 
-A four-seat commander game hosted this way answers a decision in 21 ms p50 inside the engine. What
-a guest waits is far longer, because that interval holds three other players' turns as well.
+A four-seat commander game hosted this way answers a decision in 21 ms p50 inside the engine. What a
+guest waits is far longer, because that interval holds three other players' turns as well.
 
-One cost belongs to the host and not to the engine. A self-hosted node sends most boards as patches
-against the previous one. The browser workers have no such pipeline, so every seat receives a full
-board every time. In a seven-minute four-seat game each guest downloaded about 29 MB, and not one
-frame was a patch. Adding that pipeline to the workers is the next piece of work here.
+One cost here is the host's, not the engine's. A self-hosted node sends most boards as a patch
+against the previous one. The browser workers cannot do that yet, so every seat gets a whole board
+every time. Over a seven-minute four-seat game each guest pulled about 29 MB, and not one frame was a
+patch. That pipeline is the next thing to build.
 
-## In production, but not the default
+## Shipped, and switched off
 
-The Forge WebAssembly binary is included in the production web image and disabled by default. The
-server enables the feature, after which the player can opt in under Settings.
+The binary ships in the production web image with the feature off. The server turns it on, and only
+then can a player opt in under Settings.
 
-This allows browser telemetry and compatibility testing on long games before the engine is enabled
-more broadly.
+That gives us telemetry and compatibility reports from real games before anyone gets the engine by
+default.
 
-The figures above came through that path. A longer development run did better still, at 38 ms of
-turnaround and 8 ms inside the engine, so what production reports is not the best this can do.
+The figures above arrived that way. A longer development run did better still, 38 ms of turnaround
+and 8 ms inside the engine, so production is not the ceiling here.
 
-## What remains
+## What is not done
 
-Automated browser coverage is Chrome-first. Firefox works in manual testing, but nothing guards it.
-Safari is untested. Our multiplayer tests prove that every seat can receive state and act, and a
-four-seat commander game has now run for several hundred decisions, but no four-player game has
-been played to its end.
+Our automated tests only drive Chrome. Firefox works when we try it by hand, but nothing guards it,
+and Safari is untested. The multiplayer tests show every seat receiving state and acting, and a
+four-seat commander game has run several hundred decisions, but nobody has played a four-player game
+to the end.
 
-We have not measured peak heap in the tab for a four-seat table. That number decides whether such a
-table fits in the memory of a normal laptop.
+We have not measured peak heap for a four-seat table, and that number decides whether one fits on an
+ordinary laptop.
 
-Backgrounding the hosting tab can stall relay polling and park the game. Both browser engines share
-this defect, but it is more visible when the browser hosts the entire table. The rollback limitation
-described above also remains. Web Image itself is still an experimental GraalVM technology.
+Backgrounding the hosting tab can stall relay polling and park the game. Both browser engines have
+that bug, and it matters more when the browser is hosting the whole table. Rollback is still missing.
+Web Image itself is still an experimental GraalVM technology.
 
-The feature remains opt-in while these gaps are being measured and tested.
+The engine stays opt-in until those are closed.
 
 ## Where this leaves the port
 
@@ -221,15 +215,14 @@ Manabrew started as a self-hosted way for a group of friends to play Magic onlin
 XMage and Forge, then began porting Forge's engine to Rust, because a Java desktop application could
 not run in a browser and we wanted one that could.
 
-That premise carried years of work. It stopped being true this month, and not because anyone
-rewrote anything. A compiler backend that did not exist when we started now emits WebAssembly, and
-the engine we had been reimplementing walked into the browser on its own.
+That premise carried years of work. It stopped being true this month, and not because anyone rewrote
+anything. A compiler backend that did not exist when we started now emits WebAssembly, and the engine
+we were reimplementing compiled straight into the browser.
 
 Over the past 30 days 96% of Manabrew games ran on Forge, nearly all of them on the hosted fleet.
-Those machines exist for one reason, which is that the engine needed somewhere to live. For a game
-played this way, that reason is gone. Fifteen years of card support, no account, no install, no
-hosted engine in the loop, and the tab does the rules.
+Those machines exist because the engine needed somewhere to live. For a game played this way it does
+not. Fifteen years of card support, no install, no account, and the rules run in the tab.
 
-The Rust port keeps its work. It answers limited and draft, it is a fifth of the download, and its
-disagreements with Forge are still how we find out which of the two is wrong. But the wall it was
-built to get around turned out to have a door in it.
+The port is not out of a job. It answers limited and draft, it is a fifth of the download, and its
+disagreements with Forge are still how we find bugs in both. It just no longer has to stand in for
+Forge in a browser.

--- a/website/src-landing/content/blog/graalvm.md
+++ b/website/src-landing/content/blog/graalvm.md
@@ -10,9 +10,12 @@ Forge now runs in the browser. We've compiled the Java engine itself to WebAssem
 to the Manabrew client using the same protocol and UI as our Rust engine.
 
 [Forge](https://github.com/Card-Forge/forge) is the Magic: The Gathering rules engine Manabrew has
-used as its reference implementation and hosted backend. Until now, playing with Forge meant running
-it on a server or self-hosted node. With GraalVM Web Image, the same engine can run inside a browser.
-As far as we can tell, this is the first playable browser build of Forge itself.
+used as its reference implementation and hosted backend. Until now, playing with Forge meant a
+server somewhere running it for you. With GraalVM Web Image, the same engine runs inside the tab.
+
+A Java desktop application with fifteen years of card support arrives over the wire in about 12 MB.
+The binary is 35.3 MB and the server sends it compressed with zstd. It downloads once and the
+browser keeps it. Booting it on the deployed build, assets included, takes around 642 ms.
 
 The feature is in production behind a server flag and an explicit opt-in under Settings. It's still
 experimental, but it already supports:
@@ -29,50 +32,22 @@ Limited, draft, and sealed still use the Rust worker. Rollback is unavailable on
 so a player cannot return to an earlier game state. Cancelling a mana payment still works, because
 Forge answers that itself and never asks for a snapshot.
 
-The WebAssembly binary is 35.3 MB. The server compresses it with zstd, so a browser downloads about
-12 MB. Booting it on the deployed build, assets included, takes around 642 ms. Across seven
-production games the engine's own think time had a median p50 of 16 ms.
-
 ## Why run Forge locally?
 
 Manabrew already has a Rust rules engine that runs in WebAssembly. Forge has more than fifteen years
 of rules and card support behind it, which is the reason to bring it into the browser as well.
 
 The browser currently runs the Rust implementation, whose card support grows through parity work
-against Forge. The mature Forge implementation previously required the JVM on a hosted or
-self-hosted node. Web Image allows the original Forge code to run in the browser.
+against Forge. Forge itself needed a machine somewhere else.
 
-There is no card-script translation and no second Forge-compatible implementation involved. The
-same Java engine that runs on the JVM is compiled through a different GraalVM backend. During
-development we ran full games on seeds 7, 42 and 99 to a 40-turn limit through both builds and
-compared the callback streams. They were byte-identical.
+We were already halfway here without noticing. The hosted fleet stopped running a JVM some time ago:
+`native-image` compiles the Forge harness to a shared library and the Rust node calls it in process,
+so those servers ship no Java runtime at all. Web Image is the same compiler with a different
+backend. One target is a `.so` on a server, the other is WebAssembly in a tab.
 
-## The latency win is mostly in the tail
-
-Three spans appear below, and they are not interchangeable.
-
-- Turnaround is measured in the client: the player answers, and the next prompt appears on screen.
-  For a hosted game it contains the network. For a local engine it contains nothing else.
-- Engine think time is measured inside the worker: the answer arrives, and the next prompt is ready.
-- Node time is the hosted equivalent, stamped by the relay: a seat answers, and that seat's next
-  board goes out.
-
-Seven production games on the browser engine, 399 decisions, give a turnaround p50 of 47 ms and a
-p90 of 79 ms. The engine's own think time inside those games was 16 ms p50 and 51 ms p90. Nothing
-in that path leaves the tab.
-
-The hosted fleet answers a decision in 77 ms p50, measured node-side over a day. The relay-to-node
-hop adds about 47 ms, and the player's own leg adds a median 41 ms on top. Two hosted commander
-games played by real people on the same day measured 277 ms and 306 ms of turnaround, which is what
-a player actually waits.
-
-The gap widens on expensive decisions. Ability activation on the hosted fleet is a p50 of 385 ms
-node-side on boards under 40 permanents, and it barely grows with board size, so it behaves as a
-fixed charge rather than a scaling one. The browser sampled 54 activations at a p50 near 20 ms, on
-a development server rather than in production. The populations differ, so read that as an order of
-magnitude, not a benchmark.
-
-The benefit is concentrated in decisions where the hosted path is expensive.
+So there is no card-script translation and no second Forge-compatible implementation. It is the same
+bytecode. During development we ran full games on seeds 7, 42 and 99 to a 40-turn limit through both
+builds and compared the callback streams. They were byte-identical.
 
 ## Keeping a synchronous engine synchronous
 
@@ -109,6 +84,22 @@ Forge resumes
 
 Manabrew already used this transport for its Rust WebAssembly engine, so the browser uses the
 existing game UI for Forge.
+
+## The latency win is mostly in the tail
+
+What a player waits for is the gap between answering a prompt and seeing the next one. Seven
+production games on the browser engine, 399 decisions, put that at 47 ms p50. The engine itself
+accounts for 16 ms of it, and nothing in the path leaves the tab.
+
+Two hosted commander games played by real people on the same day measured 277 ms and 306 ms for the
+same gap. The engine is not the reason. It answers in 77 ms p50 on the fleet; the rest is the round
+trip out to a server and back.
+
+The tail is where this gets interesting. Activating an ability costs the hosted fleet a p50 of
+385 ms, and it barely grows with board size, so it reads as a fixed charge rather than a scaling
+one. The browser sampled 54 activations at a p50 near 20 ms, on a development server rather than in
+production, so take that as an order of magnitude and not a benchmark. The cheap decisions were
+never the problem. The expensive ones were.
 
 ## The protocol did most of the work
 
@@ -211,11 +202,21 @@ described above also remains. Web Image itself is still an experimental GraalVM 
 
 The feature remains opt-in while these gaps are being measured and tested.
 
-## A slightly unexpected destination
+## Where this leaves the port
 
-Manabrew started as a self-hosted way for a group of friends to play Magic online. We evaluated XMage
-and Forge before beginning the Rust port of Forge's engine for browser use.
+Manabrew started as a self-hosted way for a group of friends to play Magic online. We looked at
+XMage and Forge, then began porting Forge's engine to Rust, because a Java desktop application could
+not run in a browser and we wanted one that could.
 
-Forge became the parity oracle and a hosted backend. Over the past 30 days 96% of Manabrew games ran
-on Forge rather than on the Rust engine, and almost all of them on the hosted fleet. This build is
-the first version of that path with no server in it.
+That premise carried years of work. It stopped being true this month, and not because anyone
+rewrote anything. A compiler backend that did not exist when we started now emits WebAssembly, and
+the engine we had been reimplementing walked into the browser on its own.
+
+Over the past 30 days 96% of Manabrew games ran on Forge, nearly all of them on the hosted fleet.
+Those machines exist for one reason, which is that the engine needed somewhere to live. For a game
+played this way, that reason is gone. Fifteen years of card support, no account, no install, no
+server in the loop, and the tab does the rules.
+
+The Rust port keeps its work. It answers limited and draft, it is a fifth of the download, and its
+disagreements with Forge are still how we find out which of the two is wrong. But the wall it was
+built to get around turned out to have a door in it.

--- a/website/src-landing/content/blog/graalvm.md
+++ b/website/src-landing/content/blog/graalvm.md
@@ -20,8 +20,8 @@ A Java desktop application with fifteen years of card support arrives over the w
 The binary is 35.3 MB and the server sends it compressed with zstd. The browser caches it. Booting
 it on the deployed build, assets included, takes around 642 ms.
 
-The feature is in production behind a server flag and an explicit opt-in under Settings. It is still
-experimental. What works today:
+The feature is in production. Play vs AI runs on the browser build by default. Hosting a multiplayer
+table from your own browser is an opt-in under Settings. It is still experimental. What works today:
 
 - Play vs AI
 - Constructed
@@ -43,10 +43,9 @@ coverage that the port is still working through. That is why we want it here.
 The Rust engine's card support grows by running it against Forge and fixing whatever differs. Until
 now nobody could run Forge in a browser, so a browser player got the port instead.
 
-We were already halfway here without noticing. Nothing we ship runs a JVM any more. `native-image`
-compiles the Forge harness into a shared library, and both the hosted node and the desktop app load
-it in process and call it over FFI: a `.so` on the servers, a `.dll` beside the executable on
-Windows, a `.dylib` inside the app bundle on macOS. Web Image is that compiler with a different
+Nothing we ship runs a JVM any more. `native-image` compiles the Forge harness into a shared library,
+and both the hosted node and the desktop app load it in process and call it over FFI: a `.so` on the
+servers, a `.dll` beside the executable on Windows, a `.dylib` inside the app bundle on macOS. Web Image is that compiler with a different
 backend. The browser build is the same Java code compiled for one more target.
 
 The browser is also the only place Forge is WebAssembly. In the desktop app the wasm engine is our
@@ -95,8 +94,8 @@ The Rust engine already used this transport, so Forge could reuse the game UI we
 The wait that matters is between answering a prompt and seeing the next one. Seven production games
 on the browser engine, 399 decisions, put that at 47 ms p50, of which the engine is 16 ms. Nothing in
 that path leaves the tab. The other 31 ms belongs to the client, which collects the answer on a
-requestAnimationFrame poll and then renders the board, so the screen sets the floor rather than the
-engine. The whole exchange fits in about three frames.
+requestAnimationFrame poll and then renders the board. The frame rate sets the floor. The whole
+exchange fits in about three frames.
 
 Two hosted commander games played by real people that day measured 277 ms and 306 ms for the same
 gap. Little of that is engine time. The fleet figure of 77 ms p50 is node time, not think time. It
@@ -104,11 +103,11 @@ runs from a seat's answer to that seat's next prompt going out, so it holds the 
 node packing the board for the wire, across real games on bigger boards than our seven. Most of the
 remaining gap sits outside the engine, in the hosted path.
 
-Activating an ability costs the hosted fleet a p50 of 385 ms. It barely grows with board size, which
-makes it a fixed charge rather than a scaling one. The browser sampled 54 activations at a p50 near
-20 ms, on a development server rather than in production, so read that as an order of magnitude and
-not a benchmark. The median player-visible gap is already about six-fold. Activations suggest the
-difference gets larger on expensive decisions.
+Activating an ability costs the hosted fleet a p50 of 385 ms. It barely grows with board size, so it
+reads as a fixed charge. The browser sampled 54 activations at a p50 near 20 ms, on a development
+server rather than in production, so treat that figure as an order of magnitude. The median
+player-visible gap is already about six-fold. Activations suggest the difference gets larger on
+expensive decisions.
 
 ## The protocol did most of the work
 
@@ -152,8 +151,8 @@ traces from the reference build and the WebAssembly one.
 
 ## What Web Image does not give you
 
-Web Image is not a JVM in a browser. Forge and its dependencies make assumptions that stop being true
-here:
+Web Image compiles Java ahead of time. It does not give Forge a JVM, and Forge and its dependencies
+make assumptions that stop being true here:
 
 - `Thread.start()` could appear to start a thread even though the work never ran.
 - `java.util.zip` wasn't available on the path we needed, so archive decompression moved outside
@@ -187,48 +186,10 @@ None of this retires the hosted fleet. When a browser hosts, the whole game runs
 every seat's hidden information is only as private as the host's client. A hosted node keeps hidden
 information out of another player's browser, does not park when a tab is backgrounded, and does not
 take the table down when somebody closes a window. It also plays for people whose machine will not. A
-35 MB engine and four seats of board state is a lot to ask of a phone. Hosting in the browser is
-another option, not a replacement.
+35 MB engine and four seats of board state is a lot to ask of a phone.
 
-## Shipped, and switched off
+Rollback is missing, our automated tests only drive Chrome, and Web Image is still an experimental
+GraalVM technology. Hosting a multiplayer table from the browser stays behind a setting for now.
 
-The binary ships in the production web image with the feature off. The server turns it on, and only
-then can a player opt in under Settings.
-
-That gives us telemetry and compatibility reports from real games before anyone gets the engine by
-default.
-
-The seven production games measured above were played through that path. A longer development run
-did better still, 38 ms of turnaround and 8 ms inside the engine, so production is not the ceiling
-here.
-
-## What is not done
-
-Our automated tests only drive Chrome. Firefox works when we try it by hand, but nothing guards it,
-and Safari is untested. The multiplayer tests show every seat receiving state and acting, and a
-four-seat commander game has run several hundred decisions, but nobody has played a four-player game
-to the end.
-
-We have not measured peak heap for a four-seat table, and that number decides whether one fits on an
-ordinary laptop.
-
-Backgrounding the hosting tab can stall relay polling and park the game. Both browser engines have
-that bug, and it matters more when the browser is hosting the whole table. Rollback is still missing.
-Web Image itself is still an experimental GraalVM technology.
-
-The engine stays opt-in until we are comfortable with those gaps.
-
-## Where this leaves the port
-
-We began porting Forge's engine to Rust because a Java desktop application could not run in a
-browser and we wanted one that could. That premise shaped the whole port. It no longer holds. A
-compiler backend that did not exist when we started now emits WebAssembly, and the engine we were
-reimplementing compiled straight into the browser.
-
-The port still answers limited and draft, it is a fifth of the download, and its disagreements with
-Forge are still how we find bugs in both. It just no longer has to stand in for Forge in a browser.
-
-Over the past 30 days 96% of Manabrew games ran on Forge, nearly all of them on the hosted fleet.
-Every one of those games needed a server to run the engine. A browser game does not. Fifteen years of
-card support run in the tab, with no install and no account. That is a better result than the one we
-set out to build.
+Over the past 30 days 96% of Manabrew games ran on Forge, and every one of them needed a server to
+run the engine. Play vs AI is about 80% of what people play, and it now runs in the tab.

--- a/website/src-landing/content/blog/graalvm.md
+++ b/website/src-landing/content/blog/graalvm.md
@@ -230,5 +230,5 @@ Forge are still how we find bugs in both. It just no longer has to stand in for 
 
 Over the past 30 days 96% of Manabrew games ran on Forge, nearly all of them on the hosted fleet.
 Every one of those games needed a server to run the engine. A browser game does not. Fifteen years of
-card support run in the tab, with no install and no account. That is a better result than the one we
-set out to build.
+card support run in the tab, with no install and no account. It is not the route we expected to get
+there.

--- a/website/src-landing/content/blog/graalvm.md
+++ b/website/src-landing/content/blog/graalvm.md
@@ -21,16 +21,17 @@ A Java desktop application with fifteen years of card support arrives over the w
 The binary is 35.3 MB and the server sends it compressed with zstd. The browser caches it. Booting
 it on the deployed build, assets included, takes around 642 ms.
 
-The feature is in production. Play vs AI runs on the browser build by default. Hosting a multiplayer
-table from your own browser is an opt-in under Settings. It is still experimental. What works today:
+The feature is in production. Play vs AI runs on the browser build by default. What works there
+today:
 
-- Play vs AI
 - Constructed
 - Commander
 - Brawl
 - Oathbreaker
-- Multiplayer tables with up to four human players
 - Manabrew autopass
+
+Hosting a multiplayer table of up to four human players uses the same build, but it stays behind an
+opt-in under Settings. All of it is still experimental.
 
 Limited, draft, and sealed still use the Rust worker. Rollback goes away once Forge owns a game, so a
 player cannot step back to an earlier state. Cancelling a mana payment still works, because Forge
@@ -44,13 +45,14 @@ coverage that the port is still working through. That is why we want it here.
 The Rust engine's card support grows by running it against Forge and fixing whatever differs. Until
 now nobody could run Forge in a browser, so a browser player got the port instead.
 
-Nothing we ship runs a JVM any more. `native-image` compiles the Forge harness into a shared library,
-and both the hosted node and the desktop app load it in process and call it over FFI: a `.so` on the
-servers, a `.dll` beside the executable on Windows, a `.dylib` inside the app bundle on macOS. Web Image is that compiler with a different
+None of the deployed runtimes we ship require a JVM any more. `native-image` compiles the Forge
+harness into a shared library, and both the hosted node and the desktop app load it in process and
+call it over FFI: a `.so` on the servers, a `.dll` beside the executable on Windows, a `.dylib`
+inside the app bundle on macOS. Web Image is that compiler with a different
 backend. The browser build is the same Java code compiled for one more target.
 
-The browser is also the only place Forge is WebAssembly. In the desktop app the wasm engine is our
-Rust one, running in the webview, with Forge beside it as a native library.
+The browser is also the only place Forge is WebAssembly. In the desktop app the WebAssembly engine is
+our Rust one, running in the webview, with Forge beside it as a native library.
 
 So nothing is translated and there is no second Forge-compatible implementation to keep in step.
 During development we ran identical games on seeds 7, 42 and 99 for up to 40 turns through the
@@ -94,9 +96,9 @@ The Rust engine already used this transport, so Forge could reuse the game UI we
 
 The wait that matters is between answering a prompt and seeing the next one. Seven production games
 on the browser engine, 399 decisions, put that at 47 ms p50, of which the engine is 16 ms. Nothing in
-that path leaves the tab. The other 31 ms belongs to the client, which collects the answer on a
-requestAnimationFrame poll and then renders the board. The frame rate sets the floor. The whole
-exchange fits in about three frames.
+that path leaves the tab. The other 31 ms belongs to the client: it collects the answer on a
+requestAnimationFrame poll and then renders the board, so the client render loop accounts for most of
+the remaining interval. The whole exchange fits in about three frames.
 
 Two hosted commander games played by real people that day measured 277 ms and 306 ms for the same
 gap. Little of that is engine time. The fleet figure of 77 ms p50 is node time, not think time. It
@@ -104,8 +106,8 @@ runs from a seat's answer to that seat's next prompt going out, so it holds the 
 node packing the board for the wire, across real games on bigger boards than our seven. Most of the
 remaining gap sits outside the engine, in the hosted path.
 
-Activating an ability costs the hosted fleet a p50 of 385 ms. It barely grows with board size, so it
-reads as a fixed charge. The browser sampled 54 activations at a p50 near 20 ms, on a development
+The hosted fleet measures ability activations at 385 ms p50. That figure barely grows with board
+size, so it reads as a fixed charge. The browser sampled 54 activations at a p50 near 20 ms, on a development
 server rather than in production, so treat that figure as an order of magnitude. The median
 player-visible gap is already about six-fold. Activations suggest the difference gets larger on
 expensive decisions.
@@ -126,9 +128,9 @@ identical from the outside. It now holds several runtimes behind one client:
              ┌───────────┴───────────┐
              │                       │
          Rust engine               Forge
-            (wasm)               server   .so
+        (WebAssembly)            server   .so
                                  desktop  .dll / .dylib
-                                 browser  wasm
+                                 browser  WebAssembly
 ```
 
 Compiling Forge for a new runtime changed nothing in the game wire format. The engine publishes the
@@ -186,8 +188,9 @@ patch. That pipeline is the next thing to build.
 None of this retires the hosted fleet. When a browser hosts, the whole game runs in that browser, so
 every seat's hidden information is only as private as the host's client. A hosted node keeps hidden
 information out of another player's browser, does not park when a tab is backgrounded, and does not
-take the table down when somebody closes a window. It also plays for people whose machine will not. A
-35 MB engine and four seats of board state is a lot to ask of a phone.
+take the table down when somebody closes a window. It also lets players use Forge on devices that
+cannot comfortably host the engine themselves. A 35 MB engine and four seats of board state is a lot
+to ask of a phone.
 
 Rollback is missing, our automated tests only drive Chrome, and Web Image is still an experimental
 GraalVM technology. Hosting a multiplayer table from the browser stays behind a setting for now.

--- a/website/src-landing/content/blog/graalvm.md
+++ b/website/src-landing/content/blog/graalvm.md
@@ -38,16 +38,16 @@ answers that itself and never asks for a snapshot.
 ## The same engine, one more target
 
 Manabrew already has a Rust rules engine in WebAssembly. Forge has fifteen years of rules and card
-coverage that the port is still working through. That is the whole reason to want it here.
+coverage that the port is still working through. That is why we want it here.
 
-The Rust engine's card support grows by running it against Forge and fixing whatever differs. The
-browser was the one place we could not simply hand a player Forge.
+The Rust engine's card support grows by running it against Forge and fixing whatever differs. Until
+now nobody could run Forge in a browser, so a browser player got the port instead.
 
 We were already halfway here without noticing. Nothing we ship runs a JVM any more. `native-image`
 compiles the Forge harness into a shared library, and both the hosted node and the desktop app load
 it in process and call it over FFI: a `.so` on the servers, a `.dll` beside the executable on
 Windows, a `.dylib` inside the app bundle on macOS. Web Image is that compiler with a different
-backend. Same Java code, one more compilation target, not a new engine.
+backend. The browser build is the same Java code compiled for one more target.
 
 The browser is also the only place Forge is WebAssembly. In the desktop app the wasm engine is our
 Rust one, running in the webview, with Forge beside it as a native library.
@@ -59,10 +59,9 @@ were byte-identical. That reference build is the last thing here that still runs
 
 ## Keeping a synchronous engine synchronous
 
-The hard part was Forge's blocking controller model.
-
-The engine reaches a decision, asks a player for input, and waits on the same call stack until the
-answer arrives. Web Image gives us one Java thread, so Forge's usual threading model is no help.
+Forge's controller model blocks. The engine reaches a decision, asks a player for input, and waits on
+the same call stack until the answer arrives. Web Image gives us one Java thread, so Forge's usual
+threading model is no help.
 
 So we kept the blocking model. Forge runs in a Web Worker. When it needs input, it writes a prompt to
 a `SharedArrayBuffer` and parks the WebAssembly stack with `Atomics.wait`. The client reads the
@@ -89,7 +88,7 @@ SharedArrayBuffer
 Forge resumes
 ```
 
-The Rust engine already used this transport, so Forge arrived behind the game UI we had.
+The Rust engine already used this transport, so Forge could reuse the game UI we had.
 
 ## What the player actually waits for
 
@@ -100,9 +99,9 @@ requestAnimationFrame poll and then renders the board, so the screen sets the fl
 engine. The whole exchange fits in about three frames.
 
 Two hosted commander games played by real people that day measured 277 ms and 306 ms for the same
-gap. The engine is not why. The fleet figure of 77 ms p50 is node time, not think time. It runs from
-a seat's answer to that seat's next prompt going out, so it holds the rules work plus the node
-packing the board for the wire, across real games on bigger boards than our seven. Most of the
+gap. Little of that is engine time. The fleet figure of 77 ms p50 is node time, not think time. It
+runs from a seat's answer to that seat's next prompt going out, so it holds the rules work plus the
+node packing the board for the wire, across real games on bigger boards than our seven. Most of the
 remaining gap sits outside the engine, in the hosted path.
 
 Activating an ability costs the hosted fleet a p50 of 385 ms. It barely grows with board size, which
@@ -147,9 +146,9 @@ lazily, and the bundle frames only the cards the chosen decks name, so a game st
 instead of the 33,645 Forge ships. Boot on a development server fell from 960 ms to 462 ms. The
 deployed build boots in about 642 ms, because it fetches the archive over the network.
 
-Forge starts happily without some of those files and plays a different game for it. Drop `res/lists`
-and card legality changes, which showed up immediately as a parity divergence. Side-by-side traces
-from the reference build and the WebAssembly one found it.
+Forge starts without some of those files, but game behaviour changes. Drop `res/lists` and card
+legality changes, which showed up immediately as a parity divergence. We found it in side-by-side
+traces from the reference build and the WebAssembly one.
 
 ## What Web Image does not give you
 
@@ -187,8 +186,8 @@ patch. That pipeline is the next thing to build.
 None of this retires the hosted fleet. When a browser hosts, the whole game runs in that browser, so
 every seat's hidden information is only as private as the host's client. A hosted node keeps hidden
 information out of another player's browser, does not park when a tab is backgrounded, and does not
-take the table down when somebody closes a window. It also plays for people whose machine will not:
-a 35 MB engine and four seats of board state is a lot to ask of a phone. Hosting in the browser is
+take the table down when somebody closes a window. It also plays for people whose machine will not. A
+35 MB engine and four seats of board state is a lot to ask of a phone. Hosting in the browser is
 another option, not a replacement.
 
 ## Shipped, and switched off
@@ -221,18 +220,15 @@ The engine stays opt-in until we are comfortable with those gaps.
 
 ## Where this leaves the port
 
-Manabrew started as a self-hosted way for a group of friends to play Magic online. We looked at
-XMage and Forge, then began porting Forge's engine to Rust, because a Java desktop application could
-not run in a browser and we wanted one that could.
+We began porting Forge's engine to Rust because a Java desktop application could not run in a
+browser and we wanted one that could. That premise shaped the whole port. It no longer holds. A
+compiler backend that did not exist when we started now emits WebAssembly, and the engine we were
+reimplementing compiled straight into the browser.
 
-That premise carried years of work. It stopped being true this month, and not because anyone rewrote
-anything. A compiler backend that did not exist when we started now emits WebAssembly, and the engine
-we were reimplementing compiled straight into the browser.
+The port still answers limited and draft, it is a fifth of the download, and its disagreements with
+Forge are still how we find bugs in both. It just no longer has to stand in for Forge in a browser.
 
 Over the past 30 days 96% of Manabrew games ran on Forge, nearly all of them on the hosted fleet.
-Those machines exist because the engine needed somewhere to live. For a game played this way it does
-not. Fifteen years of card support, no install, no account, and the rules run in the tab.
-
-The port is not out of a job. It answers limited and draft, it is a fifth of the download, and its
-disagreements with Forge are still how we find bugs in both. It just no longer has to stand in for
-Forge in a browser.
+Every one of those games needed a server to run the engine. A browser game does not. Fifteen years of
+card support run in the tab, with no install and no account. That is a better result than the one we
+set out to build.

--- a/website/src-landing/content/blog/graalvm.md
+++ b/website/src-landing/content/blog/graalvm.md
@@ -91,7 +91,7 @@ Forge resumes
 
 The Rust engine already used this transport, so Forge arrived behind the game UI we had.
 
-## The latency win is mostly in the tail
+## What the player actually waits for
 
 The wait that matters is between answering a prompt and seeing the next one. Seven production games
 on the browser engine, 399 decisions, put that at 47 ms p50, of which the engine is 16 ms. Nothing in
@@ -108,7 +108,7 @@ remaining gap sits outside the engine, in the hosted path.
 Activating an ability costs the hosted fleet a p50 of 385 ms. It barely grows with board size, which
 makes it a fixed charge rather than a scaling one. The browser sampled 54 activations at a p50 near
 20 ms, on a development server rather than in production, so read that as an order of magnitude and
-not a benchmark. Cheap decisions were never the ones that hurt.
+not a benchmark. The median gap is already about six-fold. Activations widen it.
 
 ## The protocol did most of the work
 
@@ -126,8 +126,9 @@ identical from the outside. It now holds several runtimes behind one client:
              ┌───────────┴───────────┐
              │                       │
          Rust engine               Forge
-            (wasm)         server .so, desktop .dll or .dylib,
-                                 browser wasm
+            (wasm)               server   .so
+                                 desktop  .dll / .dylib
+                                 browser  wasm
 ```
 
 Compiling Forge for a new runtime changed nothing in the game wire format. The engine publishes the
@@ -182,6 +183,13 @@ against the previous one. The browser workers cannot do that yet, so every seat 
 every time. Over a seven-minute four-seat game each guest pulled about 29 MB, and not one frame was a
 patch. That pipeline is the next thing to build.
 
+None of this retires the hosted fleet. When a browser hosts, the whole game runs in that browser, so
+every seat's hidden information is only as private as the host's client. A node is a neutral third
+party, it does not park itself when a tab goes to the background, and it does not take the table down
+when somebody closes a window. It also plays for people whose machine will not: a 35 MB engine and
+four seats of board state is a lot to ask of a phone. Hosting in the browser is another option, not a
+replacement.
+
 ## Shipped, and switched off
 
 The binary ships in the production web image with the feature off. The server turns it on, and only
@@ -190,8 +198,9 @@ then can a player opt in under Settings.
 That gives us telemetry and compatibility reports from real games before anyone gets the engine by
 default.
 
-The figures above arrived that way. A longer development run did better still, 38 ms of turnaround
-and 8 ms inside the engine, so production is not the ceiling here.
+The seven production games measured above were played through that path. A longer development run
+did better still, 38 ms of turnaround and 8 ms inside the engine, so production is not the ceiling
+here.
 
 ## What is not done
 

--- a/website/src-landing/content/blog/graalvm.md
+++ b/website/src-landing/content/blog/graalvm.md
@@ -13,6 +13,10 @@ to the Manabrew client using the same protocol and UI as our Rust engine.
 used as its reference implementation and hosted backend. Until now, playing with Forge meant a
 server somewhere running it for you. With GraalVM Web Image, the same engine runs inside the tab.
 
+As far as we can tell this is the first playable browser build of Forge itself. The other ways to
+play Forge in a browser run the engine on a machine elsewhere and send you the game. This one is the
+engine.
+
 A Java desktop application with fifteen years of card support arrives over the wire in about 12 MB.
 The binary is 35.3 MB and the server sends it compressed with zstd. It downloads once and the
 browser keeps it. Booting it on the deployed build, assets included, takes around 642 ms.

--- a/website/src-landing/content/blog/graalvm.md
+++ b/website/src-landing/content/blog/graalvm.md
@@ -4,6 +4,7 @@ description: "How we compiled Forge's Java rules engine to WebAssembly with Graa
 pubDate: 2026-08-30
 author: "The Manabrew team"
 audience: developers
+kind: announcement
 ---
 
 Forge now runs in the browser. We compiled the Java engine to WebAssembly and put it behind the same

--- a/website/src-landing/content/blog/graalvm.md
+++ b/website/src-landing/content/blog/graalvm.md
@@ -53,9 +53,9 @@ The browser is also the only place Forge is WebAssembly. In the desktop app the 
 Rust one, running in the webview, with Forge beside it as a native library.
 
 So nothing is translated and there is no second Forge-compatible implementation to keep in step.
-During development we ran full games on seeds 7, 42 and 99 to a 40-turn limit through the browser
-build and through the reference build our parity harness tests against, which is the last thing here
-that still runs on a JVM. The callback streams were byte-identical.
+During development we ran identical games on seeds 7, 42 and 99 for up to 40 turns through the
+browser build and through the reference build our parity harness tests against. The callback streams
+were byte-identical. That reference build is the last thing here that still runs on a JVM.
 
 ## Keeping a synchronous engine synchronous
 
@@ -108,7 +108,8 @@ remaining gap sits outside the engine, in the hosted path.
 Activating an ability costs the hosted fleet a p50 of 385 ms. It barely grows with board size, which
 makes it a fixed charge rather than a scaling one. The browser sampled 54 activations at a p50 near
 20 ms, on a development server rather than in production, so read that as an order of magnitude and
-not a benchmark. The median gap is already about six-fold. Activations widen it.
+not a benchmark. The median player-visible gap is already about six-fold. Activations suggest the
+difference gets larger on expensive decisions.
 
 ## The protocol did most of the work
 
@@ -184,11 +185,11 @@ every time. Over a seven-minute four-seat game each guest pulled about 29 MB, an
 patch. That pipeline is the next thing to build.
 
 None of this retires the hosted fleet. When a browser hosts, the whole game runs in that browser, so
-every seat's hidden information is only as private as the host's client. A node is a neutral third
-party, it does not park itself when a tab goes to the background, and it does not take the table down
-when somebody closes a window. It also plays for people whose machine will not: a 35 MB engine and
-four seats of board state is a lot to ask of a phone. Hosting in the browser is another option, not a
-replacement.
+every seat's hidden information is only as private as the host's client. A hosted node keeps hidden
+information out of another player's browser, does not park when a tab is backgrounded, and does not
+take the table down when somebody closes a window. It also plays for people whose machine will not:
+a 35 MB engine and four seats of board state is a lot to ask of a phone. Hosting in the browser is
+another option, not a replacement.
 
 ## Shipped, and switched off
 

--- a/website/src-landing/content/blog/graalvm.md
+++ b/website/src-landing/content/blog/graalvm.md
@@ -230,5 +230,5 @@ Forge are still how we find bugs in both. It just no longer has to stand in for 
 
 Over the past 30 days 96% of Manabrew games ran on Forge, nearly all of them on the hosted fleet.
 Every one of those games needed a server to run the engine. A browser game does not. Fifteen years of
-card support run in the tab, with no install and no account. It is not the route we expected to get
-there.
+card support run in the tab, with no install and no account. That is a better result than the one we
+set out to build.

--- a/website/src-landing/content/blog/graalvm.md
+++ b/website/src-landing/content/blog/graalvm.md
@@ -35,7 +35,7 @@ Limited, draft, and sealed still use the Rust worker. Rollback is unavailable on
 so a player cannot return to an earlier game state. Cancelling a mana payment still works, because
 Forge answers that itself and never asks for a snapshot.
 
-## Why run Forge locally?
+## The same engine, one more target
 
 Manabrew already has a Rust rules engine that runs in WebAssembly. Forge has more than fifteen years
 of rules and card support behind it, which is the reason to bring it into the browser as well.
@@ -54,7 +54,8 @@ one, running in the same webview, with Forge sitting next to it as a native libr
 
 So there is no card-script translation and no second Forge-compatible implementation to keep in
 step. During development we ran full games on seeds 7, 42 and 99 to a 40-turn limit through the
-browser build and the reference one, and compared the callback streams. They were byte-identical.
+browser build and the reference build, the one our parity harness tests against and the last place a
+JVM still runs here, and compared the callback streams. They were byte-identical.
 
 ## Keeping a synchronous engine synchronous
 
@@ -96,11 +97,16 @@ existing game UI for Forge.
 
 What a player waits for is the gap between answering a prompt and seeing the next one. Seven
 production games on the browser engine, 399 decisions, put that at 47 ms p50. The engine itself
-accounts for 16 ms of it, and nothing in the path leaves the tab.
+accounts for 16 ms of it, and nothing in the path leaves the tab. The other 31 ms is the client
+picking the answer up on a requestAnimationFrame poll and rendering the board, so a 60 Hz screen
+sets the floor rather than the engine. The whole exchange fits in about three frames.
 
 Two hosted commander games played by real people on the same day measured 277 ms and 306 ms for the
-same gap. The engine is not the reason. It answers in 77 ms p50 on the fleet; the rest is the round
-trip out to a server and back.
+same gap. The engine is not the reason. The fleet's own decision metric is node time rather than
+engine think time, counting from a seat's answer to that seat's next prompt going out, which is the
+rules work plus the node's step of packing the board for the wire, over real games with larger
+boards than our seven. It sits at 77 ms p50. The rest of those 300 ms is the round trip out to a
+server and back.
 
 The tail is where this gets interesting. Activating an ability costs the hosted fleet a p50 of
 385 ms, and it barely grows with board size, so it reads as a fixed charge rather than a scaling
@@ -145,8 +151,8 @@ scripts instead of the 33,645 Forge ships. Boot on a development server fell fro
 The deployed build boots in about 642 ms, because it fetches the archive over the network.
 
 Forge could start without some resources even though their absence changed game behaviour. Removing
-`res/lists`, for example, changed card legality and caused parity to diverge. Side-by-side JVM and
-WebAssembly traces exposed the difference.
+`res/lists`, for example, changed card legality and caused parity to diverge. Side-by-side traces
+from the reference build and the WebAssembly one exposed the difference.
 
 ## Where Java meets WebAssembly
 
@@ -156,7 +162,7 @@ dependencies that don't hold in this environment:
 - `Thread.start()` could appear to start a thread even though the work never ran.
 - `java.util.zip` wasn't available on the path we needed, so archive decompression moved outside
   Java.
-- Java object deserialization reached unsupported low-level memory behaviour and could crash the
+- Java object deserialisation reached unsupported low-level memory behaviour and could crash the
   runtime.
 - Some Guava code selected an `Unsafe`-based implementation and had to be initialised differently.
 
@@ -190,9 +196,8 @@ server enables the feature, after which the player can opt in under Settings.
 This allows browser telemetry and compatibility testing on long games before the engine is enabled
 more broadly.
 
-Seven production games so far, across pioneer, standard and commander, report a turnaround p50 of
-47 ms and an engine-think p50 of 16 ms. A development run on a longer game measured 38 ms
-turnaround and 8 ms engine-side.
+The figures above came through that path. A longer development run did better still, at 38 ms of
+turnaround and 8 ms inside the engine, so what production reports is not the best this can do.
 
 ## What remains
 
@@ -223,7 +228,7 @@ the engine we had been reimplementing walked into the browser on its own.
 Over the past 30 days 96% of Manabrew games ran on Forge, nearly all of them on the hosted fleet.
 Those machines exist for one reason, which is that the engine needed somewhere to live. For a game
 played this way, that reason is gone. Fifteen years of card support, no account, no install, no
-server in the loop, and the tab does the rules.
+hosted engine in the loop, and the tab does the rules.
 
 The Rust port keeps its work. It answers limited and draft, it is a fifth of the download, and its
 disagreements with Forge are still how we find out which of the two is wrong. But the wall it was

--- a/website/src-landing/content/blog/graalvm.md
+++ b/website/src-landing/content/blog/graalvm.md
@@ -17,8 +17,8 @@ As far as we can tell this is the first playable browser build of Forge itself. 
 services run Forge on a server and send the game to your browser. We run Forge in your browser.
 
 A Java desktop application with fifteen years of card support arrives over the wire in about 12 MB.
-The binary is 35.3 MB and the server sends it compressed with zstd. It downloads once and the
-browser keeps it. Booting it on the deployed build, assets included, takes around 642 ms.
+The binary is 35.3 MB and the server sends it compressed with zstd. The browser caches it. Booting
+it on the deployed build, assets included, takes around 642 ms.
 
 The feature is in production behind a server flag and an explicit opt-in under Settings. It is still
 experimental. What works today:
@@ -47,7 +47,7 @@ We were already halfway here without noticing. Nothing we ship runs a JVM any mo
 compiles the Forge harness into a shared library, and both the hosted node and the desktop app load
 it in process and call it over FFI: a `.so` on the servers, a `.dll` beside the executable on
 Windows, a `.dylib` inside the app bundle on macOS. Web Image is that compiler with a different
-backend. The browser is one more target for the same bytecode, not a new engine.
+backend. Same Java code, one more compilation target, not a new engine.
 
 The browser is also the only place Forge is WebAssembly. In the desktop app the wasm engine is our
 Rust one, running in the webview, with Forge beside it as a native library.
@@ -102,8 +102,8 @@ engine. The whole exchange fits in about three frames.
 Two hosted commander games played by real people that day measured 277 ms and 306 ms for the same
 gap. The engine is not why. The fleet figure of 77 ms p50 is node time, not think time. It runs from
 a seat's answer to that seat's next prompt going out, so it holds the rules work plus the node
-packing the board for the wire, across real games on bigger boards than our seven. The rest of those
-300 ms is the trip out to a server and back.
+packing the board for the wire, across real games on bigger boards than our seven. Most of the
+remaining gap sits outside the engine, in the hosted path.
 
 Activating an ability costs the hosted fleet a p50 of 385 ms. It barely grows with board size, which
 makes it a fixed charge rather than a scaling one. The browser sampled 54 activations at a p50 near
@@ -207,7 +207,7 @@ Backgrounding the hosting tab can stall relay polling and park the game. Both br
 that bug, and it matters more when the browser is hosting the whole table. Rollback is still missing.
 Web Image itself is still an experimental GraalVM technology.
 
-The engine stays opt-in until those are closed.
+The engine stays opt-in until we are comfortable with those gaps.
 
 ## Where this leaves the port
 

--- a/website/src-landing/content/blog/graalvm.md
+++ b/website/src-landing/content/blog/graalvm.md
@@ -42,16 +42,17 @@ Manabrew already has a Rust rules engine that runs in WebAssembly. Forge has mor
 of rules and card support behind it, which is the reason to bring it into the browser as well.
 
 The browser currently runs the Rust implementation, whose card support grows through parity work
-against Forge. Forge itself needed a machine somewhere else.
+against Forge. The browser was the one place we could not offer Forge itself.
 
-We were already halfway here without noticing. The hosted fleet stopped running a JVM some time ago:
-`native-image` compiles the Forge harness to a shared library and the Rust node calls it in process,
-so those servers ship no Java runtime at all. Web Image is the same compiler with a different
-backend. One target is a `.so` on a server, the other is WebAssembly in a tab.
+We were already halfway here without noticing. Nothing we ship runs a JVM any more. `native-image`
+compiles the Forge harness into a shared library, and both the hosted node and the desktop app load
+it in process and call it over FFI: a `.so` on the servers, a `.dll` next to the executable on
+Windows. Web Image is that same compiler with a different backend, so the browser is the third
+target rather than a new engine. Same bytecode, three shapes.
 
-So there is no card-script translation and no second Forge-compatible implementation. It is the same
-bytecode. During development we ran full games on seeds 7, 42 and 99 to a 40-turn limit through both
-builds and compared the callback streams. They were byte-identical.
+So there is no card-script translation and no second Forge-compatible implementation to keep in
+step. During development we ran full games on seeds 7, 42 and 99 to a 40-turn limit through the
+browser build and the reference one, and compared the callback streams. They were byte-identical.
 
 ## Keeping a synchronous engine synchronous
 
@@ -122,7 +123,7 @@ now gives us several interchangeable runtimes behind one client:
              ┌───────────┴───────────┐
              │                       │
          Rust engine               Forge
-          (Wasm)              JVM / Native / Wasm
+            (wasm)        server .so, desktop .dll, wasm
 ```
 
 Compiling Forge for a new runtime changed nothing in the game wire format. The engine publishes the

--- a/website/src-landing/pages/blog/[...slug].astro
+++ b/website/src-landing/pages/blog/[...slug].astro
@@ -26,6 +26,7 @@ const dateFmt = new Intl.DateTimeFormat("en-US", {
   day: "numeric",
 });
 const audienceLabel = { players: "For players", developers: "For developers" };
+const kindLabel = { announcement: "Announcement", essay: "Essay" };
 const ogImage = hero ? new URL(hero.src, Astro.site).toString() : undefined;
 ---
 
@@ -40,7 +41,8 @@ const ogImage = hero ? new URL(hero.src, Astro.site).toString() : undefined;
   <article>
     <header class="post-head">
       <p class="meta">
-        <span class="tag">{audienceLabel[post.data.audience]}</span>
+        <span class="tag">{kindLabel[post.data.kind]}</span>
+        <span class="tag muted">{audienceLabel[post.data.audience]}</span>
         <time datetime={post.data.pubDate.toISOString()}>
           {dateFmt.format(post.data.pubDate)}
         </time>
@@ -92,6 +94,10 @@ const ogImage = hero ? new URL(hero.src, Astro.site).toString() : undefined;
     letter-spacing: 0.14em;
     text-transform: uppercase;
     color: var(--primary);
+  }
+
+  .tag.muted {
+    color: var(--muted-foreground);
   }
 
   .meta time {

--- a/website/src-landing/pages/blog/index.astro
+++ b/website/src-landing/pages/blog/index.astro
@@ -13,6 +13,7 @@ const dateFmt = new Intl.DateTimeFormat("en-US", {
 });
 
 const audienceLabel = { players: "For players", developers: "For developers" };
+const kindLabel = { announcement: "Announcement", essay: "Essay" };
 
 const DESCRIPTION =
   "Updates and technical writeups from Manabrew, an open-source Magic: The Gathering client and Rust rules engine that runs in the browser.";
@@ -32,7 +33,10 @@ const DESCRIPTION =
       posts.map((post) => (
         <li>
           <a href={`/blog/${post.id}/`}>
-            <span class="tag">{audienceLabel[post.data.audience]}</span>
+            <span class="tags">
+              <span class="tag">{kindLabel[post.data.kind]}</span>
+              <span class="tag muted">{audienceLabel[post.data.audience]}</span>
+            </span>
             <h2>{post.data.title}</h2>
             <p class="desc">{post.data.description}</p>
             <time datetime={post.data.pubDate.toISOString()}>
@@ -103,6 +107,11 @@ const DESCRIPTION =
     border-color: var(--ring);
   }
 
+  .tags {
+    display: flex;
+    gap: 0.7rem;
+  }
+
   .tag {
     display: inline-block;
     font-size: 0.72rem;
@@ -110,6 +119,10 @@ const DESCRIPTION =
     letter-spacing: 0.14em;
     text-transform: uppercase;
     color: var(--primary);
+  }
+
+  .tag.muted {
+    color: var(--muted-foreground);
   }
 
   .posts h2 {


### PR DESCRIPTION
## Summary

- Adds the blog post announcing Forge in the browser through GraalVM Web Image.
- Every number in it was checked against production before it went in. The ones that were wrong are now right.


- The transport section now comes second, right after the case for running Forge locally.
- Latency section cut by about 40%. The span taxonomy is gone; the numbers that matter stayed.
- Opens on the size result, which is the most legible thing here: 35.3 MB of Java engine, about 12 MB over the wire, against 2.6 MB for the Rust engine.
- Keeps "the first playable browser build of Forge itself", and now says why: the other ways to play Forge in a browser run the engine on a machine elsewhere and send you the game.
- Corrected a wrong statement about how Forge ships. Nothing we release runs a JVM. `native-image` builds the harness into a shared library that the hosted node loads as a `.so` and the desktop app loads as a `.dll`, both over FFI. Web Image is the same compiler with a third backend, so the browser is a new target rather than a new engine. The runtime diagram now names the three shapes instead of saying "JVM / Native / Wasm".
- Harder ending.
