### PR TITLE
fix(deploy): start the STUN service on prod rollouts

### DIFF
--- a/xtask/src/deploy.rs
+++ b/xtask/src/deploy.rs
@@ -592,6 +592,13 @@ fn deploy(root: &Path, opts: &Opts) -> Result<()> {
             "up -d --no-deps --no-recreate ingress",
         ),
     )?;
+    // STUN for peer-to-peer games. Stateless and not tagged, so it is
+    // started here rather than rolled with the app images.
+    ssh_streamed(
+        root,
+        &opts.host,
+        &compose(&opts.path, &opts.tag, "up -d --no-deps coturn"),
+    )?;
     let mut services = vec!["manabrew"];
     let mut relay_note = String::new();
     if !web_only {


### PR DESCRIPTION
Peer-to-peer play (#871) added a STUN-only \`coturn\` service to \`compose.production.yml\`, but \`cargo xtask deploy\` only brings up ingress, web, hub and relay. So it was never started: nothing listens on 3478 on the prod box, a STUN binding request from outside times out, and every cross-network WebRTC attempt since v3.39.0 gathered host candidates only and timed out after 25s (\`plane_quality\` rows: \`local=host remote=none pairs=[]\`).

The deploy now runs \`up -d --no-deps coturn\` right after ingress. It is stateless and not tagged, so it is not part of the tagged rollout or its rollback.

Staging is unaffected: its deploy runs \`up -d\` with no service filter.

Until this ships, start it by hand on the box:

\`\`\`
cd /opt/manabrew && docker compose -f compose.production.yml up -d --no-deps coturn
\`\`\`