### PR TITLE
fix(telemetry): file solo engine reports under the offline game

### DIFF
--- a/src/hooks/useGameEventListeners.ts
+++ b/src/hooks/useGameEventListeners.ts
@@ -7,7 +7,7 @@ import {
   SELF_HOSTED_NODE_RELAY_PROTOCOL,
 } from "@/game";
 import { teardownForgeAiSession } from "@/game/hostedAiPlay";
-import { reportEngineStats } from "@/lib/engineStatsReport";
+import { engineReportGameId, reportEngineStats } from "@/lib/engineStatsReport";
 import {
   currentOfflineGameId,
   reportOfflineGame,
@@ -216,7 +216,11 @@ function reportEngineGame(): void {
     // engine sends a gameOver prompt and `gameView` never gets the flag, so
     // reading the flag alone filed finished games as quits.
     endReason: isOver(state) ? "gameOver" : "left",
-    gameId: useServerStore.getState().gameId ?? offlineGameId,
+    gameId: engineReportGameId(
+      state.isMultiplayer,
+      useServerStore.getState().gameId,
+      offlineGameId,
+    ),
     send: state.isMultiplayer
       ? async (stats, gameId) => {
           await getPlatform().server?.reportEngineStats(stats, gameId);

--- a/src/lib/engineStatsReport.test.ts
+++ b/src/lib/engineStatsReport.test.ts
@@ -13,7 +13,7 @@ vi.mock("@/api/hub", () => ({
 
 vi.mock("@/platform", () => ({ getPlatform: () => ({ type: "web" }) }));
 
-import { reportEngineStats } from "@/lib/engineStatsReport";
+import { engineReportGameId, reportEngineStats } from "@/lib/engineStatsReport";
 import { beginGame, noteAnswerSent, notePromptArrived } from "@/lib/engineTelemetry";
 
 function playSixDecisions(engine: string) {
@@ -73,5 +73,21 @@ describe("engine stats reporting", () => {
     end();
     end();
     expect(send).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("which game a report is filed under", () => {
+  it("files an offline game under the offline record, whatever the server store holds", () => {
+    // The server store keeps "" between rooms, and a finished relay game's id
+    // after it ends; neither is this game.
+    expect(engineReportGameId(false, "", "offline-1")).toBe("offline-1");
+    expect(engineReportGameId(false, "relay-from-last-room", "offline-1")).toBe("offline-1");
+    expect(engineReportGameId(false, "", null)).toBeNull();
+  });
+
+  it("files a relay game under the relay's id, and never under an offline record", () => {
+    expect(engineReportGameId(true, "relay-1", "offline-1")).toBe("relay-1");
+    expect(engineReportGameId(true, "", "offline-1")).toBeNull();
+    expect(engineReportGameId(true, undefined, null)).toBeNull();
   });
 });

--- a/src/lib/engineStatsReport.ts
+++ b/src/lib/engineStatsReport.ts
@@ -76,6 +76,25 @@ export function roomEngineLabel(
   return localEngineLabel();
 }
 
+/**
+ * Which game a report belongs to, from the two ids a client may hold.
+ *
+ * The relay's id lives in the server store, which keeps `""` rather than null
+ * between rooms, and stays set after a relay game ends. Read with `??` that
+ * empty string won, every solo report went out with `gameId: ""`, the hub's
+ * uuid filter threw it away, and a stale relay id could even land on an
+ * offline game. So the room decides: a relay game is filed under the relay's
+ * id, anything else under the offline record's, and never one for the other.
+ */
+export function engineReportGameId(
+  multiplayer: boolean,
+  relayGameId: string | null | undefined,
+  offlineGameId: string | null,
+): string | null {
+  if (multiplayer) return relayGameId || null;
+  return offlineGameId;
+}
+
 function loadPending(): PendingReport[] {
   if (typeof window === "undefined") return [];
   try {

--- a/src/stores/useGameStore.ts
+++ b/src/stores/useGameStore.ts
@@ -1,5 +1,6 @@
 import { beginGame, noteAnswerSent } from "@/lib/engineTelemetry";
 import {
+  engineReportGameId,
   forgeHostLabel,
   localEngineLabel,
   reportEngineStats,
@@ -654,7 +655,11 @@ export const useGameStore = create<GameState>()(
           seats: Object.keys(get().gameDecks).length || 2,
           format: get().gameConfig?.formatId ?? null,
           endReason: get().gameView?.gameOver ? "gameOver" : "left",
-          gameId: useServerStore.getState().gameId ?? currentOfflineGameId(),
+          gameId: engineReportGameId(
+            wasMultiplayer,
+            useServerStore.getState().gameId,
+            currentOfflineGameId(),
+          ),
           send: wasMultiplayer
             ? async (stats, gameId) => {
                 await getPlatform().server?.reportEngineStats(stats, gameId);


### PR DESCRIPTION
Follow-up to #816. The relay half of that fix works: hosted and remote reports join `games` on `game_id`. The offline half never did. On prod today 2737 of 2761 hub engine reports have `game_id` NULL, including 86 of 86 on 3.41.0.

**Cause.** Both report call sites read `useServerStore.getState().gameId ?? currentOfflineGameId()`. The server store keeps `""` between rooms, never null, so `??` returned the empty string, the hub's uuid filter dropped it, and the row landed unjoinable. The same read also leaks a finished relay game's id onto the next offline game (three solo reports on prod share one relay id).

**Change.** One helper, `engineReportGameId`: a relay game files under the relay's id, anything else under the offline record's, never one for the other. Used at both call sites. Tests cover the store's real `""` default and the stale-id case.

Nothing backfills. The join fills in for clients carrying this build; `offline_play_games` rows were always fine.

**Why it matters.** 72% of engine reports are solo forge-wasm. The 4-seat per-decision tail (top decile above 1.1 s same-turn p50) cannot be split by player, deck or device until these rows join.
