### PR TITLE
perf(engine): stop building rules text the client never shows

### DIFF
--- a/forge-harness/src/main/java/forge/harness/host/ManaBrewEngineAdapter.java
+++ b/forge-harness/src/main/java/forge/harness/host/ManaBrewEngineAdapter.java
@@ -81,6 +81,12 @@ public final class ManaBrewEngineAdapter {
         final GameRules rules = new GameRules(gameType);
         rules.setAppliedVariants(variants);
         rules.setSimTimeout(120);
+        // The client draws its own card faces, so nothing here or in the
+        // protocol ever reads Forge's rendered rules text. Building it asks
+        // every conditional static ability whether it applies, and each of
+        // those filters the whole battlefield, which on a four-player board is
+        // a quarter of the engine's time.
+        rules.setRenderAbilityText(false);
 
         // Resetting global counters under a live session would collide its ids;
         // multiplexed processes only reset between idle periods.


### PR DESCRIPTION
The client draws its own card faces from Scryfall. Nothing in the snapshot
extractor, the protocol adapter or the protocol crate reads Forge's rendered
rules text, but the engine rebuilt it on every change to every card, and
building it asks every conditional static ability whether it applies, each of
which filters the whole battlefield.

Sampled at the `getValidCards` call site over a four-player Commander game, that
path is 39% of every card handed to a validity filter.

Four seeds, AI evaluation on the calling thread with its deadline pinned so both
arms replay the same game move for move:

| | rendering | skipping |
| --- | --- | --- |
| engine time | 124.4s | 92.8s |
| validity checks | 31.1M | 13.4M |

Nothing at an empty board, about three quarters off once it is wide, which is
where four-player Commander lives.

Stacked on witchesofthehill/forge#6. Measured on the JVM harness; the counts are
runtime independent but the wasm share is not measured yet.

Tracking on #817.
