### PR TITLE
fix(harness): preserve copied token identity

### DIFF
--- a/forge-harness/src/main/java/forge/harness/host/InteractiveSnapshotExtractor.java
+++ b/forge-harness/src/main/java/forge/harness/host/InteractiveSnapshotExtractor.java
@@ -414,7 +414,7 @@ public final class InteractiveSnapshotExtractor {
         dto.mergedCardIds = mergedCardIds(card);
         dto.damage = card.getDamage();
         dto.summoningSick = card.hasSickness();
-        dto.isCopy = card.isCloned();
+        dto.isCopy = card.isCloned() || card.getCopiedPermanent() != null;
         dto.isDoubleFaced = card.isDoubleFaced();
         dto.isTransformed = card.isTransformed();
         dto.isFaceDown = card.isFaceDown();


### PR DESCRIPTION
## Summary

- report resolved permanent spell copies through Forge's persistent `copiedPermanent` marker
- route those tokens through the existing copied-card renderer instead of ambiguous token collector numbers

## Why

A copied permanent spell stops satisfying `isCloned()` when Forge changes it from `COPIED_SPELL` to `TOKEN`, but it retains `copiedPermanent`. The harness dropped that identity and the UI treated the source card's set and collector number as a token printing.

For Nesting Dovehawk, `MOC #17` therefore resolved as `TMOC #17`, the Assassin token with deathtouch and haste. This is deterministic, not a race.

This closes the copied-spell gap left by the token identity fixes associated with #565, #708, and #716.

Fixes #828

## Test plan

- `yarn lint:all`
- `yarn build:harness`
- `yarn vitest run --config vite.config.ts src/stores/useScryfallStore.test.ts`
