### PR TITLE
fix(website): sitemap and robots for the apex, real 404s on docs, noindex staging

### DIFF
--- a/ops/staging.Caddyfile
+++ b/ops/staging.Caddyfile
@@ -9,6 +9,9 @@
 
     encode zstd gzip
 
+    # Staging mirrors prod; without this Google indexes it as a duplicate.
+    header X-Robots-Tag "noindex"
+
     @worker path_regexp \.worker[.-][^/]+\.js$
     handle @worker {
         header {

--- a/ops/web.Caddyfile
+++ b/ops/web.Caddyfile
@@ -191,7 +191,14 @@ http://docs.manabrew.app {
     }
 
     handle {
-        try_files {path} {path}/ /404.html
+        try_files {path} {path}/
+        file_server
+    }
+
+    # Serve Starlight's 404 page with a 404 status. A try_files fallback
+    # returns it as 200, which Google reads as a soft 404 on every miss.
+    handle_errors 404 {
+        rewrite * /404.html
         file_server
     }
 }

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -1,6 +1,6 @@
 # website/ - Landing page + docs site
 
-One npm package, two Astro builds:
+One package, two Astro builds:
 
 | Build   | Config                  | Source         | Output          | Served at            |
 | ------- | ----------------------- | -------------- | --------------- | -------------------- |
@@ -17,12 +17,13 @@ The wasm app lives at `play.manabrew.app` (its own Caddy vhost, `/srv/manabrew`)
 - `src/components/SiteTitle.astro` - Starlight `SiteTitle` override: app logo linking to `https://manabrew.app/`.
 - `src/content/docs/` - documentation content at the collection root; routes land at the root of `docs.manabrew.app`. Internal links are root-relative (`/getting-started/`), app links absolute to `play.manabrew.app`.
 - `src/styles/starlight.css` - maps the injected `--mb-*` variables onto Starlight's `--sl-color-*` tokens, plus the site fonts.
+- `src-landing/pages/robots.txt.ts` and `src/pages/robots.txt.ts` - one `robots.txt` per host, each pointing at its own `sitemap-index.xml` (`@astrojs/sitemap` on the landing build, Starlight's bundled one on docs). `public/` is shared by both builds, so it cannot carry a per-host file.
 - `public/` - favicons copied from the app's `/public`, shared by both builds; in production they're byte-identical duplicates of the app's.
 - Images and theme data are imported via relative paths that escape this folder (`../images/`, `../public/`, `../src/`) - `vite.server.fs.allow` and the directory layout in the `website` Docker stage both exist to support this. New escapes need a matching `COPY` in `Dockerfile.web`.
 
 ## Constraints
 
-- **Package manager is npm here** (not yarn): `npm install`, `npm run dev` (landing), `npm run dev:docs` (docs), `npm run build` (both). The Docker stage runs `npm ci` against `website/package-lock.json` - commit lockfile changes.
+- **Package manager is yarn here** (`yarn.lock`, no `package-lock.json`): `yarn install`, `yarn dev` (landing), `yarn dev:docs` (docs), `yarn build` (both). The Docker stage runs `yarn install --frozen-lockfile` - commit lockfile changes.
 - **Node 20.** Astro is pinned to v5 and Starlight to 0.37.x because Starlight ≥0.38 requires Astro 6, which requires Node ≥22. Don't bump those majors until the repo toolchain (local + `Dockerfile.web`) moves to Node 22.
 - **Public content only.** Do not publish internal agent docs (`docs/agents/`, DSL grammar/semantics) here; this site is user-facing.
 - Verify landing-page changes at ~390px viewport - fluid layout, no fixed widths.

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,13 +1,38 @@
 // @ts-check
+import { readdirSync, readFileSync } from "node:fs";
 import { defineConfig } from "astro/config";
+import sitemap from "@astrojs/sitemap";
 
 // Landing page only — served at the root of manabrew.app. The docs site is a
 // separate build (astro.config.docs.mjs, srcDir src/) served at
 // docs.manabrew.app; the wasm app lives at play.manabrew.app.
+
+// Blog posts carry their pubDate as sitemap lastmod. Other pages get none:
+// the build has no git metadata, so a made-up date would just be ignored.
+const blogDir = new URL("./src-landing/content/blog/", import.meta.url);
+const blogLastmod = Object.fromEntries(
+  readdirSync(blogDir)
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => {
+      const date = readFileSync(new URL(f, blogDir), "utf8").match(/^pubDate:\s*"?(\S+?)"?\s*$/m);
+      return [`/blog/${f.replace(/\.md$/, "")}/`, date?.[1]];
+    }),
+);
+
 export default defineConfig({
   site: "https://manabrew.app",
   srcDir: "./src-landing",
   outDir: "./dist/landing",
+  // Starlight ships its own sitemap for the docs build; the landing build
+  // needs one explicitly or the blog is only discoverable by crawling links.
+  integrations: [
+    sitemap({
+      serialize(item) {
+        const lastmod = blogLastmod[new URL(item.url).pathname];
+        return lastmod ? { ...item, lastmod } : item;
+      },
+    }),
+  ],
   vite: {
     server: {
       fs: { allow: [".."] },

--- a/website/package.json
+++ b/website/package.json
@@ -9,6 +9,7 @@
     "preview": "astro preview"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.3.0",
     "@astrojs/starlight": "^0.37.7",
     "@fontsource/alegreya-sans": "^5.2.5",
     "@fontsource/cormorant-garamond": "^5.2.5",

--- a/website/src-landing/pages/index.astro
+++ b/website/src-landing/pages/index.astro
@@ -30,6 +30,7 @@ const mana = preset.gameColors;
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Manabrew — Magic, with Friends</title>
     <meta name="description" content={DESCRIPTION} />
+    <link rel="canonical" href={Astro.site} />
     <meta property="og:title" content="Manabrew" />
     <meta property="og:description" content={DESCRIPTION} />
     <meta property="og:image" content={new URL(brewery.src, Astro.site)} />

--- a/website/src-landing/pages/robots.txt.ts
+++ b/website/src-landing/pages/robots.txt.ts
@@ -1,0 +1,4 @@
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = ({ site }) =>
+  new Response(`User-agent: *\nAllow: /\n\nSitemap: ${new URL("sitemap-index.xml", site)}\n`);

--- a/website/src/pages/robots.txt.ts
+++ b/website/src/pages/robots.txt.ts
@@ -1,0 +1,4 @@
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = ({ site }) =>
+  new Response(`User-agent: *\nAllow: /\n\nSitemap: ${new URL("sitemap-index.xml", site)}\n`);


### PR DESCRIPTION
Search Console export (2026-09-09): 45 valid pages, flat since July 11. The GraalVM post (live since v3.33.0, Sep 1) is missing, both June posts were last crawled Jul 23, and staging.manabrew.app is indexed as a valid page.

Docs pages recrawl every few days because Starlight ships a sitemap. The apex had none, so blog posts were only reachable by crawling links from the home page.

## Changes

- landing build: `@astrojs/sitemap`, blog posts carry `pubDate` as `lastmod`
- `robots.txt` per host as an Astro endpoint, each pointing at its own `sitemap-index.xml` (`public/` is shared by both builds, so it can't hold a per-host line)
- docs vhost: misses now return 404 through `handle_errors`; the `try_files` fallback returned Starlight's 404 page as 200 (soft 404 on every miss, `robots.txt` included)
- staging: `X-Robots-Tag: noindex`
- landing page canonical
- `website/AGENTS.md`: package manager is yarn, not npm (the Docker stage runs `yarn install --frozen-lockfile`)

## Checks

- `yarn build` in `website/`: both sites emit `robots.txt` + `sitemap-index.xml`, landing sitemap lists the 5 pages with `lastmod` on the 3 posts
- `caddy validate` on `ops/web.Caddyfile` and `ops/staging.Caddyfile`
- local caddy against `dist/docs` with the new block: `/faq/` 200, `/does-not-exist/` 404 with the Starlight page, `/robots.txt` 200 text/plain

## After merge

- [ ] submit `https://manabrew.app/sitemap-index.xml` in Search Console
- [ ] URL Inspection on `/blog/graalvm/`, request indexing
- [ ] removal request for `staging.manabrew.app` once the header is live
