### PR TITLE
fix(web-image): copy packages/forge-wasm into the build context

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -72,6 +72,10 @@ COPY tree-sitter-forge-card-script/ ./tree-sitter-forge-card-script/
 COPY xtask/ ./xtask/
 COPY scripts/ ./scripts/
 COPY src/ ./src/
+# The client imports the Forge seat and card-selection modules from the
+# published package (the `@forge-wasm` alias in tsconfig/vite). Without
+# them `tsc -b` fails with TS2307 on every `@forge-wasm/*` import.
+COPY packages/forge-wasm/ ./packages/forge-wasm/
 COPY public/ ./public/
 # ops/manifest.json is read by vite.config.ts to stamp the app version.
 COPY index.html tsconfig*.json vite.config.ts ./


### PR DESCRIPTION
The v3.32.0 `manabrew-web` image build failed. `tsc -b` could not resolve any
`@forge-wasm/*` import:

```
src/lib/forgeAssets.ts(2,31): error TS2307: Cannot find module '@forge-wasm/deckCards.js'
src/platform/web.ts(66,8):   error TS2307: Cannot find module '@forge-wasm/seat.js'
```

`Dockerfile.web`'s builder stage never copied `packages/`, and the
`@forge-wasm` alias in `tsconfig.app.json` and `vite.config.ts` points there.
The `TS7006 implicitly has an 'any' type` errors that follow are all downstream
of those two unresolved modules.

This copies `packages/forge-wasm/` into the builder stage. Nothing under `src/`
reaches the other four packages, and the wasm engine itself is staged into
`public/forge/` by the workflow step, not into `packages/`.

PR checks never caught it: `build-checks.yml` typechecks the full working tree,
where the directory exists. Only the Docker build sees the trimmed context, and
that runs on tags.

The server, node and hub images for v3.32.0 built and pushed fine. Only web is
missing, so this needs a patch release once merged.
