### PR TITLE
fix(desktop): local relay builds after the deck-play handle removal

### DIFF
--- a/src-tauri/src/local_relay.rs
+++ b/src-tauri/src/local_relay.rs
@@ -111,7 +111,6 @@ pub async fn start_local_relay(
             4,
             None,
             manabrew_server::analytics::AnalyticsHandle::disabled(),
-            manabrew_server::deck_play_events::DeckPlayEventHandle::disabled(),
             None,
             None,
         ));


### PR DESCRIPTION
#883 removed \`manabrew_server::deck_play_events\` and the matching \`ServerState::new\` argument. \`src-tauri/src/local_relay.rs\` (behind \`forge-room\`) still passed it:

\`\`\`
error[E0433]: cannot find `deck_play_events` in `manabrew_server`
\`\`\`

So all three v3.40.0 desktop installer jobs failed and \`Deploy production\` was skipped. Prod is still on v3.39.0 while the node fleet self-updated to 0.31.0, so the relay now logs \`unknown variant ReportGameOutcome\` and drops the fleet's game outcome reports.

Verified with \`cargo check -p manabrew --features forge-room\` (fails on main, passes here).

The PR checks did not catch it because the forge-room build in Build checks is path-gated and #883 touched no desktop file. Worth widening that gate to the relay crate, in a separate PR.