### PR TITLE
feat(forge-wasm): run the package on Node

### DIFF
--- a/packages/forge-wasm/README.md
+++ b/packages/forge-wasm/README.md
@@ -1,8 +1,8 @@
 # @manabrew/forge-wasm
 
-Forge compiled to WebAssembly with GraalVM Web Image. The package runs Forge in a classic Web Worker and exposes its state, display and prompt messages on the main thread.
+Forge compiled to WebAssembly with GraalVM Web Image. The package runs Forge on a worker and exposes its state, display and prompt messages on the main thread.
 
-The package is browser-only. It includes the Forge launcher, the WebAssembly engine and a static `cardset.rkyv` archive. Card scripts for the decks in play are selected from the archive before Forge boots, so the Java boundary only receives the files needed by that game.
+It runs in a browser and on Node. The entry point differs, the API does not. It includes the Forge launcher, the WebAssembly engine and a static `cardset.rkyv` archive. Card scripts for the decks in play are selected from the archive before Forge boots, so the Java boundary only receives the files needed by that game.
 
 ## Install
 
@@ -12,9 +12,9 @@ Pin an exact version while the API is pre-1.0:
 npm install --save-exact @manabrew/forge-wasm@0.1.0
 ```
 
-## Server headers
+## Browser: server headers
 
-Forge uses `SharedArrayBuffer` and requires a cross-origin isolated page. Serve the application with these response headers:
+In a browser, Forge uses `SharedArrayBuffer` and requires a cross-origin isolated page. Serve the application with these response headers:
 
 ```http
 Cross-Origin-Opener-Policy: same-origin
@@ -23,7 +23,7 @@ Cross-Origin-Embedder-Policy: require-corp
 
 `createForgeEngine()` rejects if `crossOriginIsolated` is false.
 
-## Vite setup
+## Browser: Vite setup
 
 The package's Vite plugin keeps the large engine and cardset out of dependency pre-bundling and emits them as static assets:
 
@@ -35,6 +35,19 @@ export default {
   plugins: [forgeWasm()],
 };
 ```
+
+## Node
+
+`import` resolves to a Node entry through the package's `node` condition, with the same API. There is no bundler and no cross-origin isolation to arrange: Node has `SharedArrayBuffer` unconditionally, and the engine runs on a `worker_threads` worker that reads its files from disk.
+
+```js
+import { createForgeEngine } from "@manabrew/forge-wasm";
+
+const engine = await createForgeEngine({ onState, onPrompt });
+await engine.startGame({ deck, opponentDecks: [deck] });
+```
+
+Node 20 or later. Call `dispose()` when the game ends, or the worker thread keeps the process alive.
 
 ## Usage
 
@@ -122,7 +135,7 @@ await createForgeEngine({
 });
 ```
 
-The launcher, worker, engine WASM, asset-selector WASM and cardset URLs can all be overridden. Their defaults are module-relative URLs that Vite and other modern bundlers emit as static assets.
+The launcher, worker, engine WASM, asset-selector WASM and cardset URLs can all be overridden. Their defaults are module-relative URLs that Vite and other modern bundlers emit as static assets. On Node they default to the installed files, and an override may be a path or a `file:` URL.
 
 ## Which build is this
 

--- a/packages/forge-wasm/engine.js
+++ b/packages/forge-wasm/engine.js
@@ -1,0 +1,152 @@
+import initAssetBuilder, { forge_asset_bundle } from "./forge-assets.js";
+import { deckCardNames } from "./deckCards.js";
+import { createSeat, deliverSeatDirective, pollSeat, writeSeatMessage } from "./seat.js";
+
+const LOCAL_SEAT = "local";
+
+let assetBuilderPromise;
+
+/**
+ * The engine, less the four things a runtime decides: where its files are, how
+ * a worker starts, how bytes are read, and whether the runtime can host it at
+ * all. `forge.js` binds the browser to it, `node.js` binds Node.
+ */
+export class ForgeEngine {
+  constructor(platform, options = {}) {
+    this.platform = platform;
+    this.options = options;
+    this.locations = platform.locations(options);
+    this.worker = null;
+    this.ready = null;
+    this.requestId = 0;
+    this.pending = new Map();
+    this.seats = new Map();
+    this.cardsetBytes = null;
+  }
+
+  async init() {
+    if (this.ready) return this.ready;
+    this.ready = new Promise((resolve, reject) => {
+      const unsupported = this.platform.unsupported();
+      if (unsupported) {
+        reject(new Error(unsupported));
+        return;
+      }
+      this.worker = this.platform.spawnWorker(this.locations.worker);
+      this.worker.onError((error) => reject(error));
+      this.worker.onMessage((message) => {
+        if (message?.type === "response") {
+          const pending = this.pending.get(message.requestId);
+          if (!pending) return;
+          this.pending.delete(message.requestId);
+          if (message.error) pending.reject(new Error(String(message.error)));
+          else pending.resolve(message.payload);
+          return;
+        }
+        if (message?.type !== "event") return;
+        if (message.event === "worker:init" && message.payload?.stage === "ready") resolve();
+        if (message.event === "game:sab") this.attachSeat(LOCAL_SEAT, message.payload.buffer);
+        if (message.event === "game:remote_sab") {
+          this.attachSeat(message.payload.playerSlot, message.payload.buffer);
+        }
+        this.options.onEvent?.(message.event, message.payload);
+      });
+    });
+    return this.ready;
+  }
+
+  async buildAssets(decks) {
+    if (typeof this.options.assets === "string") return this.options.assets;
+    if (typeof this.options.assets === "function") return this.options.assets(decks);
+    if (!assetBuilderPromise) {
+      assetBuilderPromise = this.platform
+        .assetModule(this.locations.assetWasm)
+        .then((module_or_path) => initAssetBuilder({ module_or_path }));
+    }
+    await assetBuilderPromise;
+    if (!this.cardsetBytes) {
+      this.cardsetBytes = await this.platform.readCardset(this.locations.cardset);
+    }
+    return forge_asset_bundle(this.cardsetBytes, deckCardNames(decks));
+  }
+
+  async startGame(args) {
+    await this.init();
+    const decks = [args.deck, ...(args.opponentDecks?.length ? args.opponentDecks : [args.deck])];
+    const forgeAssets = args.forgeAssets || (await this.buildAssets(decks));
+    return this.command("start_game", this.runtimeArgs(args, forgeAssets));
+  }
+
+  async startMultiplayerGame(args) {
+    await this.init();
+    const forgeAssets = args.forgeAssets || (await this.buildAssets(args.decks));
+    return this.command("start_multiplayer_game", this.runtimeArgs(args, forgeAssets));
+  }
+
+  runtimeArgs(args, forgeAssets) {
+    return {
+      ...args,
+      forgeAssets,
+      forgeLauncherUrl: this.locations.launcher,
+      forgeWasmUrl: this.locations.wasm,
+    };
+  }
+
+  command(command, args) {
+    if (!this.worker) return Promise.reject(new Error("Forge worker is not initialised."));
+    const requestId = String(++this.requestId);
+    return new Promise((resolve, reject) => {
+      this.pending.set(requestId, { resolve, reject });
+      this.worker.postMessage({ type: "command", command, requestId, args });
+    });
+  }
+
+  attachSeat(playerSlot, buffer) {
+    const seat = createSeat(buffer);
+    const previous = this.seats.get(playerSlot);
+    if (previous) previous.cancelled = true;
+    this.seats.set(playerSlot, seat);
+    pollSeat(
+      seat,
+      (message) => this.dispatchMessage(message, playerSlot),
+      (error) => this.options.onError?.(error),
+    );
+  }
+
+  dispatchMessage(message, seatSlot) {
+    const playerSlot = seatSlot === LOCAL_SEAT ? undefined : seatSlot;
+    this.options.onMessage?.(message, playerSlot);
+    if (message?.kind === "state") this.options.onState?.(message.state, playerSlot);
+    if (message?.kind === "prompt") this.options.onPrompt?.(message.prompt, playerSlot);
+    if (message?.kind === "display") this.options.onDisplay?.(message.event, playerSlot);
+    if (message?.kind === "error") this.options.onError?.(message.error, playerSlot);
+  }
+
+  respond(promptId, action, playerSlot = LOCAL_SEAT) {
+    const seat = this.seat(playerSlot);
+    if (!seat.awaitingResponse) throw new Error(`Forge seat ${playerSlot} is not awaiting input.`);
+    writeSeatMessage(seat, { kind: "response", promptId, action });
+  }
+
+  /** Delivered at once if the engine is blocked there, otherwise at that
+   *  seat's next prompt. A concession between prompts is not dropped. */
+  directive(directive, playerSlot = LOCAL_SEAT) {
+    deliverSeatDirective(this.seat(playerSlot), directive);
+  }
+
+  seat(playerSlot) {
+    const seat = this.seats.get(playerSlot);
+    if (!seat) throw new Error(`Forge seat ${playerSlot} is not available.`);
+    return seat;
+  }
+
+  dispose() {
+    for (const seat of this.seats.values()) seat.cancelled = true;
+    this.seats.clear();
+    this.worker?.terminate();
+    this.worker = null;
+    for (const pending of this.pending.values())
+      pending.reject(new Error("Forge engine disposed."));
+    this.pending.clear();
+  }
+}

--- a/packages/forge-wasm/forge.js
+++ b/packages/forge-wasm/forge.js
@@ -1,163 +1,55 @@
-import initAssetBuilder, { forge_asset_bundle } from "./forge-assets.js";
 import workerUrl from "./forge-engine.worker.js?url";
 import launcherUrl from "./forgeharness.js?url";
 import wasmUrl from "./forgeharness.js.wasm?url";
 import cardsetUrl from "./cardset.rkyv?url";
 import assetWasmUrl from "./forge-assets_bg.wasm?url";
-import { deckCardNames } from "./deckCards.js";
-import { createSeat, deliverSeatDirective, pollSeat, writeSeatMessage } from "./seat.js";
-
-const LOCAL_SEAT = "local";
-
-let assetBuilderPromise;
+import { ForgeEngine as Engine } from "./engine.js";
 
 function asUrl(value, fallback) {
-  if (value instanceof URL) return value;
-  return new URL(value || fallback, globalThis.location?.href || import.meta.url);
+  const base = globalThis.location?.href || import.meta.url;
+  return value instanceof URL ? value.href : new URL(value || fallback, base).href;
 }
 
-export class ForgeEngine {
-  constructor(options = {}) {
-    this.options = options;
-    this.workerUrl = asUrl(options.workerUrl, workerUrl);
-    this.launcherUrl = asUrl(options.launcherUrl, launcherUrl);
-    this.wasmUrl = asUrl(options.wasmUrl, wasmUrl);
-    this.cardsetUrl = asUrl(options.cardsetUrl, cardsetUrl);
-    this.assetWasmUrl = asUrl(options.assetWasmUrl, assetWasmUrl);
-    this.worker = null;
-    this.ready = null;
-    this.requestId = 0;
-    this.pending = new Map();
-    this.seats = new Map();
-    this.cardsetBytes = null;
-  }
+const browser = {
+  locations: (options) => ({
+    worker: asUrl(options.workerUrl, workerUrl),
+    launcher: asUrl(options.launcherUrl, launcherUrl),
+    wasm: asUrl(options.wasmUrl, wasmUrl),
+    cardset: asUrl(options.cardsetUrl, cardsetUrl),
+    assetWasm: asUrl(options.assetWasmUrl, assetWasmUrl),
+  }),
 
-  async init() {
-    if (this.ready) return this.ready;
-    this.ready = new Promise((resolve, reject) => {
-      if (!globalThis.crossOriginIsolated || typeof SharedArrayBuffer === "undefined") {
-        reject(
-          new Error("Forge requires a cross-origin isolated page with SharedArrayBuffer enabled."),
-        );
-        return;
-      }
-      this.worker = new Worker(this.workerUrl);
-      this.worker.onerror = (event) => reject(event.error || new Error(event.message));
-      this.worker.onmessage = (event) => {
-        const message = event.data;
-        if (message?.type === "response") {
-          const pending = this.pending.get(message.requestId);
-          if (!pending) return;
-          this.pending.delete(message.requestId);
-          if (message.error) pending.reject(new Error(String(message.error)));
-          else pending.resolve(message.payload);
-          return;
-        }
-        if (message?.type !== "event") return;
-        if (message.event === "worker:init" && message.payload?.stage === "ready") resolve();
-        if (message.event === "game:sab") this.attachSeat(LOCAL_SEAT, message.payload.buffer);
-        if (message.event === "game:remote_sab") {
-          this.attachSeat(message.payload.playerSlot, message.payload.buffer);
-        }
-        this.options.onEvent?.(message.event, message.payload);
-      };
-    });
-    return this.ready;
-  }
+  unsupported: () =>
+    globalThis.crossOriginIsolated && typeof SharedArrayBuffer !== "undefined"
+      ? null
+      : "Forge requires a cross-origin isolated page with SharedArrayBuffer enabled.",
 
-  async buildAssets(decks) {
-    if (typeof this.options.assets === "string") return this.options.assets;
-    if (typeof this.options.assets === "function") return this.options.assets(decks);
-    if (!assetBuilderPromise) {
-      assetBuilderPromise = initAssetBuilder({ module_or_path: this.assetWasmUrl });
-    }
-    await assetBuilderPromise;
-    if (!this.cardsetBytes) {
-      const response = await fetch(this.cardsetUrl);
-      if (!response.ok) throw new Error(`Failed to fetch Forge cardset: HTTP ${response.status}`);
-      this.cardsetBytes = new Uint8Array(await response.arrayBuffer());
-    }
-    return forge_asset_bundle(this.cardsetBytes, deckCardNames(decks));
-  }
-
-  async startGame(args) {
-    await this.init();
-    const decks = [args.deck, ...(args.opponentDecks?.length ? args.opponentDecks : [args.deck])];
-    const forgeAssets = args.forgeAssets || (await this.buildAssets(decks));
-    return this.command("start_game", this.runtimeArgs(args, forgeAssets));
-  }
-
-  async startMultiplayerGame(args) {
-    await this.init();
-    const forgeAssets = args.forgeAssets || (await this.buildAssets(args.decks));
-    return this.command("start_multiplayer_game", this.runtimeArgs(args, forgeAssets));
-  }
-
-  runtimeArgs(args, forgeAssets) {
+  spawnWorker(location) {
+    const worker = new Worker(location);
     return {
-      ...args,
-      forgeAssets,
-      forgeLauncherUrl: this.launcherUrl.href,
-      forgeWasmUrl: this.wasmUrl.href,
+      postMessage: (message) => worker.postMessage(message),
+      terminate: () => worker.terminate(),
+      onMessage: (handler) => {
+        worker.onmessage = (event) => handler(event.data);
+      },
+      onError: (handler) => {
+        worker.onerror = (event) => handler(event.error || new Error(event.message));
+      },
     };
-  }
+  },
 
-  command(command, args) {
-    if (!this.worker) return Promise.reject(new Error("Forge worker is not initialised."));
-    const requestId = String(++this.requestId);
-    return new Promise((resolve, reject) => {
-      this.pending.set(requestId, { resolve, reject });
-      this.worker.postMessage({ type: "command", command, requestId, args });
-    });
-  }
+  assetModule: async (location) => location,
 
-  attachSeat(playerSlot, buffer) {
-    const seat = createSeat(buffer);
-    const previous = this.seats.get(playerSlot);
-    if (previous) previous.cancelled = true;
-    this.seats.set(playerSlot, seat);
-    pollSeat(
-      seat,
-      (message) => this.dispatchMessage(message, playerSlot),
-      (error) => this.options.onError?.(error),
-    );
-  }
+  async readCardset(location) {
+    const response = await fetch(location);
+    if (!response.ok) throw new Error(`Failed to fetch Forge cardset: HTTP ${response.status}`);
+    return new Uint8Array(await response.arrayBuffer());
+  },
+};
 
-  dispatchMessage(message, seatSlot) {
-    const playerSlot = seatSlot === LOCAL_SEAT ? undefined : seatSlot;
-    this.options.onMessage?.(message, playerSlot);
-    if (message?.kind === "state") this.options.onState?.(message.state, playerSlot);
-    if (message?.kind === "prompt") this.options.onPrompt?.(message.prompt, playerSlot);
-    if (message?.kind === "display") this.options.onDisplay?.(message.event, playerSlot);
-    if (message?.kind === "error") this.options.onError?.(message.error, playerSlot);
-  }
-
-  respond(promptId, action, playerSlot = LOCAL_SEAT) {
-    const seat = this.seat(playerSlot);
-    if (!seat.awaitingResponse) throw new Error(`Forge seat ${playerSlot} is not awaiting input.`);
-    writeSeatMessage(seat, { kind: "response", promptId, action });
-  }
-
-  /** Delivered at once if the engine is blocked there, otherwise at that
-   *  seat's next prompt. A concession between prompts is not dropped. */
-  directive(directive, playerSlot = LOCAL_SEAT) {
-    deliverSeatDirective(this.seat(playerSlot), directive);
-  }
-
-  seat(playerSlot) {
-    const seat = this.seats.get(playerSlot);
-    if (!seat) throw new Error(`Forge seat ${playerSlot} is not available.`);
-    return seat;
-  }
-
-  dispose() {
-    for (const seat of this.seats.values()) seat.cancelled = true;
-    this.seats.clear();
-    this.worker?.terminate();
-    this.worker = null;
-    for (const pending of this.pending.values())
-      pending.reject(new Error("Forge engine disposed."));
-    this.pending.clear();
+export class ForgeEngine extends Engine {
+  constructor(options = {}) {
+    super(browser, options);
   }
 }
 
@@ -167,15 +59,4 @@ export async function createForgeEngine(options = {}) {
   return engine;
 }
 
-// Stamped at build time. A checkout that has not been through that build
-// reads as dev.
-export const VERSION = "0.0.0-dev";
-
-/**
- * The `forge-cardset-archive` release carrying the same selector, installable
- * with `cargo add`. It is the last *released* version, so a package built
- * between crate releases holds source the crate has not shipped: BUILD_COMMIT
- * is the exact answer.
- */
-export const CARDSET_ARCHIVE_VERSION = "0.0.0-dev";
-export const BUILD_COMMIT = "unknown";
+export { VERSION, CARDSET_ARCHIVE_VERSION, BUILD_COMMIT } from "./stamp.js";

--- a/packages/forge-wasm/node-worker.cjs
+++ b/packages/forge-wasm/node-worker.cjs
@@ -1,0 +1,36 @@
+/**
+ * Runs `forge-engine.worker.js` on a Node worker thread.
+ *
+ * That file and the generated launcher are classic scripts written for a web
+ * worker: they read `self`, call `postMessage` bare, and load each other with
+ * `importScripts`. This supplies all three, then evaluates them as scripts.
+ *
+ * They cannot be `require`d. Both are `.js` inside a `"type": "module"`
+ * package, so Node parses them as ESM, and the launcher needs the CommonJS
+ * `require` and `__filename` in scope: that is how it finds `fs` to read the
+ * WebAssembly module, and how it locates itself.
+ */
+const fs = require("fs");
+const path = require("path");
+const { parentPort, workerData } = require("worker_threads");
+
+const workerScript = workerData.workerScript;
+
+function runScript(file) {
+  const code = fs.readFileSync(file, "utf8");
+  const script = new Function("require", "__filename", "__dirname", code);
+  script(require, file, path.dirname(file));
+}
+
+globalThis.self = globalThis;
+globalThis.postMessage = (message) => parentPort.postMessage(message);
+globalThis.importScripts = (location) => {
+  const file = location.startsWith("file:") ? new URL(location).pathname : location;
+  runScript(path.resolve(path.dirname(workerScript), file));
+};
+
+parentPort.on("message", (message) => {
+  if (typeof globalThis.onmessage === "function") globalThis.onmessage({ data: message });
+});
+
+runScript(workerScript);

--- a/packages/forge-wasm/node.js
+++ b/packages/forge-wasm/node.js
@@ -1,0 +1,60 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { Worker } from "node:worker_threads";
+import { ForgeEngine as Engine } from "./engine.js";
+
+const sibling = (name) => fileURLToPath(new URL(name, import.meta.url));
+
+/** The launcher and the cardset are read with `fs`, which wants a path. */
+function asPath(value, fallback) {
+  if (!value) return fallback;
+  if (value instanceof URL) return fileURLToPath(value);
+  return value.startsWith("file:") ? fileURLToPath(new URL(value)) : value;
+}
+
+const node = {
+  locations: (options) => ({
+    worker: asPath(options.workerUrl, sibling("./forge-engine.worker.js")),
+    launcher: asPath(options.launcherUrl, sibling("./forgeharness.js")),
+    wasm: asPath(options.wasmUrl, sibling("./forgeharness.js.wasm")),
+    cardset: asPath(options.cardsetUrl, sibling("./cardset.rkyv")),
+    assetWasm: asPath(options.assetWasmUrl, sibling("./forge-assets_bg.wasm")),
+  }),
+
+  // Node has SharedArrayBuffer unconditionally, so there is no cross-origin
+  // isolation to check for.
+  unsupported: () => null,
+
+  spawnWorker(location) {
+    // The launcher reads argv from `process.argv` on Node, where a browser
+    // worker hands it `scriptArgs`.
+    const worker = new Worker(sibling("./node-worker.cjs"), {
+      workerData: { workerScript: location },
+      argv: ["--serve"],
+    });
+    return {
+      postMessage: (message) => worker.postMessage(message),
+      terminate: () => void worker.terminate(),
+      onMessage: (handler) => worker.on("message", handler),
+      onError: (handler) => worker.on("error", handler),
+    };
+  },
+
+  assetModule: (location) => readFile(location),
+
+  readCardset: async (location) => new Uint8Array(await readFile(location)),
+};
+
+export class ForgeEngine extends Engine {
+  constructor(options = {}) {
+    super(node, options);
+  }
+}
+
+export async function createForgeEngine(options = {}) {
+  const engine = new ForgeEngine(options);
+  await engine.init();
+  return engine;
+}
+
+export { VERSION, CARDSET_ARCHIVE_VERSION, BUILD_COMMIT } from "./stamp.js";

--- a/packages/forge-wasm/package.json
+++ b/packages/forge-wasm/package.json
@@ -16,6 +16,7 @@
   "exports": {
     ".": {
       "types": "./forge.d.ts",
+      "node": "./node.js",
       "default": "./forge.js"
     },
     "./vite": {
@@ -38,6 +39,10 @@
   "files": [
     "forge.js",
     "forge.d.ts",
+    "engine.js",
+    "node.js",
+    "node-worker.cjs",
+    "stamp.js",
     "deckCards.js",
     "deckCards.d.ts",
     "seat.js",

--- a/packages/forge-wasm/stamp.js
+++ b/packages/forge-wasm/stamp.js
@@ -1,0 +1,12 @@
+// Stamped at build time from package.json and the tree. A checkout that has
+// not been through that build reads as dev.
+export const VERSION = "0.0.0-dev";
+
+/**
+ * The `forge-cardset-archive` release carrying the same selector, installable
+ * with `cargo add`. It is the last *released* version, so a package built
+ * between crate releases holds source the crate has not shipped: BUILD_COMMIT
+ * is the exact answer.
+ */
+export const CARDSET_ARCHIVE_VERSION = "0.0.0-dev";
+export const BUILD_COMMIT = "unknown";

--- a/scripts/build-forge-wasm-package.mjs
+++ b/scripts/build-forge-wasm-package.mjs
@@ -94,6 +94,10 @@ for (const file of [
   "package.json",
   "forge.js",
   "forge.d.ts",
+  "engine.js",
+  "node.js",
+  "node-worker.cjs",
+  "stamp.js",
   "deckCards.js",
   "deckCards.d.ts",
   "seat.js",
@@ -149,18 +153,18 @@ if (!cardsetArchiveVersion) throw new Error("forge-cardset-archive has no versio
 const head = spawnSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" });
 const buildCommit = head.status === 0 ? head.stdout.trim() : "unknown";
 
-const entryPath = join(output, "forge.js");
-let entry = readFileSync(entryPath, "utf8");
+const stampPath = join(output, "stamp.js");
+let stamps = readFileSync(stampPath, "utf8");
 for (const [name, value] of [
   ["VERSION", manifest.version],
   ["CARDSET_ARCHIVE_VERSION", cardsetArchiveVersion],
   ["BUILD_COMMIT", buildCommit],
 ]) {
   const declaration = new RegExp(`^export const ${name} = ".*";$`, "m");
-  if (!declaration.test(entry)) throw new Error(`forge.js has no ${name} export to stamp.`);
-  entry = entry.replace(declaration, `export const ${name} = ${JSON.stringify(value)};`);
+  if (!declaration.test(stamps)) throw new Error(`stamp.js has no ${name} export to stamp.`);
+  stamps = stamps.replace(declaration, `export const ${name} = ${JSON.stringify(value)};`);
 }
-writeFileSync(entryPath, entry);
+writeFileSync(stampPath, stamps);
 
 console.log(
   `Built ${manifest.name}@${manifest.version} in ${output}` +

--- a/scripts/verify-forge-wasm-package.mjs
+++ b/scripts/verify-forge-wasm-package.mjs
@@ -30,6 +30,10 @@ function run(command, args, cwd = root) {
 const required = [
   "forge.js",
   "forge.d.ts",
+  "engine.js",
+  "node.js",
+  "node-worker.cjs",
+  "stamp.js",
   "deckCards.js",
   "deckCards.d.ts",
   "seat.js",
@@ -66,13 +70,13 @@ if (statSync(join(packageDir, "cardset.rkyv")).size < 30_000_000) {
 
 // A mismatch means the stamp did not run, and consumers would read stale
 // numbers.
-const entry = readFileSync(join(packageDir, "forge.js"), "utf8");
-const stampOf = (name) => entry.match(new RegExp(`^export const ${name} = "(.*)";$`, "m"))?.[1];
+const stamps = readFileSync(join(packageDir, "stamp.js"), "utf8");
+const stampOf = (name) => stamps.match(new RegExp(`^export const ${name} = "(.*)";$`, "m"))?.[1];
 
 const manifestVersion = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8")).version;
 if (stampOf("VERSION") !== manifestVersion) {
   throw new Error(
-    `forge.js exports VERSION ${stampOf("VERSION")}, manifest says ${manifestVersion}.`,
+    `stamp.js exports VERSION ${stampOf("VERSION")}, manifest says ${manifestVersion}.`,
   );
 }
 
@@ -82,11 +86,11 @@ const cardsetArchiveVersion = readFileSync(
 ).match(/^version\s*=\s*"(.+)"$/m)?.[1];
 if (stampOf("CARDSET_ARCHIVE_VERSION") !== cardsetArchiveVersion) {
   throw new Error(
-    `forge.js exports CARDSET_ARCHIVE_VERSION ${stampOf("CARDSET_ARCHIVE_VERSION")}, the crate is ${cardsetArchiveVersion}.`,
+    `stamp.js exports CARDSET_ARCHIVE_VERSION ${stampOf("CARDSET_ARCHIVE_VERSION")}, the crate is ${cardsetArchiveVersion}.`,
   );
 }
 if (!/^[0-9a-f]{40}$/.test(stampOf("BUILD_COMMIT") ?? "")) {
-  throw new Error(`forge.js exports BUILD_COMMIT ${stampOf("BUILD_COMMIT")}, expected a commit.`);
+  throw new Error(`stamp.js exports BUILD_COMMIT ${stampOf("BUILD_COMMIT")}, expected a commit.`);
 }
 
 const packed = JSON.parse(
@@ -191,6 +195,84 @@ for (const expected of ["forge-engine.worker", "forgeharness", "cardset", "forge
     throw new Error(`Vite did not emit the ${expected} package asset: ${assets.join(", ")}`);
   }
 }
+
+// The browser entry is bundler-only: its `?url` imports do not resolve outside
+// one. The `node` condition has to keep pointing at an entry Node can load, and
+// with a real engine it has to actually play a game.
+writeFileSync(
+  join(consumer, "node-usage.mjs"),
+  [
+    'import { createForgeEngine, ForgeEngine, VERSION } from "@manabrew/forge-wasm";',
+    'if (typeof ForgeEngine !== "function") throw new Error("the node entry exports no ForgeEngine.");',
+    'if (!VERSION) throw new Error("the node entry exports no VERSION.");',
+    'if (process.argv.includes("--import-only")) {',
+    "  console.log(`Node entry loads: @manabrew/forge-wasm ${VERSION}`);",
+    "  process.exit(0);",
+    "}",
+    "",
+    "const copies = (name, count) => Array.from({ length: count }, () => ({ name }));",
+    'const deck = { format: "constructed", cards: [...copies("Mountain", 24), ...copies("Raging Goblin", 36)] };',
+    "",
+    // Pass on everything. The AI wins in a couple of seconds, and what is under
+    // test is the packaging, not the rules.
+    "const REPLIES = {",
+    "  mulligan: () => ({ keep: true }),",
+    "  mulliganPutBack: () => ({ cardIds: [] }),",
+    "  diceRolled: () => ({}),",
+    "  revealCards: () => ({}),",
+    '  chooseAction: () => ({ type: "pass" }),',
+    "  chooseBoolean: () => ({ value: false }),",
+    "  chooseCards: () => ({ chosenCardIds: [] }),",
+    "  chooseAttackers: () => ({ assignments: [] }),",
+    "  chooseBlockers: () => ({ assignments: [] }),",
+    "};",
+    "",
+    "// The worker forwards its whole console, which is where a boot failure",
+    "// explains itself. Keep the tail of it to print if one happens.",
+    "const logs = [];",
+    "const die = (message) => {",
+    '  console.error([...logs.slice(-20), message].join("\\n"));',
+    "  process.exit(1);",
+    "};",
+    "let prompts = 0;",
+    "let states = 0;",
+    'const timer = setTimeout(() => die("Forge did not finish a game in 300s."), 300_000);',
+    "",
+    "const engine = await createForgeEngine({",
+    "  onState: () => { states += 1; },",
+    "  onPrompt: (prompt) => {",
+    "    prompts += 1;",
+    "    const type = prompt.input?.type;",
+    "    const reply = REPLIES[type];",
+    "    if (reply) engine.respond(prompt.promptId, { type, output: reply(prompt) });",
+    '    else engine.directive({ type: "concede" });',
+    "  },",
+    "  onError: (error) => die(`Forge reported an error: ${JSON.stringify(error)}`),",
+    "  onEvent: (event, payload) => {",
+    '    if (event === "forge:log") logs.push(payload.text);',
+    '    if (event === "game:forced_end") die(`Forge ended the game early: ${JSON.stringify(payload)}`);',
+    '    if (event !== "game:over") return;',
+    "    clearTimeout(timer);",
+    "    if (!prompts || !states) die(`Forge ended after ${prompts} prompts and ${states} states.`);",
+    "    console.log(`Node entry played a game: ${prompts} prompts, ${states} states.`);",
+    "    engine.dispose();",
+    "    process.exit(0);",
+    "  },",
+    "});",
+    "",
+    "await engine.startGame({ deck, opponentDecks: [deck] });",
+    "",
+  ].join("\n"),
+);
+process.stdout.write(
+  run(
+    process.execPath,
+    stubEngine
+      ? [join(consumer, "node-usage.mjs"), "--import-only"]
+      : [join(consumer, "node-usage.mjs")],
+    consumer,
+  ),
+);
 
 console.log(
   `Verified ${basename(tarball)}: ${(packed.size / 1024 / 1024).toFixed(1)} MiB tarball, ${packed.files.length} files.` +


### PR DESCRIPTION
## Summary

- Add a `node` export condition, so `import "@manabrew/forge-wasm"` resolves to an entry Node can load. Same API as the browser one.
- Split the runtime-independent half of the engine into `engine.js`. `forge.js` and `node.js` are thin bindings over it: each supplies five file locations, a worker, a byte reader, and a support check.
- Run the engine on a `worker_threads` worker. `node-worker.cjs` supplies the `self`, `postMessage` and `importScripts` that the Forge worker and the generated launcher expect, and evaluates both as classic scripts.
- Move the three build stamps into `stamp.js`, so both entries export them and the build still writes one file.
- Verification loads the package through the `node` condition on every run, and plays a whole game when the engine is not stubbed.

## Why

Follow-up to #796. The package was browser-only for one reason: `forge.js` opens with five `?url` imports, which is Vite syntax. Node throws `ERR_MODULE_NOT_FOUND` on the second line, before any of the rest gets a chance to matter.

Behind that were four smaller things, each an assumption rather than a requirement. `init()` rejected unless `crossOriginIsolated`, which Node never sets and does not need, because it has `SharedArrayBuffer` unconditionally. `new Worker` has no global equivalent there. `fetch` refuses a `file:` URL. The asset selector was handed a URL where Node needs bytes.

None of it was the engine. The generated launcher already branches on Node: it reads argv from `process.argv`, and loads the WebAssembly module through `fs` rather than `fetch`. `seat.js` and `deckCards.js` were already runtime-agnostic and are untouched, which is most of the seat protocol.

So Forge now plays a game with no browser and no bundler, in about three seconds including boot. That is cheap enough that verification plays one before publishing, rather than only checking that the files are present and the right shape. It also gives the harness somewhere to go that is not a headless Chrome.

## Test plan

The Web Image toolchain is not on this machine, so `yarn build:forge-wasm-package` was not run here. It is what the `Forge WASM package` check and the publish workflow run, and the packaging paths it drives are the copy list and the stamp target, both updated.

Everything else ran against a package directory assembled from the published `0.1.0` tarball with these sources dropped in, which is the same layout the build produces:

- `node scripts/verify-forge-wasm-package.mjs` passes end to end: `npm pack` at 21 files, the TypeScript consumer, the Vite browser build with all four assets emitted, and a full Forge game on Node. Repeated runs played 20, 21 and 29 prompts, each in a couple of seconds.
- The same with `.stub-engine` present falls back to the import-only check and passes.
- Removing `forgeharness.js` fails the smoke test with exit 1 and the boot error, rather than hanging to the timeout.
- The Vite build in that run is the evidence for the browser half: `forge.js` still bundles and still type-checks against `usage.ts`.
- `yarn lint` and `yarn lint:rust` clean.
