### PR TITLE
feat(net): report how a direct plane attempt turned out

### DIFF
--- a/manabrew-rs/crates/manabrew-relay-protocol/src/lib.rs
+++ b/manabrew-rs/crates/manabrew-relay-protocol/src/lib.rs
@@ -132,6 +132,67 @@ pub struct SeatTransportReport {
     pub transport: String,
 }
 
+/// One end's account of one attempt to reach a peer off the relay.
+///
+/// Every field past `peer` and `outcome` is the reporter's own measurement, so
+/// the relay treats all of it as a claim: it bounds the numbers, caps the
+/// strings, and records who said it rather than trusting what was said.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PlaneQualityReport {
+    /// The other end, as the relay attested that username to this session.
+    pub peer: String,
+    /// [`PLANE_OUTCOME_CONNECTED`], [`PLANE_OUTCOME_FAILED`] or
+    /// [`PLANE_OUTCOME_TIMEOUT`]. Anything else is dropped.
+    pub outcome: String,
+    /// Which plane was attempted: [`TRANSPORT_WEBRTC`] or
+    /// [`TRANSPORT_IROH_DIRECT`].
+    pub plane: String,
+    /// [`PLANE_PHASE_SETTLED`] once per attempt, when it reaches its outcome,
+    /// or [`PLANE_PHASE_MEASURED`] for the later report that carries the round
+    /// trip. Only the first is counted as an attempt: a connected peer reports
+    /// twice and a failed one once, so counting both would inflate the connect
+    /// rate this exists to measure.
+    pub phase: String,
+    /// First offer to open channel.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connect_ms: Option<u32>,
+    /// Median round trip measured on the channel itself.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rtt_ms: Option<u32>,
+    /// The same session's round trip to the relay, sampled by the reporter at
+    /// the same time. Paired deliberately: an unpaired direct RTT cannot say
+    /// whether it beat the path it replaced.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relay_rtt_ms: Option<u32>,
+    /// The ICE pair that won, `local/remote`, or what was on offer when none
+    /// did. `host/host` never left the LAN and proves no traversal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub candidate_pair: Option<String>,
+}
+
+pub const PLANE_PHASE_SETTLED: &str = "settled";
+pub const PLANE_PHASE_MEASURED: &str = "measured";
+
+pub const PLANE_OUTCOME_CONNECTED: &str = "connected";
+pub const PLANE_OUTCOME_FAILED: &str = "failed";
+pub const PLANE_OUTCOME_TIMEOUT: &str = "timeout";
+
+/// Outcomes the relay will record. An unknown one is dropped rather than
+/// recorded, so a client cannot invent labels into the metric's cardinality.
+pub const PLANE_OUTCOMES: &[&str] = &[
+    PLANE_OUTCOME_CONNECTED,
+    PLANE_OUTCOME_FAILED,
+    PLANE_OUTCOME_TIMEOUT,
+];
+
+/// Longest `candidate_pair` the relay will record. Real values are like
+/// `srflx/srflx`; this is room for that and not for a label attack.
+pub const MAX_CANDIDATE_PAIR_BYTES: usize = 64;
+
+/// Anything past this is a broken clock or a lie, and is dropped rather than
+/// skewing an average. Ten minutes.
+pub const MAX_PLANE_MS: u32 = 600_000;
+
 pub const TRANSPORT_IROH_DIRECT: &str = "iroh-direct";
 pub const TRANSPORT_IROH_RELAYED: &str = "iroh-relayed";
 /// A browser pair on an `RTCDataChannel`. There is no TURN server, so a WebRTC
@@ -303,6 +364,23 @@ pub enum ClientMessage {
     SignalPeer {
         to: String,
         payload: serde_json::Value,
+    },
+
+    /// Reports how one direct-plane attempt turned out, whether or not it
+    /// worked. Analytics only, like [`ClientMessage::ReportTransport`].
+    ///
+    /// [`ClientMessage::ReportTransport`] cannot answer this. It is sent by the
+    /// host at game start and names only the seats that succeeded, so the
+    /// attempts that failed reach nobody: a seat that cannot punch through
+    /// stays on the relay and says nothing about having tried. Without the
+    /// failures there is no denominator, and a connect rate is exactly the
+    /// number that decides whether production gets ICE servers.
+    ///
+    /// The measuring end sends this, which is the seat, not the host. The relay
+    /// stamps the sender from its own record and does not read the numbers
+    /// beyond bounding them.
+    ReportPlaneQuality {
+        report: PlaneQualityReport,
     },
 }
 
@@ -584,10 +662,16 @@ pub const FEATURE_ROOM_TRANSPORT: &str = "room_transport";
 /// never starts a negotiation that cannot finish.
 pub const FEATURE_PEER_SIGNAL: &str = "peer_signal";
 
+/// The relay accepts [`ClientMessage::ReportPlaneQuality`]. A client that
+/// does not see this stays quiet rather than sending a message an older
+/// relay would reject as a parse error.
+pub const FEATURE_PLANE_QUALITY: &str = "plane_quality";
+
 pub const FEATURES: &[&str] = &[
     FEATURE_LOCAL_GAME,
     FEATURE_ROOM_TRANSPORT,
     FEATURE_PEER_SIGNAL,
+    FEATURE_PLANE_QUALITY,
 ];
 
 /// The largest signalling blob the relay will forward. An SDP offer with a

--- a/manabrew-rs/crates/manabrew-server/src/analytics/event.rs
+++ b/manabrew-rs/crates/manabrew-server/src/analytics/event.rs
@@ -91,6 +91,34 @@ pub enum AnalyticsEvent {
         host: String,
         seats: Vec<SeatTransportReport>,
     },
+    /// One end's account of one attempt to reach a peer off the relay, kept
+    /// whether or not it worked.
+    ///
+    /// [`AnalyticsEvent::TransportUsed`] is the host's list of seats that
+    /// succeeded. This is the other half: the attempts, including the ones
+    /// that failed and left the seat on the relay saying nothing. A connect
+    /// rate needs both.
+    PlaneQuality {
+        ts: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        room_id: Option<String>,
+        /// The reporter, named from the relay's own record of the session.
+        username: String,
+        /// The other end, as the reporter named it.
+        peer: String,
+        plane: String,
+        outcome: String,
+        /// `settled` or `measured`; a connected peer reports both.
+        phase: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        connect_ms: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        rtt_ms: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        relay_rtt_ms: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        candidate_pair: Option<String>,
+    },
     EngineStats {
         ts: String,
         /// The room the seat was in when the report landed, which at game over

--- a/manabrew-rs/crates/manabrew-server/src/connection.rs
+++ b/manabrew-rs/crates/manabrew-server/src/connection.rs
@@ -1850,6 +1850,16 @@ fn candidate_pair_label(pair: Option<&str>) -> &'static str {
     let Some(pair) = pair else {
         return "unknown";
     };
+    // iroh reports the path in its own words rather than ICE's, because a
+    // QUIC path has no candidate types and inventing some would read as a
+    // measurement of something that never happened. The buckets are the same
+    // question either way: did this leave the network, and did it stay direct.
+    match pair {
+        "direct-lan" => return "lan",
+        "direct-wan" => return "punched",
+        "relayed" => return "turn",
+        _ => {}
+    }
     let (local, remote) = match pair.split_once('/') {
         Some(split) => split,
         None => return "other",
@@ -1905,6 +1915,19 @@ mod plane_quality_tests {
         // configured with one we did not publish.
         assert_eq!(candidate_pair_label(Some("relay/srflx")), "turn");
         assert_eq!(candidate_pair_label(Some("srflx/relay")), "turn");
+    }
+
+    /// iroh has no candidate types, so it names the path itself. Both planes
+    /// still answer the same question, and both land in the same buckets.
+    #[test]
+    fn an_iroh_path_buckets_beside_an_ice_pair() {
+        assert_eq!(candidate_pair_label(Some("direct-lan")), "lan");
+        assert_eq!(candidate_pair_label(Some("direct-wan")), "punched");
+        assert_eq!(candidate_pair_label(Some("relayed")), "turn");
+        assert_eq!(
+            candidate_pair_label(Some("direct-lan")),
+            candidate_pair_label(Some("host/host"))
+        );
     }
 
     #[test]

--- a/manabrew-rs/crates/manabrew-server/src/connection.rs
+++ b/manabrew-rs/crates/manabrew-server/src/connection.rs
@@ -1657,6 +1657,71 @@ fn handle_client_message(
             metrics::record_peer_signal("forwarded");
         }
 
+        ClientMessage::ReportPlaneQuality { report } => {
+            if !state.direct_transport {
+                return;
+            }
+            // Same attestation as `SignalPeer`: the reporter is named from the
+            // relay's own record, never from the message. A session cannot file
+            // a measurement under someone else's name.
+            let Some(username) = state.players.get(player_id).map(|p| p.username.clone()) else {
+                return;
+            };
+            let room_id = state.players.get(player_id).and_then(|p| p.room_id.clone());
+            // A report about someone the relay has not placed beside this
+            // session is not a measurement of anything it can reason about.
+            let known_peer = room_id
+                .as_ref()
+                .and_then(|rid| state.rooms.get(rid))
+                .is_some_and(|room| room.participant_id_by_username(&report.peer).is_some());
+            if !known_peer {
+                return;
+            }
+            // Labels come from fixed sets, never from the wire: a client that
+            // could name a label could pick this metric's cardinality.
+            let Some(outcome) = plane_outcome_label(&report.outcome) else {
+                return;
+            };
+            let Some(plane) = plane_label(&report.plane) else {
+                return;
+            };
+            let pair = candidate_pair_label(report.candidate_pair.as_deref());
+            // Counted once per attempt. The follow-up that carries the round
+            // trip is the same attempt, not another one.
+            if report.phase == crate::protocol::PLANE_PHASE_SETTLED {
+                metrics::record_plane_attempt(plane, outcome, pair);
+            }
+
+            // A broken clock or a lie is dropped rather than averaged in.
+            let sane = |value: Option<u32>| value.filter(|ms| *ms <= crate::protocol::MAX_PLANE_MS);
+            let connect_ms = sane(report.connect_ms);
+            let rtt_ms = sane(report.rtt_ms);
+            let relay_rtt_ms = sane(report.relay_rtt_ms);
+            if let Some(ms) = connect_ms {
+                metrics::record_plane_connect(plane, ms);
+            }
+            if let Some(ms) = rtt_ms {
+                metrics::record_plane_rtt(plane, ms, relay_rtt_ms);
+            }
+
+            let candidate_pair = report.candidate_pair.filter(|value| {
+                value.len() <= crate::protocol::MAX_CANDIDATE_PAIR_BYTES && !value.is_empty()
+            });
+            state.analytics.emit(AnalyticsEvent::PlaneQuality {
+                ts: analytics::now_ts(),
+                room_id,
+                username,
+                peer: report.peer,
+                plane: plane.to_string(),
+                outcome: outcome.to_string(),
+                phase: report.phase,
+                connect_ms,
+                rtt_ms,
+                relay_rtt_ms,
+                candidate_pair,
+            });
+        }
+
         ClientMessage::TurnChange {
             new_active_player,
             turn_number,
@@ -1753,5 +1818,99 @@ fn client_msg_type(msg: &ClientMessage) -> &'static str {
         ClientMessage::AnnounceTransport { .. } => "AnnounceTransport",
         ClientMessage::ReportTransport { .. } => "ReportTransport",
         ClientMessage::SignalPeer { .. } => "SignalPeer",
+        ClientMessage::ReportPlaneQuality { .. } => "ReportPlaneQuality",
+    }
+}
+
+/// Maps a reported outcome onto the fixed set the metric labels come from.
+/// An unknown value is dropped, not recorded as itself.
+fn plane_outcome_label(outcome: &str) -> Option<&'static str> {
+    crate::protocol::PLANE_OUTCOMES
+        .iter()
+        .find(|known| **known == outcome)
+        .copied()
+}
+
+fn plane_label(plane: &str) -> Option<&'static str> {
+    match plane {
+        crate::protocol::TRANSPORT_WEBRTC => Some(crate::protocol::TRANSPORT_WEBRTC),
+        crate::protocol::TRANSPORT_IROH_DIRECT => Some(crate::protocol::TRANSPORT_IROH_DIRECT),
+        _ => None,
+    }
+}
+
+/// Buckets an ICE candidate pair into labels that are worth separating and
+/// cannot grow without bound.
+///
+/// The distinction that matters is whether the path left the network at all:
+/// `host/host` is a LAN pair and proves no traversal, `srflx` on both sides is
+/// a punched-through path, and `relay` would be TURN, which we do not run. The
+/// exact pair still reaches the capture; only the metric is bucketed.
+fn candidate_pair_label(pair: Option<&str>) -> &'static str {
+    let Some(pair) = pair else {
+        return "unknown";
+    };
+    let (local, remote) = match pair.split_once('/') {
+        Some(split) => split,
+        None => return "other",
+    };
+    match (local, remote) {
+        ("host", "host") => "lan",
+        (_, "relay") | ("relay", _) => "turn",
+        ("srflx" | "prflx", "srflx" | "prflx") => "punched",
+        ("host", "srflx" | "prflx") | ("srflx" | "prflx", "host") => "mixed",
+        _ => "other",
+    }
+}
+
+#[cfg(test)]
+mod plane_quality_tests {
+    use super::*;
+
+    #[test]
+    fn outcomes_come_from_the_fixed_set() {
+        assert_eq!(plane_outcome_label("connected"), Some("connected"));
+        assert_eq!(plane_outcome_label("timeout"), Some("timeout"));
+        // A client cannot name a label, because a label it could name is a
+        // label it could use to pick this metric's cardinality.
+        assert_eq!(plane_outcome_label("connected "), None);
+        assert_eq!(plane_outcome_label("whatever"), None);
+        assert_eq!(plane_outcome_label(""), None);
+    }
+
+    #[test]
+    fn planes_come_from_the_fixed_set() {
+        assert_eq!(plane_label("webrtc"), Some("webrtc"));
+        assert_eq!(plane_label("iroh-direct"), Some("iroh-direct"));
+        // Relayed iroh is not a direct plane, so it is not an attempt at one.
+        assert_eq!(plane_label("iroh-relayed"), None);
+        assert_eq!(plane_label("carrier pigeon"), None);
+    }
+
+    /// The distinction the whole measurement turns on: a pair that never left
+    /// the network says nothing about traversal, and counting it beside a
+    /// punched-through pair would flatter the connect rate.
+    #[test]
+    fn a_lan_pair_is_not_a_punched_one() {
+        assert_eq!(candidate_pair_label(Some("host/host")), "lan");
+        assert_eq!(candidate_pair_label(Some("srflx/srflx")), "punched");
+        assert_eq!(candidate_pair_label(Some("prflx/srflx")), "punched");
+        assert_eq!(candidate_pair_label(Some("host/srflx")), "mixed");
+        assert_eq!(candidate_pair_label(Some("srflx/host")), "mixed");
+    }
+
+    #[test]
+    fn turn_is_labelled_even_though_we_run_none() {
+        // We do not run TURN, so seeing this at all would mean a client was
+        // configured with one we did not publish.
+        assert_eq!(candidate_pair_label(Some("relay/srflx")), "turn");
+        assert_eq!(candidate_pair_label(Some("srflx/relay")), "turn");
+    }
+
+    #[test]
+    fn an_absent_or_malformed_pair_stays_bounded() {
+        assert_eq!(candidate_pair_label(None), "unknown");
+        assert_eq!(candidate_pair_label(Some("nonsense")), "other");
+        assert_eq!(candidate_pair_label(Some("a/b")), "other");
     }
 }

--- a/manabrew-rs/crates/manabrew-server/src/metrics.rs
+++ b/manabrew-rs/crates/manabrew-server/src/metrics.rs
@@ -22,6 +22,10 @@ const STATE_PATCH_DOWNGRADES: &str = "manabrew_relay_state_patch_downgrades_tota
 const ENGINE_REPORTS: &str = "manabrew_relay_engine_reports_total";
 const TRANSPORT_ANNOUNCEMENTS: &str = "manabrew_relay_transport_announcements_total";
 const PEER_SIGNALS: &str = "manabrew_relay_peer_signals_total";
+const PLANE_ATTEMPTS: &str = "manabrew_relay_plane_attempts_total";
+const PLANE_RTT: &str = "manabrew_relay_plane_rtt_ms";
+const PLANE_RELAY_RTT: &str = "manabrew_relay_plane_relay_rtt_ms";
+const PLANE_CONNECT: &str = "manabrew_relay_plane_connect_ms";
 const CLIENT_RTT: &str = "manabrew_relay_client_rtt_ms";
 const STATE_HANDLING: &str = "manabrew_relay_state_handling_seconds";
 const SOCKET_WRITE: &str = "manabrew_relay_socket_write_seconds";
@@ -34,6 +38,8 @@ const LABEL_ENGINE: &str = "engine";
 const LABEL_REASON: &str = "reason";
 const LABEL_SEATS: &str = "seats";
 const LABEL_OUTCOME: &str = "outcome";
+const LABEL_PLANE: &str = "plane";
+const LABEL_PAIR: &str = "pair";
 
 pub const REJECTION_OUTDATED_WIRE: &str = "outdated_wire";
 
@@ -170,6 +176,39 @@ pub fn record_transport_announcement(kind: &'static str) {
 /// never completes becomes visible.
 pub fn record_peer_signal(kind: &'static str) {
     counter!(PEER_SIGNALS, LABEL_KIND => kind).increment(1);
+}
+
+/// One end's account of one attempt to leave the relay, whether it worked or
+/// not. The failures are the point: `ReportTransport` names only the seats
+/// that succeeded, so without this the denominator of a connect rate does not
+/// exist anywhere, and the rate is what decides whether production runs ICE
+/// servers at all.
+///
+/// `pair` is bounded to a known set by the caller before it reaches here. A
+/// client-supplied label would otherwise pick the cardinality of this metric.
+pub fn record_plane_attempt(plane: &'static str, outcome: &'static str, pair: &'static str) {
+    counter!(PLANE_ATTEMPTS, LABEL_PLANE => plane, LABEL_OUTCOME => outcome, LABEL_PAIR => pair)
+        .increment(1);
+}
+
+/// The direct path's round trip next to the same session's round trip to the
+/// relay, recorded as a pair. Either number alone says nothing: the direct
+/// path is only worth having if it beats the path it replaced, and how far it
+/// beats it depends entirely on where the two players are.
+///
+/// Unlike [`record_client_rtt`] this is the client's own measurement. The
+/// relay cannot take it: once a seat goes direct the relay stops seeing that
+/// seat's traffic, which is the same reason `clientRttMs` disappears from a
+/// capture the moment the feature works.
+pub fn record_plane_rtt(plane: &'static str, rtt_ms: u32, relay_rtt_ms: Option<u32>) {
+    histogram!(PLANE_RTT, LABEL_PLANE => plane).record(rtt_ms as f64);
+    if let Some(relay) = relay_rtt_ms {
+        histogram!(PLANE_RELAY_RTT, LABEL_PLANE => plane).record(relay as f64);
+    }
+}
+
+pub fn record_plane_connect(plane: &'static str, connect_ms: u32) {
+    histogram!(PLANE_CONNECT, LABEL_PLANE => plane).record(connect_ms as f64);
 }
 
 pub fn record_resync() {

--- a/src/game/directSeat.ts
+++ b/src/game/directSeat.ts
@@ -23,6 +23,30 @@ export interface DirectTransportStatus {
   kind: string;
   lan: boolean;
   rttMs?: number;
+  setupMs?: number;
+  reconnects?: number;
+}
+
+/** What the relay is told about one attempt on this plane. Mirrors the browser
+ *  plane's report so both arrive as the same measurement.
+ *
+ *  iroh needs no probe: QUIC keeps the path's round trip, whether it went
+ *  direct, and whether the remote address is private. That is the same three
+ *  facts the WebRTC plane has to derive from ICE stats. */
+export interface DirectSeatMeasurement {
+  peer: string;
+  outcome: "connected" | "failed";
+  rttMs?: number;
+  connectMs?: number;
+  /** iroh's own vocabulary, not ICE's: the relay buckets both. */
+  path?: "direct-lan" | "direct-wan" | "relayed";
+}
+
+/** iroh's three facts, in iroh's own words. Inventing ICE candidate types for
+ *  a QUIC path would read as a measurement of something that never happened. */
+function pathOf(status: DirectTransportStatus): DirectSeatMeasurement["path"] {
+  if (status.kind === "iroh-relayed") return "relayed";
+  return status.lan ? "direct-lan" : "direct-wan";
 }
 
 /** Only a seat's own answers move. A host serves its seats from the shell's
@@ -36,6 +60,7 @@ export class DirectSeat {
   private readonly username: string;
   private readonly relayUrl: string | null;
   private readonly deliver: (envelope: StateEnvelope, fromPlayer: string) => void;
+  private readonly onMeasurement: ((m: DirectSeatMeasurement) => void) | undefined;
   private unlisten: (() => void) | null = null;
   private live = false;
   private active = false;
@@ -50,10 +75,12 @@ export class DirectSeat {
     username: string,
     relayUrl: string | null,
     deliver: (envelope: StateEnvelope, fromPlayer: string) => void,
+    onMeasurement?: (m: DirectSeatMeasurement) => void,
   ) {
     this.username = username;
     this.relayUrl = relayUrl;
     this.deliver = deliver;
+    this.onMeasurement = onMeasurement;
   }
 
   /** The endpoint to announce, once. Null when nothing can bind, which leaves
@@ -102,7 +129,7 @@ export class DirectSeat {
   }
 
   /** Installs the relay's roster and dials the host it names. */
-  async onRoster(roomId: string, members: unknown): Promise<void> {
+  async onRoster(roomId: string, members: unknown, host: string): Promise<void> {
     await this.binding;
     if (!this.unlisten) return;
     try {
@@ -110,15 +137,37 @@ export class DirectSeat {
         roomId,
         members,
       });
-      if (!status) return;
+      if (!status) {
+        // No path to the host. This seat stays on the relay, and until now that
+        // was the end of it: the attempt reached nobody, so the failures never
+        // appeared in any denominator.
+        this.measured({ peer: host, outcome: "failed" });
+        return;
+      }
       this.live = true;
       console.info(
         `[direct] seat reached the host over ${status.kind}` +
           (status.lan ? " on the local network" : "") +
           (status.rttMs === undefined ? "" : ` (rtt ${status.rttMs}ms)`),
       );
+      this.measured({
+        peer: host,
+        outcome: "connected",
+        rttMs: status.rttMs,
+        connectMs: status.setupMs,
+        path: pathOf(status),
+      });
     } catch (error) {
       console.warn("[direct] could not reach the host:", error);
+      this.measured({ peer: host, outcome: "failed" });
+    }
+  }
+
+  private measured(m: DirectSeatMeasurement): void {
+    try {
+      this.onMeasurement?.(m);
+    } catch {
+      // Measurement must never take a seat down with it.
     }
   }
 

--- a/src/game/webrtcPlane.ts
+++ b/src/game/webrtcPlane.ts
@@ -80,6 +80,13 @@ export interface PlaneMeasurement {
    *  a LAN pair, `srflx` means it was punched through, `relay` means TURN,
    *  which we do not run. */
   candidatePair?: string;
+  /** `settled` is the attempt reaching its outcome, once. `measured` is the
+   *  later refinement that carries the round trip.
+   *
+   *  A connected peer reports twice, and without telling the two apart anything
+   *  counting attempts counts a success twice and a failure once -- which
+   *  inflates exactly the connect rate this measurement exists to establish. */
+  phase: "settled" | "measured";
 }
 
 export interface WebRtcPlaneOptions {
@@ -491,6 +498,7 @@ export class WebRtcPlane {
     this.report({
       peer,
       outcome: "connected",
+      phase: "measured",
       rttMs,
       candidatePair: await this.candidatePair(state),
     });
@@ -570,7 +578,7 @@ export class WebRtcPlane {
     state.settled = true;
     const connectMs = this.now() - state.startedAt;
     if (outcome === "connected") {
-      this.report({ peer, outcome, connectMs });
+      this.report({ peer, outcome, connectMs, phase: "settled" });
       return;
     }
     // Read the candidates before anything tears the connection down, and log
@@ -579,7 +587,7 @@ export class WebRtcPlane {
       console.warn(
         `[webrtc] ${peer} stayed on the relay: ${outcome}` + (summary ? ` (${summary})` : ""),
       );
-      this.report({ peer, outcome, connectMs, candidatePair: summary });
+      this.report({ peer, outcome, connectMs, candidatePair: summary, phase: "settled" });
     });
   }
 

--- a/src/platform/web.ts
+++ b/src/platform/web.ts
@@ -52,7 +52,7 @@ import { getClientPlatform } from "./clientPlatform";
 import { rememberSpawnedBot, forgetSpawnedBot, clearSpawnedBots } from "@/lib/spawnedBots";
 import { isPromptLoggingEnabled } from "@/lib/debugPrompts";
 import { applyStateDelta, diffStateDelta } from "@/lib/stateDelta";
-import { DirectSeat } from "@/game/directSeat";
+import { DirectSeat, type DirectSeatMeasurement } from "@/game/directSeat";
 import {
   WebRtcPlane,
   iceServersFrom,
@@ -1360,15 +1360,27 @@ class WebServerApi implements IServerApi {
 
     const relayUrl = typeof msg.iroh_relay_url === "string" ? msg.iroh_relay_url : null;
     if (!this.directSeat) {
-      this.directSeat = new DirectSeat(this.authedUsername, relayUrl, (envelope, fromPlayer) =>
-        this.handleServerMessage({ type: "StateUpdate", from_player: fromPlayer, state: envelope }),
+      this.directSeat = new DirectSeat(
+        this.authedUsername,
+        relayUrl,
+        (envelope, fromPlayer) =>
+          this.handleServerMessage({
+            type: "StateUpdate",
+            from_player: fromPlayer,
+            state: envelope,
+          }),
+        (m) => this.onDirectSeatMeasurement(m),
       );
       const endpoint = await this.directSeat.announce();
       if (endpoint) this.send({ type: "AnnounceTransport", endpoint });
     } else if (relayUrl) {
       await this.directSeat.adoptRelay(relayUrl);
     }
-    await this.directSeat.onRoster(String(msg.room_id ?? ""), msg.members);
+    await this.directSeat.onRoster(
+      String(msg.room_id ?? ""),
+      msg.members,
+      typeof msg.host === "string" ? msg.host : "",
+    );
   }
 
   private dropDirectSeat(): void {
@@ -1497,6 +1509,20 @@ class WebServerApi implements IServerApi {
    * succeeded. An attempt that times out currently reaches nobody at all,
    * which leaves a connect rate with no denominator.
    */
+  /** The iroh seat measured itself all along and only ever said so in a
+   *  console line, exactly as the browser plane did. QUIC keeps the path's
+   *  round trip, so there is nothing to probe: one report per attempt. */
+  private onDirectSeatMeasurement(m: DirectSeatMeasurement): void {
+    this.reportPlaneQuality("iroh-direct", {
+      peer: m.peer,
+      outcome: m.outcome,
+      phase: "settled",
+      rttMs: m.rttMs,
+      connectMs: m.connectMs,
+      candidatePair: m.path,
+    });
+  }
+
   private reportPlaneQuality(plane: string, m: PlaneMeasurement): void {
     if (!this.planeQualityReporting) return;
     const whole = (value: number | undefined): number | undefined =>

--- a/src/platform/web.ts
+++ b/src/platform/web.ts
@@ -781,6 +781,7 @@ class WebServerApi implements IServerApi {
    *  has to beat. The relay records its own view of this as
    *  `manabrew_relay_client_rtt_ms`; this is the client's. */
   private relayRttMs: number | null = null;
+  private planeQualityReporting = false;
   private pingSentAt: number | null = null;
 
   constructor(eventBus: WebEventBus) {
@@ -1482,6 +1483,37 @@ class WebServerApi implements IServerApi {
     if (this.relayRttMs !== null) parts.push(`relayRtt=${this.relayRttMs}ms`);
     console.info(`[webrtc] ${parts.join(" ")}`);
     this.eventBus.emit("transport:measurement", { transport: "webrtc", ...m });
+    this.reportPlaneQuality("webrtc", m);
+  }
+
+  /**
+   * Sends the measurement to the relay, failures included.
+   *
+   * The console line above is only ever read by whoever happens to have the
+   * tab open, which is why the one cross-network sample anybody has is a
+   * screenshot. More to the point, the relay stops seeing a seat the moment
+   * this works, so `manabrew_relay_client_rtt_ms` goes quiet for exactly the
+   * seats worth measuring, and `ReportTransport` names only the ones that
+   * succeeded. An attempt that times out currently reaches nobody at all,
+   * which leaves a connect rate with no denominator.
+   */
+  private reportPlaneQuality(plane: string, m: PlaneMeasurement): void {
+    if (!this.planeQualityReporting) return;
+    const whole = (value: number | undefined): number | undefined =>
+      value === undefined || !Number.isFinite(value) ? undefined : Math.max(0, Math.round(value));
+    this.send({
+      type: "ReportPlaneQuality",
+      report: {
+        peer: m.peer,
+        outcome: m.outcome,
+        plane,
+        phase: m.phase,
+        connect_ms: whole(m.connectMs),
+        rtt_ms: whole(m.rttMs),
+        relay_rtt_ms: whole(this.relayRttMs ?? undefined),
+        candidate_pair: m.candidatePair,
+      },
+    });
   }
 
   private send(msg: Record<string, unknown>): void {
@@ -1509,6 +1541,10 @@ class WebServerApi implements IServerApi {
       // is ever started against one.
       this.peerSignalling =
         Array.isArray(msg.features) && (msg.features as string[]).includes("peer_signal");
+      // A relay built before the report existed rejects it as a parse error,
+      // so an older one is simply never sent one.
+      this.planeQualityReporting =
+        Array.isArray(msg.features) && (msg.features as string[]).includes("plane_quality");
     }
     if (DEBUG_TRANSPORT) console.log("[transport←ws] received:", JSON.stringify(msg));
     if (isPromptLoggingEnabled()) {


### PR DESCRIPTION
Closes the measurement hole that testing #848 exposed. Part of #838.

The feature working is what removes the evidence that it works. The relay times
a seat's round trip from that seat's own traffic, so a seat that leaves the
relay stops being measurable. Game `5a900dc9`, where both seats went direct,
produced **zero** `clientRttMs` samples; the same two players on the relay the
day before recorded 56ms and 504ms.

`ReportTransport` cannot fill it. The host sends it once at `GameStarted` and it
names only the seats that succeeded, so a seat that fails to punch through stays
on the relay and tells nobody it tried. That leaves a connect rate with no
denominator — and the connect rate is what #838 says should decide whether
production runs ICE servers.

So the measuring end reports its own attempts, failures included.

## What it sends

`ReportPlaneQuality` carries outcome, time to open, median channel round trip,
and the same session's round trip to the relay alongside it. Paired
deliberately: a direct RTT on its own cannot say whether it beat the path it
replaced.

## What the relay trusts

Nothing in it. Same discipline as `SignalPeer`:

- the reporter is named from the relay's own record, never from the message
- the peer must be someone the relay placed in the same room
- outcome and plane come from fixed sets, so a client cannot pick this metric's
  cardinality
- timings past ten minutes are dropped rather than averaged in

## Counted once

A connected peer reports twice — when the channel opens, and again with the
round trip. Without a `phase` the counter would score every success twice and
every failure once, inflating the exact rate this exists to measure.

## Buckets

`candidate_pair` is bucketed to `lan`/`punched`/`mixed`/`turn` for the metric
while the capture keeps the exact pair. Both successes measured so far were
`host/host`, which never left the network. A rate that cannot separate those
from punched-through pairs would flatter itself.

## Metrics

```
manabrew_relay_plane_attempts_total{plane,outcome,pair}
manabrew_relay_plane_rtt_ms{plane}
manabrew_relay_plane_relay_rtt_ms{plane}
manabrew_relay_plane_connect_ms{plane}
```

Behind a `plane_quality` feature flag, so an older relay is never sent a message
it would reject as a parse error.

## Scope

Wires the WebRTC plane, which is where the measurement already exists. The iroh
seat measures nothing today and is not covered here.
