### PR TITLE
fix(desktop): give the embedded node somewhere to log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4396,6 +4396,9 @@ dependencies = [
  "tauri-plugin-updater",
  "tiny_http",
  "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "walkdir",
 ]
 
@@ -7649,6 +7652,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8682,6 +8691,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,9 @@ forge-limited = { path = "../manabrew-rs/crates/forge-limited" }
 tauri-plugin-http = "2.5.9"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-appender = "0.2"
 self-hosted-node = { path = "../manabrew-rs/crates/self-hosted-node", default-features = false, features = [
     "graal-forge",
 ], optional = true }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod limited_commands;
 mod limited_dto;
 mod limited_manager;
 mod local_relay;
+mod logging;
 
 use limited_manager::LimitedManager;
 use tauri::Manager;
@@ -40,6 +41,7 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .setup(|app| {
+            logging::init(app.handle());
             if let Ok(resource_dir) = app.path().resource_dir() {
                 for (key, subdir) in RESOURCE_ENV_MAP {
                     let path = resource_dir.join(subdir);

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -1,0 +1,60 @@
+//! The desktop shell never installed a tracing subscriber, so every `info!`
+//! and `warn!` from the embedded node was written to nothing. That is how the
+//! host bridge could be denied at the IPC boundary for days without leaving a
+//! trace: the denial was logged, and nobody was listening.
+//!
+//! Printing alone does not fix it. A bundled `.app` launched from Finder has
+//! no stdout, and that is the build that matters — the one a player runs. So
+//! the same lines also go to a file under the app's log directory, which is
+//! somewhere a user can be asked to look.
+
+use std::fs;
+
+use tauri::{AppHandle, Manager};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::EnvFilter;
+
+/// What to record when `RUST_LOG` says nothing. The node's own CLI defaults to
+/// `self_hosted_node=info` for the same reason; the shell adds itself and the
+/// relay it can embed.
+const DEFAULT_FILTER: &str = "manabrew_lib=info,self_hosted_node=info,manabrew_server=info";
+
+/// Kept for the life of the process: dropping it stops the writer thread and
+/// silently truncates whatever had not been flushed.
+static GUARD: std::sync::OnceLock<tracing_appender::non_blocking::WorkerGuard> =
+    std::sync::OnceLock::new();
+
+pub fn init(app: &AppHandle) {
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(DEFAULT_FILTER));
+
+    // A missing log directory is not a reason to lose the terminal output too,
+    // so the file layer is optional and the stdout layer is not.
+    let file_layer = app
+        .path()
+        .app_log_dir()
+        .ok()
+        .and_then(|dir| fs::create_dir_all(&dir).ok().map(|()| dir))
+        .map(|dir| {
+            let appender = tracing_appender::rolling::daily(&dir, "manabrew.log");
+            let (writer, guard) = tracing_appender::non_blocking(appender);
+            let _ = GUARD.set(guard);
+            eprintln!("[startup] logging to {}", dir.join("manabrew.log").display());
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_writer(writer)
+        });
+
+    if tracing_subscriber::registry()
+        .with(filter)
+        .with(tracing_subscriber::fmt::layer())
+        .with(file_layer)
+        .try_init()
+        .is_err()
+    {
+        // Something already set the global subscriber. Losing that race is not
+        // worth taking the app down for.
+        eprintln!("[startup] tracing subscriber already installed");
+    }
+}


### PR DESCRIPTION
The desktop shell builds a Tauri app and never installs a tracing subscriber.
Every `info!` and `warn!` from the node it embeds goes nowhere.

This came out of testing the transport work. The host bridge commands were
missing from the permission manifest, so Tauri denied them on every origin.
The node logged that. Nothing was listening, and a release build has no
console for the JS-side rejection either, so the desktop host looked like it
had simply never offered. It took relay-side metrics to find, because the
machine running the code could not report what it had done.

Stdout alone would not close it: a bundled `.app` launched from Finder has no
stdout, and that is the build players run. So the same lines also go to a
daily-rolled file under the app's log directory, which is somewhere a user can
be asked to look.

- default filter `manabrew_lib=info,self_hosted_node=info,manabrew_server=info`,
  matching the node's own CLI; `RUST_LOG` still wins
- a missing log directory drops the file layer only, never the terminal one
- losing the race to install the global subscriber is not fatal

Off `main` rather than on the transport stack: all three lines need it, and it
depends on none of them.

## Checking it

Run the app from a terminal and the node's lines appear. In a bundled build,
`~/Library/Logs/<bundle-id>/manabrew.log` on macOS.
