### PR TITLE
fix(relay): fold a state patch per seat, and never for a service

### DIFF
--- a/manabrew-rs/crates/manabrew-server/src/connection.rs
+++ b/manabrew-rs/crates/manabrew-server/src/connection.rs
@@ -493,29 +493,72 @@ fn room_player_id_in(room: &Room, target_username: &str) -> Option<String> {
     }
 }
 
-/// Whether every client that would receive this envelope ships the `stateDelta`
-/// applier. One seat that does not is enough to fall back to a full state: a
-/// dropped patch leaves that player's board frozen for the rest of the game.
-fn state_patch_audience_ready(
+/// The seats that would receive this envelope and cannot take a `stateDelta`,
+/// so must be sent the whole board instead: a dropped patch leaves that
+/// player's board frozen for the rest of the game.
+///
+/// Per seat, not per envelope. Until 2026-09-11 one such seat folded the patch
+/// for everyone, and every hosted room has one: the node's bot seats and the
+/// node itself authenticate as services with no client version. So every
+/// broadcast patch went out as a full state to every human, ~40 KB per
+/// decision on a four-seat board that the seated client then discarded, and
+/// the node was sent its own bot seats' boards back. A service is our own
+/// code, never a stale install, and either applies patches or ignores states
+/// altogether; it is never the reason to fold.
+fn seats_needing_full_state(
     state: &Arc<ServerState>,
     room: &Room,
     sender_player_id: &str,
     target_username: Option<&str>,
-) -> bool {
-    let applies = |player_id: &str| {
-        state
-            .players
-            .get(player_id)
-            .is_some_and(|player| player.client.applies_state_patches())
+) -> Vec<String> {
+    let needs_full = |player_id: &str| {
+        state.players.get(player_id).is_some_and(|player| {
+            !player.is_service && !player.client.applies_state_patches()
+        })
     };
     match target_username {
         // An unresolvable target means the send is about to be dropped anyway.
-        Some(target) => room_player_id_in(room, target).is_none_or(|pid| applies(&pid)),
+        Some(target) => room_player_id_in(room, target)
+            .filter(|pid| needs_full(pid))
+            .into_iter()
+            .collect(),
         None => room
             .connected_player_ids()
-            .iter()
-            .filter(|pid| pid.as_str() != sender_player_id)
-            .all(|pid| applies(pid)),
+            .into_iter()
+            .filter(|pid| pid.as_str() != sender_player_id && needs_full(pid))
+            .collect(),
+    }
+}
+
+/// Broadcast a board update, sending each seat the shape it can take: the
+/// patch to seats that apply patches, the whole board to the rest.
+fn broadcast_state_split(
+    state: &Arc<ServerState>,
+    sender_player_id: &str,
+    room_id: &str,
+    patch: &ServerMessage,
+    full: Option<&ServerMessage>,
+    needs_full: &[String],
+) {
+    let Some(full) = full else {
+        broadcast_to_room_except(state, sender_player_id, room_id, patch);
+        return;
+    };
+    let (Ok(patch_json), Ok(full_json)) = (serde_json::to_string(patch), serde_json::to_string(full))
+    else {
+        return;
+    };
+    let player_ids = match state.rooms.get(room_id) {
+        Some(room) => room.connected_player_ids(),
+        None => return,
+    };
+    for pid in player_ids.iter().filter(|pid| pid.as_str() != sender_player_id) {
+        if needs_full.contains(pid) {
+            metrics::record_state_patch_downgrade();
+            emit_to(state, pid, full, &full_json);
+        } else {
+            emit_to(state, pid, patch, &patch_json);
+        }
     }
 }
 
@@ -1739,19 +1782,18 @@ fn handle_client_message(
                         .then(|| replay.game_id.clone())
                 });
                 let seats = room.players.len();
-                let folded_state = (is_state_patch(&game_state)
-                    && !state_patch_audience_ready(
-                        state,
-                        &room,
-                        player_id,
-                        canonical_target.as_deref(),
-                    ))
-                .then(|| {
-                    room.replay
-                        .as_ref()
-                        .and_then(|replay| replay.state_after(&game_state).cloned())
-                })
-                .flatten();
+                let needs_full = if is_state_patch(&game_state) {
+                    seats_needing_full_state(state, &room, player_id, canonical_target.as_deref())
+                } else {
+                    Vec::new()
+                };
+                let folded_state = (!needs_full.is_empty())
+                    .then(|| {
+                        room.replay
+                            .as_ref()
+                            .and_then(|replay| replay.state_after(&game_state).cloned())
+                    })
+                    .flatten();
                 drop(room);
                 if let Some(game_id) = capture_game_id {
                     // Only a player's own envelope carries a link that is theirs.
@@ -1775,17 +1817,14 @@ fn handle_client_message(
                     metrics::record_state_handling(seats, handling_started.elapsed());
                     return;
                 }
-                let game_state = match folded_state {
-                    Some(full) => {
-                        metrics::record_state_patch_downgrade();
-                        full
-                    }
-                    None => game_state,
-                };
                 let msg = ServerMessage::StateUpdate {
                     from_player: username.to_string(),
                     state: game_state,
                 };
+                let full_msg = folded_state.map(|full| ServerMessage::StateUpdate {
+                    from_player: username.to_string(),
+                    state: full,
+                });
                 match canonical_target {
                     Some(target) => {
                         debug!(
@@ -1794,7 +1833,15 @@ fn handle_client_message(
                             target,
                             &rid[..8]
                         );
-                        send_to_room_player(state, &rid, &target, &msg);
+                        // A patch the relay could not expand still goes out:
+                        // the seat drops it, which is no worse than silence.
+                        match &full_msg {
+                            Some(full) => {
+                                metrics::record_state_patch_downgrade();
+                                send_to_room_player(state, &rid, &target, full);
+                            }
+                            None => send_to_room_player(state, &rid, &target, &msg),
+                        }
                     }
                     None => {
                         debug!(
@@ -1802,7 +1849,14 @@ fn handle_client_message(
                             username,
                             &rid[..8]
                         );
-                        broadcast_to_room_except(state, player_id, &rid, &msg);
+                        broadcast_state_split(
+                            state,
+                            player_id,
+                            &rid,
+                            &msg,
+                            full_msg.as_ref(),
+                            &needs_full,
+                        );
                     }
                 }
                 metrics::record_state_handling(seats, handling_started.elapsed());

--- a/manabrew-rs/crates/networking-tests/tests/networking_regression.rs
+++ b/manabrew-rs/crates/networking-tests/tests/networking_regression.rs
@@ -16,7 +16,8 @@ use libtest_mimic::Arguments;
 use manabrew_agent_interface::protocol::{identity_token, IdentityProof};
 use serde_json::json;
 use support::{
-    case, execute, list, scenario, spawn_guest_bot, step, summary, webrtc_endpoint, Case, Client,
+    case, execute, list, play_pair, scenario, spawn_guest_bot, step, summary, webrtc_endpoint, Case,
+    Client,
     Manifest, Sim, GRACE_DEADLINE,
 };
 
@@ -522,6 +523,76 @@ async fn old_clients_are_sent_whole_boards() {
     );
 }
 
+async fn bot_seats_never_make_the_relay_fold_a_patch() {
+    scenario(
+        "a hosted 2-player game: a current human, and the node's bot seat, which authenticates as a service with no client version.",
+        "the node sends its patched board updates, per seat and to the bot.",
+        "the relay expands none of them. Until 2026-09-11 the bot seat failed the version check like a stale install, so every patch addressed to it and every broadcast in its room went out as a full board: ~40 KB per decision to each human on a four-seat table, and the node sent its own bots' boards back.",
+    );
+    let sim = Sim::spawn(9680).await;
+    let mut alice = Client::connect_versioned(&sim.relay_url, "alice", CURRENT_CLIENT_VERSION)
+        .await
+        .unwrap();
+    alice.join(&sim.room_id, false).await.unwrap();
+    alice.spawn_node_bot(&sim.room_id).await.unwrap();
+    alice.select_deck_and_ready().await.unwrap();
+    alice.start_game(2).await.unwrap();
+    alice.answer_prompts(6).await.unwrap();
+
+    assert!(
+        alice.saw_envelope_kind("stateDelta"),
+        "the human was sent no patch at all, so the counter below proves nothing",
+    );
+    let folded = sim
+        .metric("manabrew_relay_state_patch_downgrades_total")
+        .await;
+    assert_eq!(
+        folded, 0.0,
+        "the relay expanded {folded} patches into full boards in a room whose only non-current seat is a bot",
+    );
+}
+
+async fn old_clients_get_whole_boards_without_costing_the_current_ones_theirs() {
+    scenario(
+        "a hosted game with two humans: one current, one old enough to report no version.",
+        "the node sends patched board updates to both.",
+        "each seat is sent the shape it can take: the old client whole boards and never a patch, the current one patches, and the relay's fold counter moves only for the old seat.",
+    );
+    let sim = Sim::spawn(9684).await;
+    let mut alice = Client::connect_versioned(&sim.relay_url, "alice", CURRENT_CLIENT_VERSION)
+        .await
+        .unwrap();
+    let mut bob = Client::connect(&sim.relay_url, "bob").await.unwrap();
+    alice.join(&sim.room_id, false).await.unwrap();
+    bob.join(&sim.room_id, false).await.unwrap();
+    alice.spawn_node_bot(&sim.room_id).await.unwrap();
+    alice.select_deck_and_ready().await.unwrap();
+    bob.select_deck_and_ready().await.unwrap();
+    alice.start_game(3).await.unwrap();
+    bob.await_game_started().await.unwrap();
+    play_pair(&mut alice, &mut bob, 8).await.unwrap();
+
+    assert!(
+        !bob.saw_envelope_kind("stateDelta"),
+        "the old client was sent a patch it cannot apply; its board would have frozen here",
+    );
+    assert!(
+        bob.saw_envelope_kind("state"),
+        "the old client received no board at all, so the test proves nothing",
+    );
+    assert!(
+        alice.saw_envelope_kind("stateDelta"),
+        "the current client lost its patches to the old seat in the same room",
+    );
+    let folded = sim
+        .metric("manabrew_relay_state_patch_downgrades_total")
+        .await;
+    assert!(
+        folded > 0.0,
+        "the old seat was sent boards the relay never counted as folded",
+    );
+}
+
 async fn publishing_a_release_never_ends_a_live_game() {
     scenario(
         "a node armed to auto-update, hosting a game between a human and its bot.",
@@ -761,6 +832,14 @@ fn main() {
         case(
             "ghost_session_reaped_on_room_teardown",
             ghost_session_reaped_on_room_teardown,
+        ),
+        case(
+            "bot_seats_never_make_the_relay_fold_a_patch",
+            bot_seats_never_make_the_relay_fold_a_patch,
+        ),
+        case(
+            "old_clients_get_whole_boards_without_costing_the_current_ones_theirs",
+            old_clients_get_whole_boards_without_costing_the_current_ones_theirs,
         ),
         case(
             "publishing_a_release_never_ends_a_live_game",

--- a/manabrew-rs/crates/networking-tests/tests/support/mod.rs
+++ b/manabrew-rs/crates/networking-tests/tests/support/mod.rs
@@ -543,6 +543,48 @@ impl Client {
         }
     }
 
+    /// Wait for the game another seat started. `start_game` only returns on
+    /// the socket that sent `StartGame`; every other human waits here.
+    pub async fn await_game_started(&mut self) -> Result<(), String> {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+        loop {
+            if tokio::time::Instant::now() > deadline {
+                return Err(format!("'{}' never saw the game start", self.username));
+            }
+            match recv(&mut self.write, &mut self.read).await {
+                Some(ServerMessage::GameStarted {
+                    game_id,
+                    player_order,
+                    ..
+                }) => {
+                    self.slot = player_order
+                        .iter()
+                        .position(|name| name == &self.username)
+                        .map(player_slot);
+                    self.game_id = Some(game_id);
+                    return Ok(());
+                }
+                Some(_) => continue,
+                None => return Err("connection closed before game start".into()),
+            }
+        }
+    }
+
+    /// Receive one message and answer it if it is our prompt. `Ok(true)` when
+    /// a prompt was answered.
+    async fn step(&mut self) -> Result<bool, String> {
+        let Some(message) = recv(&mut self.write, &mut self.read).await else {
+            return Err(format!("'{}' connection closed mid-game", self.username));
+        };
+        match self.prompt_response(message)? {
+            Some(response) => {
+                self.broadcast(&response).await?;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
     /// Answer `n` prompts addressed to this seat — proves the engine is live
     /// and serving us.
     pub async fn answer_prompts(&mut self, n: usize) -> Result<(), String> {
@@ -829,6 +871,28 @@ impl Client {
         )
         .await
     }
+}
+
+/// Two humans at one table answering whichever of them the engine asks,
+/// until `n` prompts have been answered between them. Neither can be driven
+/// alone: each blocks on its own socket while the engine waits on the other.
+pub async fn play_pair(a: &mut Client, b: &mut Client, n: usize) -> Result<(), String> {
+    let mut answered = 0;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(120);
+    while answered < n {
+        let step = tokio::select! {
+            r = a.step() => r?,
+            r = b.step() => r?,
+            _ = tokio::time::sleep_until(deadline) => {
+                return Err(format!("the pair answered {answered}/{n} prompts before timing out"));
+            }
+        };
+        if step {
+            answered += 1;
+        }
+    }
+    check(format!("the pair answered {n} prompt(s) between them"));
+    Ok(())
 }
 
 /// A guest seat that answers its prompts (slowly, so games outlive


### PR DESCRIPTION
**Why.** The relay expands a `stateDelta` into a full board when a recipient cannot apply patches, and it did so for the whole audience when any one recipient could not. Every hosted room has such a recipient: the node's bot seats and the node itself authenticate as services with no client version. So every broadcast patch went to every human as a whole board, about 38 KB per decision in 2-seat and 80 KB in 4-seat games, that a seated client discards on arrival, and the node was sent its own bots' boards back at 44 KB each. Prod counts about 536k folds a week, about 790 per game, and relay outbound is 75 GB a week against 23 GB in.

**Change.**
- A service connection is never the reason to fold. It is our own code, never a stale install, and either applies patches or ignores boards.
- A broadcast folds per recipient: the patch to seats that take it, the board only to seats that cannot. Before, one old seat cost every other seat its patches.
- The fold counter now moves once per board actually sent, so it reads as "boards sent to seats that could not take a patch".

**Tests.** Two networking regression cases. `bot_seats_never_make_the_relay_fold_a_patch` reads the relay's fold counter after six decisions in a room with one current human and a bot: 0 on this branch, 34 against the relay built from main. `old_clients_get_whole_boards_without_costing_the_current_ones_theirs` seats an unversioned client next to a current one at one table: the old one sees only whole boards, the current one keeps its patches, and the counter moves only for the old seat. The full suite is 21 for 21 locally. `play_pair` in the support module drives two human seats at one table, which nothing did before.

**Not changed.** The node still sends per-seat boards to its own bot seats through the relay. Those now travel as patches rather than boards, but a bot ignores them either way; dropping them at the source is a node change.
